### PR TITLE
Adding support for returning with application/vnd.api+json content-type

### DIFF
--- a/context.go
+++ b/context.go
@@ -331,6 +331,15 @@ func (c *Context) JSON(code int, obj interface{}) {
 	}
 }
 
+// Serializes the given struct as JSON into the response body.
+// It also sets the Content-Type as "application/vnd.api+json".
+func (c *Context) JSONAPI(code int, obj interface{}) {
+	c.writermem.WriteHeader(code)
+	if err := render.WriteJSONAPI(c.Writer, obj); err != nil {
+		c.renderError(err)
+	}
+}
+
 // Serializes the given struct as XML into the response body.
 // It also sets the Content-Type as "application/xml".
 func (c *Context) XML(code int, obj interface{}) {

--- a/context_test.go
+++ b/context_test.go
@@ -220,6 +220,17 @@ func TestContextRenderJSON(t *testing.T) {
 }
 
 // Tests that the response is serialized as JSON
+// and Content-Type is set to application/vnd.api+json
+func TestContextRenderJSON(t *testing.T) {
+	c, w, _ := createTestContext()
+	c.JSONAPI(201, H{"foo": "bar"})
+
+	assert.Equal(t, w.Code, 201)
+	assert.Equal(t, w.Body.String(), "{\"foo\":\"bar\"}\n")
+	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/vnd.api+json")
+}
+
+// Tests that the response is serialized as JSON
 // and Content-Type is set to application/json
 func TestContextRenderIndentedJSON(t *testing.T) {
 	c, w, _ := createTestContext()

--- a/render/json.go
+++ b/render/json.go
@@ -13,16 +13,27 @@ type (
 	JSON struct {
 		Data interface{}
 	}
+	
+	JSONAPI struct {
+		Data interface{}
+	}
 
 	IndentedJSON struct {
 		Data interface{}
 	}
 )
 
-var jsonContentType = []string{"application/json; charset=utf-8"}
+var (
+	jsonContentType = []string{"application/json; charset=utf-8"}
+	jsonAPIContentType = []string{"application/vnd.api+json"}
+)
 
 func (r JSON) Render(w http.ResponseWriter) error {
 	return WriteJSON(w, r.Data)
+}
+
+func (r JSONAPI) Render(w http.ResponseWriter) error {
+	return WriteJSONAPI(w, r.Data)
 }
 
 func (r IndentedJSON) Render(w http.ResponseWriter) error {
@@ -38,4 +49,9 @@ func (r IndentedJSON) Render(w http.ResponseWriter) error {
 func WriteJSON(w http.ResponseWriter, obj interface{}) error {
 	w.Header()["Content-Type"] = jsonContentType
 	return json.NewEncoder(w).Encode(obj)
+}
+
+func WriteJSONAPI(w http.ResponseWrite, obj interface{}) error {
+	w.Header()["Content-Type"] = jsonAPIContentType
+	return json.NewEncode(w).Encode(obj)
 }

--- a/render/json.go
+++ b/render/json.go
@@ -51,7 +51,7 @@ func WriteJSON(w http.ResponseWriter, obj interface{}) error {
 	return json.NewEncoder(w).Encode(obj)
 }
 
-func WriteJSONAPI(w http.ResponseWrite, obj interface{}) error {
+func WriteJSONAPI(w http.ResponseWriter, obj interface{}) error {
 	w.Header()["Content-Type"] = jsonAPIContentType
-	return json.NewEncode(w).Encode(obj)
+	return json.NewEncoder(w).Encode(obj)
 }

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -29,6 +29,19 @@ func TestRenderJSON(t *testing.T) {
 	assert.Equal(t, w.Header().Get("Content-Type"), "application/json; charset=utf-8")
 }
 
+func TestRenderJSONAPI(t *testing.T) {
+	w := httptest.NewRecorder()
+	data := map[string]interface{}{
+		"foo": "bar",
+	}
+
+	err := (JSONAPI{data}).Render(w)
+
+	assert.NoError(t, err)
+	assert.Equal(t, w.Body.String(), "{\"foo\":\"bar\"}\n")
+	assert.Equal(t, w.Header().Get("Content-Type"), "application/vnd.api+json")
+}
+
 func TestRenderIndentedJSON(t *testing.T) {
 	w := httptest.NewRecorder()
 	data := map[string]interface{}{


### PR DESCRIPTION
Right now, if I want to return some JSON I'm (apparently) forced to use the default `application/json; charset=utf-8` content-type, when I need `application/vnd.api+json`. This PR includes modifications and a new unit test to add support.

Previous alternative was using `Data`, having to manually Marshal my struct, etc. Why not build it in? :)