### PR TITLE
RunTLS() for http.ListenAndServeTLS

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -118,6 +118,10 @@ func (engine *Engine) Run(addr string) {
 	http.ListenAndServe(addr, engine)
 }
 
+func (engine *Engine) RunTLS(addr string, cert string, key string) {
+    http.ListenAndServeTLS(addr, cert, key, engine)
+}
+
 /************************************/
 /********** ROUTES GROUPING *********/
 /************************************/


### PR DESCRIPTION
I wanted to add http.ListenAndServeTLS to serve up https requests.

I read this doc:
- http://golang.org/pkg/net/http/#ListenAndServeTLS

And tried it out here:
- https://github.com/kyledinh/toolkit/wiki/Golang---Getting-TSL-HTTPS-to-work

Let me know you have a better method to do this.
