### PR TITLE
Use only the ip part of request RemoteAddr

### DIFF
--- a/context.go
+++ b/context.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -269,7 +270,10 @@ func (c *Context) ClientIP() string {
 			return clientIP
 		}
 	}
-	return strings.TrimSpace(c.Request.RemoteAddr)
+	if ip, _, err := net.SplitHostPort(strings.TrimSpace(c.Request.RemoteAddr)); err == nil {
+		return ip
+	}
+	return ""
 }
 
 func (c *Context) ContentType() string {

--- a/context_test.go
+++ b/context_test.go
@@ -478,7 +478,7 @@ func TestContextClientIP(t *testing.T) {
 
 	c.Request.Header.Set("X-Real-IP", " 10.10.10.10  ")
 	c.Request.Header.Set("X-Forwarded-For", "  20.20.20.20, 30.30.30.30")
-	c.Request.RemoteAddr = "  40.40.40.40 "
+	c.Request.RemoteAddr = "  40.40.40.40:42123 "
 
 	assert.Equal(t, c.ClientIP(), "10.10.10.10")
 


### PR DESCRIPTION
If you see http://golang.org/pkg/net/http/#Request, the RemoteAddr value is "IP:port". So I remove the port part.