### PR TITLE
Adding helper functions to router group for LINK and UNLINK.

### DIFF
--- a/routergroup.go
+++ b/routergroup.go
@@ -5,9 +5,10 @@
 package gin
 
 import (
-	"github.com/julienschmidt/httprouter"
 	"net/http"
 	"path"
+
+	"github.com/julienschmidt/httprouter"
 )
 
 // Used internally to configure router, a RouterGroup is associated with a prefix
@@ -93,6 +94,16 @@ func (group *RouterGroup) OPTIONS(relativePath string, handlers ...HandlerFunc) 
 // HEAD is a shortcut for router.Handle("HEAD", path, handle)
 func (group *RouterGroup) HEAD(relativePath string, handlers ...HandlerFunc) {
 	group.Handle("HEAD", relativePath, handlers)
+}
+
+// LINK is a shortcut for router.Handle("LINK", path, handle)
+func (group *RouterGroup) LINK(relativePath string, handlers ...HandlerFunc) {
+	group.Handle("LINK", relativePath, handlers)
+}
+
+// UNLINK is a shortcut for router.Handle("UNLINK", path, handle)
+func (group *RouterGroup) UNLINK(relativePath string, handlers ...HandlerFunc) {
+	group.Handle("UNLINK", relativePath, handlers)
 }
 
 // Static serves files from the given file system root.


### PR DESCRIPTION
Minus the small reformat that Goimports automatically made with the structure of imports, this just adds a few helper methods to the Router Group that would help us as we are using them in our project.

If you want, I can remove the import reordering.

Thanks for Gin!