### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import "github.com/gin-gonic/gin"
 
 func main() {
     r := gin.Default()
-    r.GET("ping", func(c *gin.Context){
+    r.GET("/ping", func(c *gin.Context){
         c.String(200, "pong")
     })
     


### PR DESCRIPTION
The first example fails because there's no leading slash:

```
$ go run main.go 
panic: path must begin with '/'

goroutine 1 [running]:
runtime.panic(0x22f400, 0xc21000a660)
    /usr/local/Cellar/go/1.2.2/libexec/src/pkg/runtime/panic.c:266 +0xb6
github.com/julienschmidt/httprouter.(*Router).Handle(0xc2100494e0, 0x2f6d20, 0x3, 0x309460, 0x4, ...)
    /Users/ysimonson/go/src/github.com/julienschmidt/httprouter/router.go:192 +0x6f
github.com/gin-gonic/gin.(*RouterGroup).Handle(0xc210044200, 0x2f6d20, 0x3, 0x309460, 0x4, ...)
    /Users/ysimonson/go/src/github.com/gin-gonic/gin/gin.go:168 +0x3ce
github.com/gin-gonic/gin.(*RouterGroup).GET(0xc210044200, 0x309460, 0x4, 0xc2100001b8, 0x1, ...)
    /Users/ysimonson/go/src/github.com/gin-gonic/gin/gin.go:178 +0x6d
main.main()
    /Users/ysimonson/go/src/github.com/ysimonson/nutrino-api/main.go:9 +0xa1
exit status 2
```
