### PR TITLE
Setting logging to release mode in example

### DIFF
--- a/examples/app-engine/hello.go
+++ b/examples/app-engine/hello.go
@@ -9,6 +9,7 @@ import (
 func init() {
 	// Starts a new Gin instance with no middle-ware
 	r := gin.New()
+	gin.SetMode(gin.ReleaseMode)
 
 	// Define your handlers
 	r.GET("/", func(c *gin.Context){


### PR DESCRIPTION
Debug causes App Engine to fail building, output looks like this:

```
ERROR    2015-03-22 04:15:01,027 http_runtime.py:285] bad runtime process port ['[GIN-debug] GET   /                         --> web.func\xc2\xb7001 (1 handlers)\n']
```

Setting to ReleaseMode fixes this.