### PR TITLE
Add validating sub structures

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -209,6 +209,11 @@ func Validate(obj interface{}, parents ...string) error {
 					if err != nil {
 						return err
 					}
+				} else if fieldType == reflect.Slice && field.Type.Elem().Kind() == reflect.Struct {
+					err := Validate(fieldValue, field.Name)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/binding/binding.go
+++ b/binding/binding.go
@@ -199,6 +199,17 @@ func Validate(obj interface{}, parents ...string) error {
 						return err
 					}
 				}
+			} else {
+				fieldType := field.Type.Kind()
+				if fieldType == reflect.Struct {
+					if reflect.DeepEqual(zero, fieldValue) {
+						continue
+					}
+					err := Validate(fieldValue, field.Name)
+					if err != nil {
+						return err
+					}
+				}
 			}
 		}
 	case reflect.Slice:


### PR DESCRIPTION
This fix can help validating sub structures, for example we have something like this:
```go
struct {
  RequiredField int `json:"required"`
  OptionalField struct{
    RequiredSubField string `json:"optional_sub_field" binding:"required"` 
    OptionalSubField string `json:"optional_sub_field"`
  }  `json:"optional_field"`
}
```
Without this patch Bind wont fail on something like this json
```go
{
  "optional_field": {
    "optional_sub_field": "more"
  },
  "required_field": 10
}
```

This allow to define optional fields, that, if present, shoud fit some critreias.