### PR TITLE
CRUD API

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -205,47 +205,6 @@ func (group *RouterGroup) HEAD(path string, handlers ...HandlerFunc) {
 	group.Handle("HEAD", path, handlers)
 }
 
-// All of the methods are the same type as HandlerFunc
-// if you don't want to support any methods of CRUD, then don't implement it
-type CreateSupported interface {
-	CreateHandler(*Context)
-}
-type ListSupported interface {
-	ListHandler(*Context)
-}
-type TakeSupported interface {
-	TakeHandler(*Context)
-}
-type UpdateSupported interface {
-	UpdateHandler(*Context)
-}
-type DeleteSupported interface {
-	DeleteHandler(*Context)
-}
-
-// It defines
-//   POST: /path
-//   GET:  /path
-//   PUT:  /path/:id
-//   POST: /path/:id
-func (group *RouterGroup) CRUD(path string, resource interface{}) {
-	if resource, ok := resource.(CreateSupported); ok {
-		group.POST(path, resource.CreateHandler)
-	}
-	if resource, ok := resource.(ListSupported); ok {
-		group.GET(path, resource.ListHandler)
-	}
-	if resource, ok := resource.(TakeSupported); ok {
-		group.GET(path+"/:id", resource.TakeHandler)
-	}
-	if resource, ok := resource.(UpdateSupported); ok {
-		group.PUT(path+"/:id", resource.UpdateHandler)
-	}
-	if resource, ok := resource.(DeleteSupported); ok {
-		group.DELETE(path+"/:id", resource.DeleteHandler)
-	}
-}
-
 // Static serves files from the given file system root.
 // Internally a http.FileServer is used, therefore http.NotFound is used instead
 // of the Router's NotFound handler.

--- a/gin.go
+++ b/gin.go
@@ -212,6 +212,8 @@ type Resource interface {
 	ReadHandler(*Context)
 	UpdateHandler(*Context)
 	DeleteHandler(*Context)
+
+	Supported(string) bool
 }
 
 // It defines
