### PR TITLE
add support for embedded struct to Bind

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -84,6 +84,17 @@ func mapForm(ptr interface{}, form map[string][]string) error {
 	formStruct := reflect.ValueOf(ptr).Elem()
 	for i := 0; i < typ.NumField(); i++ {
 		typeField := typ.Field(i)
+
+		// support for embeded fields
+		valueField := formStruct.Field(i)
+		if valueField.Kind() == reflect.Struct {
+			err := mapForm(valueField.Addr().Interface(), form)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
 		if inputFieldName := typeField.Tag.Get("form"); inputFieldName != "" {
 			structField := formStruct.Field(i)
 			if !structField.CanSet() {


### PR DESCRIPTION
We had the following issue:

```
type Event struct {
	Timestamp string `form:"timestamp" json:"timestamp,omitempty"`
}
type AnotherEvent struct {
      Event
      Value string `form:"value" json:"value,omitempty"`
}
```

Using gins default Bind the embedded struct is ignored. This pull request adds support for embedded structs. Not sure if this is useful in general. 