### PR TITLE
RedirectTrailingSlash has no effect unless RedirectFixedPath is set

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -294,7 +294,7 @@ func (engine *Engine) handleHTTPRequest(context *Context) {
 				return
 
 			} else if httpMethod != "CONNECT" && path != "/" {
-				if tsr && engine.RedirectFixedPath {
+				if tsr && engine.RedirectTrailingSlash {
 					redirectTrailingSlash(context)
 					return
 				}


### PR DESCRIPTION
Which is not likely the desired behavior.

RedirectTrailingSlash setting is meant to cause a redirect, but the code is never called because the setting wasn't being checked. Instead RedirectFixedPath was being checked.