@@ -220,10 +222,21 @@ type Resource interface {
 //   PUT:  /path/:id
 //   POST: /path/:id
 func (group *RouterGroup) CRUD(path string, resource Resource) {
-	group.POST(path, resource.CreateHandler)
-	group.GET(path, resource.ReadHandler)
-	group.PUT(path+"/:id", resource.UpdateHandler)
-	group.DELETE(path+"/:id", resource.DeleteHandler)
+	if resource.Supported("C") {
+		group.POST(path, resource.CreateHandler)
+	}
+
+	if resource.Supported("R") {
+		group.GET(path, resource.ReadHandler)
+	}
+
+	if resource.Supported("U") {
+		group.PUT(path+"/:id", resource.UpdateHandler)
+	}
+
+	if resource.Supported("D") {
+		group.DELETE(path+"/:id", resource.DeleteHandler)
+	}
 }
 
 // Static serves files from the given file system root.

--- a/gin.go
+++ b/gin.go
@@ -205,15 +205,19 @@ func (group *RouterGroup) HEAD(path string, handlers ...HandlerFunc) {
 	group.Handle("HEAD", path, handlers)
 }
 
-// Resouce API
 // All of the methods are the same type as HandlerFunc
-type Resource interface {
+// if you don't want to support any methods of CRUD, then don't implement it
+type CreateSupported interface {
 	CreateHandler(*Context)
+}
+type ReadSupported interface {
 	ReadHandler(*Context)
+}
+type UpdateSupported interface {
 	UpdateHandler(*Context)
+}
+type DeleteSupported interface {
 	DeleteHandler(*Context)
-
-	Supported(string) bool
 }
 
 // It defines
@@ -221,20 +225,17 @@ type Resource interface {
 //   GET:  /path
 //   PUT:  /path/:id
 //   POST: /path/:id
-func (group *RouterGroup) CRUD(path string, resource Resource) {
-	if resource.Supported("C") {
+func (group *RouterGroup) CRUD(path string, resource interface{}) {
+	if resource, ok := resource.(CreateSupported); ok {
 		group.POST(path, resource.CreateHandler)
 	}
-
-	if resource.Supported("R") {
+	if resource, ok := resource.(ReadSupported); ok {
 		group.GET(path, resource.ReadHandler)
 	}
-
-	if resource.Supported("U") {
+	if resource, ok := resource.(UpdateSupported); ok {
 		group.PUT(path+"/:id", resource.UpdateHandler)
 	}
-
-	if resource.Supported("D") {
+	if resource, ok := resource.(DeleteSupported); ok {
 		group.DELETE(path+"/:id", resource.DeleteHandler)
 	}
 }

--- a/gin.go
+++ b/gin.go
@@ -210,8 +210,11 @@ func (group *RouterGroup) HEAD(path string, handlers ...HandlerFunc) {
 type CreateSupported interface {
 	CreateHandler(*Context)
 }
-type ReadSupported interface {
-	ReadHandler(*Context)
+type ListSupported interface {
+	ListHandler(*Context)
+}
+type TakeSupported interface {
+	TakeHandler(*Context)
 }
 type UpdateSupported interface {
 	UpdateHandler(*Context)
@@ -229,8 +232,11 @@ func (group *RouterGroup) CRUD(path string, resource interface{}) {
 	if resource, ok := resource.(CreateSupported); ok {
 		group.POST(path, resource.CreateHandler)
 	}
-	if resource, ok := resource.(ReadSupported); ok {
-		group.GET(path, resource.ReadHandler)
+	if resource, ok := resource.(ListSupported); ok {
+		group.GET(path, resource.ListHandler)
+	}
+	if resource, ok := resource.(TakeSupported); ok {
+		group.GET(path+"/:id", resource.TakeHandler)
 	}
 	if resource, ok := resource.(UpdateSupported); ok {
 		group.PUT(path+"/:id", resource.UpdateHandler)

--- a/gin.go
+++ b/gin.go
@@ -205,6 +205,27 @@ func (group *RouterGroup) HEAD(path string, handlers ...HandlerFunc) {
 	group.Handle("HEAD", path, handlers)
 }
 
+// Resouce API
+// All of the methods are the same type as HandlerFunc
+type Resource interface {
+	CreateHandler(*Context)
+	ReadHandler(*Context)
+	UpdateHandler(*Context)
+	DeleteHandler(*Context)
+}
+
+// It defines
+//   POST: /path
+//   GET:  /path
+//   PUT:  /path/:id
+//   POST: /path/:id
+func (group *RouterGroup) CRUD(path string, resource Resource) {
+	group.POST(path, resource.CreateHandler)
+	group.GET(path, resource.ReadHandler)
+	group.PUT(path+"/:id", resource.UpdateHandler)
+	group.DELETE(path+"/:id", resource.DeleteHandler)
+}
+
 // Static serves files from the given file system root.
 // Internally a http.FileServer is used, therefore http.NotFound is used instead
 // of the Router's NotFound handler.

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -1,0 +1,46 @@
+package rest
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// All of the methods are the same type as HandlerFunc
+// if you don't want to support any methods of CRUD, then don't implement it
+type CreateSupported interface {
+	CreateHandler(*gin.Context)
+}
+type ListSupported interface {
+	ListHandler(*gin.Context)
+}
+type TakeSupported interface {
+	TakeHandler(*gin.Context)
+}
+type UpdateSupported interface {
+	UpdateHandler(*gin.Context)
+}
+type DeleteSupported interface {
+	DeleteHandler(*gin.Context)
+}
+
+// It defines
+//   POST: /path
+//   GET:  /path
+//   PUT:  /path/:id
+//   POST: /path/:id
+func CRUD(group *gin.RouterGroup, path string, resource interface{}) {
+	if resource, ok := resource.(CreateSupported); ok {
+		group.POST(path, resource.CreateHandler)
+	}
+	if resource, ok := resource.(ListSupported); ok {
+		group.GET(path, resource.ListHandler)
+	}
+	if resource, ok := resource.(TakeSupported); ok {
+		group.GET(path+"/:id", resource.TakeHandler)
+	}
+	if resource, ok := resource.(UpdateSupported); ok {
+		group.PUT(path+"/:id", resource.UpdateHandler)
+	}
+	if resource, ok := resource.(DeleteSupported); ok {
+		group.DELETE(path+"/:id", resource.DeleteHandler)
+	}
+}


### PR DESCRIPTION
I added CRUD API which can be used like:
```go
type Books struct {}

func (books Books) CreateHandler(ctx *gin.Context) {
  // create logic here ...
}

func (books Books) ReadHandler(ctx *gin.Context) {
  // read logic here ...
}

func (books Books) UpdateHandler(ctx *gin.Context) {
  // update logic here ...
  // you can access to :id by ctx.Params.ByName("id")
}

func (books Books) DeleteHandler(ctx *gin.Context) {
  // delete logic here ...
  // you can access to :id by ctx.Params.ByName("id")
}

// The API is:
//   POST:       /api/books
//   GET:        /api/books
//   PUT:        /api/books/:id
//   DELETE:     /api/books/:id
booksAPI := r.Group("/api/books", auth.TokenAuth)
booksAPI.CRUD("", books)
```

What do you think about this?
