### PR TITLE
Append queue

### DIFF
--- a/context.go
+++ b/context.go
@@ -69,6 +69,7 @@ type Context struct {
 
 	Engine   *Engine
 	Keys     map[string]interface{}
+	Queue     []interface{}
 	Errors   errorMsgs
 	Accepted []string
 }
@@ -269,6 +270,25 @@ func (c *Context) Value(key interface{}) interface{} {
 		return val
 	}
 	return c.Context.Value(key)
+}
+
+//Enqueue new item
+func (c *Context) Enqueue(item interface{}) {
+	if c.Queue == nil {
+		c.Queue = []interface{}{}
+	}
+	c.Queue = append(c.Queue, item)
+}
+
+//Dequeue returns the value from top of the queue
+func (c *Context) Dequeue () (interface{}, error) {
+	size := len(c.Queue)
+	if c.Queue == nil || size == 0 {
+		return nil, errors.New("Queue is empty")
+	}
+	result := c.Queue[size-1]
+	c.Queue = c.Queue[0:size-1]
+	return result, nil
 }
 
 /************************************/

--- a/context_test.go
+++ b/context_test.go
@@ -91,6 +91,16 @@ func TestContextSetGetValues(t *testing.T) {
 
 }
 
+func TestContextQueue(t *testing.T) {
+	c, _, _ := createTestContext()
+	c.Enqueue("value")
+	c.Enqueue("data")
+	v, _ := c.Dequeue()
+	assert.Exactly(t, v, "data")
+	v2, _ := c.Dequeue()
+	assert.Exactly(t, v2, "value")
+}
+
 func TestContextCopy(t *testing.T) {
 	c, _, _ := createTestContext()
 	c.index = 2


### PR DESCRIPTION
Hi!
What do you think about simple queue to the context? We already have a functions
```go 
func (c *Context) Set(key string, value interface{})
```
and 
```go 
func (c *Context) Get(key string) (value interface{}, exists bool)
```
for the specified context, but this is just a queue for non-specified contexts.
This is looks like:

```go
func Foobar() gin.HandlerFunc {
    return func(c *gin.Context) {
        c.Enqueue("item1")
        c.Enqueue("item2")
    }
}

func main() {
    r := gin.New()
    r.Use(Foobar())

    r.GET("/test", func(c *gin.Context) {
        fmt.Println(c.Dequeue()) //item2
        fmt.Println(c.Dequeue()) //item1
    })
    r.Run(":8080")
}
```
