### PR TITLE
Add gin.CreateContext(http.ResponseWriter, *http.Request) as a test helper

### DIFF
--- a/context.go
+++ b/context.go
@@ -66,6 +66,15 @@ type Context struct {
 }
 
 /************************************/
+/*********** TEST HELPERS ***********/
+/************************************/
+
+func CreateContext(w http.ResponseWriter, req *http.Request) *Context {
+	engine := New()
+	return engine.createContext(w, req, nil, nil)
+}
+
+/************************************/
 /********** ROUTES GROUPING *********/
 /************************************/
 

--- a/context_test.go
+++ b/context_test.go
@@ -436,3 +436,23 @@ func TestBindingJSONMalformed(t *testing.T) {
 		t.Errorf("Content-Type should not be application/json, was %s", w.HeaderMap.Get("Content-Type"))
 	}
 }
+
+func TestCreateContext(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	c := CreateContext(w, req)
+	c.JSON(200, H{"foo": "bar"})
+
+	if w.Code != 200 {
+		t.Errorf("Response code should be Ok, was: %s", w.Code)
+	}
+
+	if w.HeaderMap.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type should be application/json, was %s", w.HeaderMap.Get("Content-Type"))
+	}
+
+	if w.Body.String() != "{\"foo\":\"bar\"}\n" {
+		t.Errorf("Response should be {\"foo\":\"bar\"}, was: %s", w.Body.String())
+	}
+}


### PR DESCRIPTION
I do unit test my controllers and I need to assign `httptest.NewRecorder()` as the Context.Writer. However we wrap the `http.ResponseWriter` with `gin.responseWriter` an unexported struct that we can create objects from.

This pull request adds the function `gin.CreateContext(http.ResponseWriter, *http.Request)`, please see the included Test for a usage example

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gin-gonic/gin/102)
<!-- Reviewable:end -->
