### PR TITLE
skip unexported fields for bindings

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -174,6 +174,11 @@ func Validate(obj interface{}) error {
 				continue
 			}
 
+			// skip unexported fields
+			if field.PkgPath != "" {
+				continue
+			}
+
 			fieldValue := val.Field(i).Interface()
 			zero := reflect.Zero(field.Type).Interface()
 


### PR DESCRIPTION
Just a little check so it does not panic if the struct contains an unexported field.
