### PR TITLE
Fix HTML form binding example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ func main() {
         }
 	})
 
-    // Example for binding a HTLM form (user=manu&password=123)
+    // Example for binding a HTML form (user=manu&password=123)
     r.POST("/login", func(c *gin.Context) {
         var form LoginForm
 


### PR DESCRIPTION
There's a small typo on the HTML POST form binding example. This PR fixes it.
