### PR TITLE
Fix named parameter handle bugs

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -4,7 +4,7 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/julienschmidt/httprouter",
-			"Rev": "90d58bada7e6154006f2728ee09053271154a8f6"
+			"Rev": "00ce1c6a267162792c367acc43b1681a884e1872"
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ func main() {
 		c.String(200, message)
 	})
 
-	// However, this one will match /user/john and also /user/john/send
+	// However, this one will match /user/john/ and also /user/john/send
+	// If no other routers match /user/john, it will redirect to /user/join/
 	r.GET("/user/:name/*action", func(c *gin.Context) {
 		name := c.Params.ByName("name")
 		action := c.Params.ByName("action")


### PR DESCRIPTION
In current gin version, if we use demo like this

```go
func main() {
    r := gin.Default()
    // If no other routers match /user/john, it will redirect to /user/join/
    r.GET("/user/:name/*action", func(c *gin.Context) {
        name := c.Params.ByName("name")
        action := c.Params.ByName("action")
        message := name + " is " + action
        c.String(200, message)
    })

    // Listen and server on 0.0.0.0:8080
    r.Run(":8080")
}
```

It cannot handle request **/user/john**, but it could handle **/user/john/**, and the demo is extrally copied from the readme, the  actually reason that why the demo in readme can handle **/user/john**  is that it's handled by

```go
  r.GET("/user/:name", func(c *gin.Context) {
        name := c.Params.ByName("name")
        message := "Hello "+name
        c.String(200, message)
    })
```

not the

```go
 r.GET("/user/:name/*action", func(c *gin.Context) {
        name := c.Params.ByName("name")
        action := c.Params.ByName("action")
        message := name + " is " + action
        c.String(200, message)
    })
```

Fortunately， the latest [httprouter](https://github.com/julienschmidt/httprouter) solve this problem, if url like **/user/john** cannot be handled by other routers, it will redirect 301 to **/user/john/**
