### PR TITLE
tests: make path assertions aware of vendoring

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -161,7 +161,7 @@ func TestContextHandlerName(t *testing.T) {
 	c, _, _ := createTestContext()
 	c.handlers = HandlersChain{func(c *Context) {}, handlerNameTest}
 
-	assert.Equal(t, c.HandlerName(), "github.com/gin-gonic/gin.handlerNameTest")
+	assert.Regexp(t, "^(.*/vendor/)?github.com/gin-gonic/gin.handlerNameTest$", c.HandlerName())
 }
 
 func handlerNameTest(c *Context) {

--- a/debug_test.go
+++ b/debug_test.go
@@ -63,7 +63,7 @@ func TestDebugPrintRoutes(t *testing.T) {
 	defer teardown()
 
 	debugPrintRoute("GET", "/path/to/route/:param", HandlersChain{func(c *Context) {}, handlerNameTest})
-	assert.Equal(t, w.String(), "[GIN-debug] GET   /path/to/route/:param     --> github.com/gin-gonic/gin.handlerNameTest (2 handlers)\n")
+	assert.Regexp(t, `^\[GIN-debug\] GET   /path/to/route/:param     --> (.*/vendor/)?github.com/gin-gonic/gin.handlerNameTest \(2 handlers\)\n$`, w.String())
 }
 
 func setup(w io.Writer) {

--- a/gin_test.go
+++ b/gin_test.go
@@ -214,31 +214,41 @@ func TestListOfRoutes(t *testing.T) {
 	list := router.Routes()
 
 	assert.Len(t, list, 7)
-	assert.Contains(t, list, RouteInfo{
+	assertRoutePresent(t, list, RouteInfo{
 		Method:  "GET",
 		Path:    "/favicon.ico",
-		Handler: "github.com/gin-gonic/gin.handler_test1",
+		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handler_test1$",
 	})
-	assert.Contains(t, list, RouteInfo{
+	assertRoutePresent(t, list, RouteInfo{
 		Method:  "GET",
 		Path:    "/",
-		Handler: "github.com/gin-gonic/gin.handler_test1",
+		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handler_test1$",
 	})
-	assert.Contains(t, list, RouteInfo{
+	assertRoutePresent(t, list, RouteInfo{
 		Method:  "GET",
 		Path:    "/users/",
-		Handler: "github.com/gin-gonic/gin.handler_test2",
+		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handler_test2$",
 	})
-	assert.Contains(t, list, RouteInfo{
+	assertRoutePresent(t, list, RouteInfo{
 		Method:  "GET",
 		Path:    "/users/:id",
-		Handler: "github.com/gin-gonic/gin.handler_test1",
+		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handler_test1$",
 	})
-	assert.Contains(t, list, RouteInfo{
+	assertRoutePresent(t, list, RouteInfo{
 		Method:  "POST",
 		Path:    "/users/:id",
-		Handler: "github.com/gin-gonic/gin.handler_test2",
+		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handler_test2$",
 	})
+}
+
+func assertRoutePresent(t *testing.T, gotRoutes RoutesInfo, wantRoute RouteInfo) {
+	for _, gotRoute := range gotRoutes {
+		if gotRoute.Path == wantRoute.Path && gotRoute.Method == wantRoute.Method {
+			assert.Regexp(t, wantRoute.Path, gotRoute.Path)
+			return
+		}
+	}
+	t.Errorf("route not found: %v", wantRoute)
 }
 
 func handler_test1(c *Context) {}

--- a/utils_test.go
+++ b/utils_test.go
@@ -78,7 +78,7 @@ func TestFilterFlags(t *testing.T) {
 }
 
 func TestFunctionName(t *testing.T) {
-	assert.Equal(t, nameOfFunction(somefunction), "github.com/gin-gonic/gin.somefunction")
+	assert.Regexp(t, `^(.*/vendor/)?github.com/gin-gonic/gin.somefunction$`, nameOfFunction(somefunction))
 }
 
 func somefunction() {


### PR DESCRIPTION
The path of a package can change in a situation where
dependency vendoring is in use.
This change modifies gin's unit tests to allow such paths.