### PR TITLE
Fix IsAborted() method

### DIFF
--- a/context.go
+++ b/context.go
@@ -93,7 +93,7 @@ func (c *Context) Next() {
 
 // Returns if the currect context was aborted.
 func (c *Context) IsAborted() bool {
-	return c.index == AbortIndex
+	return c.index >= AbortIndex
 }
 
 // Stops the system to continue calling the pending handlers in the chain.

--- a/context_test.go
+++ b/context_test.go
@@ -417,7 +417,7 @@ func TestContextIsAborted(t *testing.T) {
 
 	assert.True(t, c.IsAborted())
 
-	c.index += 1
+	c.Next()
 
 	assert.True(t, c.IsAborted())
 }

--- a/context_test.go
+++ b/context_test.go
@@ -408,6 +408,20 @@ func TestContextNegotiationFormatCustum(t *testing.T) {
 	assert.Equal(t, c.NegotiateFormat(MIMEJSON), MIMEJSON)
 }
 
+func TestContextIsAborted(t *testing.T) {
+	c, _, _ := createTestContext()
+
+	assert.False(t, c.IsAborted())
+
+	c.Abort()
+
+	assert.True(t, c.IsAborted())
+
+	c.index += 1
+
+	assert.True(t, c.IsAborted())
+}
+
 // TestContextData tests that the response can be written from `bytesting`
 // with specified MIME type
 func TestContextAbortWithStatus(t *testing.T) {


### PR DESCRIPTION
According to the documentation IsAborted() method should return true if the current context was aborted. 

At the moment it  works only for the Handlers in which Abort() method was triggered. It doesn't work in the previous Handlers after the c.Next() call. It is because c.index will be higher then AbortIndex.

In my applications I would like to be able to determine whether the Context was aborted after the request was processed, without having to populate c.Errors slice.