### PR TITLE
Specify utf-8 as content type charset on renderers

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -76,7 +76,7 @@ func TestContextJSON(t *testing.T) {
 		t.Errorf("Response should be {\"foo\":\"bar\"}, was: %s", w.Body.String())
 	}
 
-	if w.HeaderMap.Get("Content-Type") != "application/json" {
+	if w.HeaderMap.Get("Content-Type") != "application/json; charset=utf-8" {
 		t.Errorf("Content-Type should be application/json, was %s", w.HeaderMap.Get("Content-Type"))
 	}
 }
@@ -103,7 +103,7 @@ func TestContextHTML(t *testing.T) {
 		t.Errorf("Response should be Hello alexandernyquist, was: %s", w.Body.String())
 	}
 
-	if w.HeaderMap.Get("Content-Type") != "text/html" {
+	if w.HeaderMap.Get("Content-Type") != "text/html; charset=utf-8" {
 		t.Errorf("Content-Type should be text/html, was %s", w.HeaderMap.Get("Content-Type"))
 	}
 }
@@ -125,7 +125,7 @@ func TestContextString(t *testing.T) {
 		t.Errorf("Response should be test, was: %s", w.Body.String())
 	}
 
-	if w.HeaderMap.Get("Content-Type") != "text/plain" {
+	if w.HeaderMap.Get("Content-Type") != "text/plain; charset=utf-8" {
 		t.Errorf("Content-Type should be text/plain, was %s", w.HeaderMap.Get("Content-Type"))
 	}
 }
@@ -147,7 +147,7 @@ func TestContextXML(t *testing.T) {
 		t.Errorf("Response should be <map><foo>bar</foo></map>, was: %s", w.Body.String())
 	}
 
-	if w.HeaderMap.Get("Content-Type") != "application/xml" {
+	if w.HeaderMap.Get("Content-Type") != "application/xml; charset=utf-8" {
 		t.Errorf("Content-Type should be application/xml, was %s", w.HeaderMap.Get("Content-Type"))
 	}
 }
@@ -336,7 +336,7 @@ func TestBindingJSON(t *testing.T) {
 		t.Errorf("Response should be {\"parsed\":\"bar\"}, was: %s", w.Body.String())
 	}
 
-	if w.HeaderMap.Get("Content-Type") != "application/json" {
+	if w.HeaderMap.Get("Content-Type") != "application/json; charset=utf-8" {
 		t.Errorf("Content-Type should be application/json, was %s", w.HeaderMap.Get("Content-Type"))
 	}
 }
@@ -369,7 +369,7 @@ func TestBindingJSONEncoding(t *testing.T) {
 		t.Errorf("Response should be {\"parsed\":\"嘉\"}, was: %s", w.Body.String())
 	}
 
-	if w.HeaderMap.Get("Content-Type") != "application/json" {
+	if w.HeaderMap.Get("Content-Type") != "application/json; charset=utf-8" {
 		t.Errorf("Content-Type should be application/json, was %s", w.HeaderMap.Get("Content-Type"))
 	}
 }

--- a/render/render.go
+++ b/render/render.go
@@ -50,7 +50,7 @@ var (
 )
 
 func writeHeader(w http.ResponseWriter, code int, contentType string) {
-	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Type", contentType+"; charset=utf-8")
 	w.WriteHeader(code)
 }
 


### PR DESCRIPTION
Content type charset is not specified for renderers, currently there's no way to configure it. I believe this might be a sane default.