### PR TITLE
Rename gin.RoutesInterface to gin.RouterGroupInterface, and gin.routesInterface to gin.RoutesInterface

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -78,7 +78,7 @@ type (
 	}
 )
 
-var _ RoutesInterface = &Engine{}
+var _ RouterGroupInterface = &Engine{}
 
 // Returns a new blank Engine instance without any middleware attached.
 // The most basic configuration
@@ -154,7 +154,7 @@ func (engine *Engine) NoMethod(handlers ...HandlerFunc) {
 // Attachs a global middleware to the router. ie. the middlewares attached though Use() will be
 // included in the handlers chain for every single request. Even 404, 405, static files...
 // For example, this is the right place for a logger or error management middleware.
-func (engine *Engine) Use(middlewares ...HandlerFunc) routesInterface {
+func (engine *Engine) Use(middlewares ...HandlerFunc) RoutesInterface {
 	engine.RouterGroup.Use(middlewares...)
 	engine.rebuild404Handlers()
 	engine.rebuild405Handlers()

--- a/routergroup.go
+++ b/routergroup.go
@@ -12,27 +12,27 @@ import (
 )
 
 type (
-	RoutesInterface interface {
-		routesInterface
+	RouterGroupInterface interface {
+		RoutesInterface
 		Group(string, ...HandlerFunc) *RouterGroup
 	}
 
-	routesInterface interface {
-		Use(...HandlerFunc) routesInterface
+	RoutesInterface interface {
+		Use(...HandlerFunc) RoutesInterface
 
-		Handle(string, string, ...HandlerFunc) routesInterface
-		Any(string, ...HandlerFunc) routesInterface
-		GET(string, ...HandlerFunc) routesInterface
-		POST(string, ...HandlerFunc) routesInterface
-		DELETE(string, ...HandlerFunc) routesInterface
-		PATCH(string, ...HandlerFunc) routesInterface
-		PUT(string, ...HandlerFunc) routesInterface
-		OPTIONS(string, ...HandlerFunc) routesInterface
-		HEAD(string, ...HandlerFunc) routesInterface
+		Handle(string, string, ...HandlerFunc) RoutesInterface
+		Any(string, ...HandlerFunc) RoutesInterface
+		GET(string, ...HandlerFunc) RoutesInterface
+		POST(string, ...HandlerFunc) RoutesInterface
+		DELETE(string, ...HandlerFunc) RoutesInterface
+		PATCH(string, ...HandlerFunc) RoutesInterface
+		PUT(string, ...HandlerFunc) RoutesInterface
+		OPTIONS(string, ...HandlerFunc) RoutesInterface
+		HEAD(string, ...HandlerFunc) RoutesInterface
 
-		StaticFile(string, string) routesInterface
-		Static(string, string) routesInterface
-		StaticFS(string, http.FileSystem) routesInterface
+		StaticFile(string, string) RoutesInterface
+		Static(string, string) RoutesInterface
+		StaticFS(string, http.FileSystem) RoutesInterface
 	}
 
 	// Used internally to configure router, a RouterGroup is associated with a prefix
@@ -45,10 +45,10 @@ type (
 	}
 )
 
-var _ RoutesInterface = &RouterGroup{}
+var _ RouterGroupInterface = &RouterGroup{}
 
 // Adds middlewares to the group, see example code in github.
-func (group *RouterGroup) Use(middlewares ...HandlerFunc) routesInterface {
+func (group *RouterGroup) Use(middlewares ...HandlerFunc) RoutesInterface {
 	group.Handlers = append(group.Handlers, middlewares...)
 	return group.returnObj()
 }
@@ -73,14 +73,14 @@ func (group *RouterGroup) Group(relativePath string, handlers ...HandlerFunc) *R
 // This function is intended for bulk loading and to allow the usage of less
 // frequently used, non-standardized or custom methods (e.g. for internal
 // communication with a proxy).
-func (group *RouterGroup) handle(httpMethod, relativePath string, handlers HandlersChain) routesInterface {
+func (group *RouterGroup) handle(httpMethod, relativePath string, handlers HandlersChain) RoutesInterface {
 	absolutePath := group.calculateAbsolutePath(relativePath)
 	handlers = group.combineHandlers(handlers)
 	group.engine.addRoute(httpMethod, absolutePath, handlers)
 	return group.returnObj()
 }
 
-func (group *RouterGroup) Handle(httpMethod, relativePath string, handlers ...HandlerFunc) routesInterface {
+func (group *RouterGroup) Handle(httpMethod, relativePath string, handlers ...HandlerFunc) RoutesInterface {
 	if matches, err := regexp.MatchString("^[A-Z]+$", httpMethod); !matches || err != nil {
 		panic("http method " + httpMethod + " is not valid")
 	}
@@ -88,41 +88,41 @@ func (group *RouterGroup) Handle(httpMethod, relativePath string, handlers ...Ha
 }
 
 // POST is a shortcut for router.Handle("POST", path, handle)
-func (group *RouterGroup) POST(relativePath string, handlers ...HandlerFunc) routesInterface {
+func (group *RouterGroup) POST(relativePath string, handlers ...HandlerFunc) RoutesInterface {
 	return group.handle("POST", relativePath, handlers)
 }
 
 // GET is a shortcut for router.Handle("GET", path, handle)
-func (group *RouterGroup) GET(relativePath string, handlers ...HandlerFunc) routesInterface {
+func (group *RouterGroup) GET(relativePath string, handlers ...HandlerFunc) RoutesInterface {
 	return group.handle("GET", relativePath, handlers)
 }
 
 // DELETE is a shortcut for router.Handle("DELETE", path, handle)
-func (group *RouterGroup) DELETE(relativePath string, handlers ...HandlerFunc) routesInterface {
+func (group *RouterGroup) DELETE(relativePath string, handlers ...HandlerFunc) RoutesInterface {
 	return group.handle("DELETE", relativePath, handlers)
 }
 
 // PATCH is a shortcut for router.Handle("PATCH", path, handle)
-func (group *RouterGroup) PATCH(relativePath string, handlers ...HandlerFunc) routesInterface {
+func (group *RouterGroup) PATCH(relativePath string, handlers ...HandlerFunc) RoutesInterface {
 	return group.handle("PATCH", relativePath, handlers)
 }
 
 // PUT is a shortcut for router.Handle("PUT", path, handle)
-func (group *RouterGroup) PUT(relativePath string, handlers ...HandlerFunc) routesInterface {
+func (group *RouterGroup) PUT(relativePath string, handlers ...HandlerFunc) RoutesInterface {
 	return group.handle("PUT", relativePath, handlers)
 }
 
 // OPTIONS is a shortcut for router.Handle("OPTIONS", path, handle)
-func (group *RouterGroup) OPTIONS(relativePath string, handlers ...HandlerFunc) routesInterface {
+func (group *RouterGroup) OPTIONS(relativePath string, handlers ...HandlerFunc) RoutesInterface {
 	return group.handle("OPTIONS", relativePath, handlers)
 }
 
 // HEAD is a shortcut for router.Handle("HEAD", path, handle)
-func (group *RouterGroup) HEAD(relativePath string, handlers ...HandlerFunc) routesInterface {
+func (group *RouterGroup) HEAD(relativePath string, handlers ...HandlerFunc) RoutesInterface {
 	return group.handle("HEAD", relativePath, handlers)
 }
 
-func (group *RouterGroup) Any(relativePath string, handlers ...HandlerFunc) routesInterface {
+func (group *RouterGroup) Any(relativePath string, handlers ...HandlerFunc) RoutesInterface {
 	// GET, POST, PUT, PATCH, HEAD, OPTIONS, DELETE, CONNECT, TRACE
 	group.handle("GET", relativePath, handlers)
 	group.handle("POST", relativePath, handlers)
@@ -136,7 +136,7 @@ func (group *RouterGroup) Any(relativePath string, handlers ...HandlerFunc) rout
 	return group.returnObj()
 }
 
-func (group *RouterGroup) StaticFile(relativePath, filepath string) routesInterface {
+func (group *RouterGroup) StaticFile(relativePath, filepath string) RoutesInterface {
 	if strings.Contains(relativePath, ":") || strings.Contains(relativePath, "*") {
 		panic("URL parameters can not be used when serving a static file")
 	}
@@ -154,11 +154,11 @@ func (group *RouterGroup) StaticFile(relativePath, filepath string) routesInterf
 // To use the operating system's file system implementation,
 // use :
 //     router.Static("/static", "/var/www")
-func (group *RouterGroup) Static(relativePath, root string) routesInterface {
+func (group *RouterGroup) Static(relativePath, root string) RoutesInterface {
 	return group.StaticFS(relativePath, Dir(root, false))
 }
 
-func (group *RouterGroup) StaticFS(relativePath string, fs http.FileSystem) routesInterface {
+func (group *RouterGroup) StaticFS(relativePath string, fs http.FileSystem) RoutesInterface {
 	if strings.Contains(relativePath, ":") || strings.Contains(relativePath, "*") {
 		panic("URL parameters can not be used when serving a static folder")
 	}
@@ -198,7 +198,7 @@ func (group *RouterGroup) calculateAbsolutePath(relativePath string) string {
 	return joinPaths(group.BasePath, relativePath)
 }
 
-func (group *RouterGroup) returnObj() routesInterface {
+func (group *RouterGroup) returnObj() RoutesInterface {
 	if group.root {
 		return group.engine
 	} else {


### PR DESCRIPTION
The reason of those changes is that till methods in the gin.routesInterface returns unexported type there are no ability to implement such interface outside of the gin package.

This PR relates to https://github.com/gin-gonic/gin/pull/348