### PR TITLE
Fix "encoding/xml cannot marshal maps"

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -64,12 +64,21 @@ type (
 
 // Allows type H to be used with xml.Marshal
 func (h H) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	e.EncodeToken(start)
-	for key, value := range h {
-		elem := xml.StartElement{Name: xml.Name{Local: key}}
-		e.EncodeElement(value, elem)
+	if err := e.EncodeToken(start); err != nil {
+		return err
 	}
-	e.EncodeToken(xml.EndElement{start.Name})
+	for key, value := range h {
+		elem := xml.StartElement{
+			xml.Name{"", key},
+			[]xml.Attr{},
+		}
+		if err = e.EncodeElement(value, elem); err != nil {
+			return err
+		}
+	}
+	if err = e.EncodeToken(xml.EndElement{start.Name}); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
This is an implementation of the MarshalXML interface for the type gin.H.  It fixes [bug #12](https://github.com/gin-gonic/gin/issues/12).  The implementation is very simple, and probably doesn't take into account all possible edge cases.  Even so, it will correctly parse all basic types as well as structs and maps, even with nested components.  For example, the following works:

```
r.GET("/someXML", func(c *gin.Context) {
    c.XML(200, gin.H{
        "int":    42,
        "string": "hello, world",
        "slice":  []int{1, 2, 3},
        "map":    gin.H{"nested": "still works"},
    })
})
```

It will produce the output:

```
<H>
    <string>hello, world</string>
    <slice>1</slice>
    <slice>2</slice>
    <slice>3</slice>
    <map>
        <nested>still works</nested>
    </map>
    <int>42</int>
</H>
```
