### PR TITLE
Rawjson for the ability to write out a Buffer of raw JSON bytes when you have it

### DIFF
--- a/context.go
+++ b/context.go
@@ -5,6 +5,7 @@
 package gin
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"math"
@@ -356,6 +357,14 @@ func (c *Context) JSON(code int, obj interface{}) {
 	if err := render.WriteJSON(c.Writer, obj); err != nil {
 		c.renderError(err)
 	}
+}
+
+// RawJSON give a buffer of bytes representing JSON just write it out
+// this habdles cases where you get back JSON as bytes from redis or ffjson
+// and you do not want the extra marshall/demarshal overhead
+// It also sets the Content-Type as "application/json".
+func (c *Context) RawJSON(code int, obj interface{}) {
+	c.Render(code, render.RawJSON{Data: obj.(*bytes.Buffer)})
 }
 
 // XML serializes the given struct as XML into the response body.

--- a/context_test.go
+++ b/context_test.go
@@ -161,7 +161,7 @@ func TestContextHandlerName(t *testing.T) {
 	c, _, _ := createTestContext()
 	c.handlers = HandlersChain{func(c *Context) {}, handlerNameTest}
 
-	assert.Equal(t, c.HandlerName(), "github.com/gin-gonic/gin.handlerNameTest")
+	assert.Equal(t, c.HandlerName(), TestPath+"/gin.handlerNameTest")
 }
 
 func handlerNameTest(c *Context) {

--- a/context_test.go
+++ b/context_test.go
@@ -257,6 +257,21 @@ func TestContextRenderJSON(t *testing.T) {
 	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/json; charset=utf-8")
 }
 
+// Tests that the response is JSON writen out from bytes
+// and Content-Type is set to application/json
+func TestContextRenderRawJSON(t *testing.T) {
+	c, w, _ := createTestContext()
+
+	var buffer bytes.Buffer
+	buffer.WriteString("{\"foo\": \"bar\"}")
+
+	c.RawJSON(201, &buffer)
+
+	assert.Equal(t, w.Code, 201)
+	assert.Equal(t, w.Body.String(), "{\"foo\": \"bar\"}")
+	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/json; charset=utf-8")
+}
+
 // Tests that the response is serialized as JSON
 // we change the content-type before
 func TestContextRenderAPIJSON(t *testing.T) {

--- a/debug_test.go
+++ b/debug_test.go
@@ -63,7 +63,7 @@ func TestDebugPrintRoutes(t *testing.T) {
 	defer teardown()
 
 	debugPrintRoute("GET", "/path/to/route/:param", HandlersChain{func(c *Context) {}, handlerNameTest})
-	assert.Equal(t, w.String(), "[GIN-debug] GET   /path/to/route/:param     --> github.com/gin-gonic/gin.handlerNameTest (2 handlers)\n")
+	assert.Equal(t, w.String(), "[GIN-debug] GET   /path/to/route/:param     --> "+TestPath+"/gin.handlerNameTest (2 handlers)\n")
 }
 
 func setup(w io.Writer) {

--- a/gin.go
+++ b/gin.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path"
+	"runtime"
 	"sync"
 
 	"github.com/gin-gonic/gin/render"
@@ -19,6 +21,13 @@ const Version = "v1.0rc2"
 
 var default404Body = []byte("404 page not found")
 var default405Body = []byte("405 method not allowed")
+
+// replace hardcoded paths in assertions within tests to
+// make it easier for contributors to run tests
+var _, CurrentFile, _, _ = runtime.Caller(1)
+var TestPath = path.Dir(path.Dir(path.Dir(CurrentFile)))
+
+//TestPath,_ := os.Open(path.Join(path.Dir(TestFile), "gin.go"))
 
 type HandlerFunc func(*Context)
 type HandlersChain []HandlerFunc

--- a/gin_test.go
+++ b/gin_test.go
@@ -217,27 +217,27 @@ func TestListOfRoutes(t *testing.T) {
 	assert.Contains(t, list, RouteInfo{
 		Method:  "GET",
 		Path:    "/favicon.ico",
-		Handler: "github.com/gin-gonic/gin.handler_test1",
+		Handler: TestPath + "/gin.handler_test1",
 	})
 	assert.Contains(t, list, RouteInfo{
 		Method:  "GET",
 		Path:    "/",
-		Handler: "github.com/gin-gonic/gin.handler_test1",
+		Handler: TestPath + "/gin.handler_test1",
 	})
 	assert.Contains(t, list, RouteInfo{
 		Method:  "GET",
 		Path:    "/users/",
-		Handler: "github.com/gin-gonic/gin.handler_test2",
+		Handler: TestPath + "/gin.handler_test2",
 	})
 	assert.Contains(t, list, RouteInfo{
 		Method:  "GET",
 		Path:    "/users/:id",
-		Handler: "github.com/gin-gonic/gin.handler_test1",
+		Handler: TestPath + "/gin.handler_test1",
 	})
 	assert.Contains(t, list, RouteInfo{
 		Method:  "POST",
 		Path:    "/users/:id",
-		Handler: "github.com/gin-gonic/gin.handler_test2",
+		Handler: TestPath + "/gin.handler_test2",
 	})
 }
 

--- a/render/json.go
+++ b/render/json.go
@@ -5,6 +5,7 @@
 package render
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 )
@@ -16,6 +17,9 @@ type (
 
 	IndentedJSON struct {
 		Data interface{}
+	}
+	RawJSON struct {
+		Data *bytes.Buffer
 	}
 )
 
@@ -38,4 +42,10 @@ func (r IndentedJSON) Render(w http.ResponseWriter) error {
 func WriteJSON(w http.ResponseWriter, obj interface{}) error {
 	writeContentType(w, jsonContentType)
 	return json.NewEncoder(w).Encode(obj)
+}
+
+func (r RawJSON) Render(w http.ResponseWriter) error {
+	writeContentType(w, jsonContentType)
+	w.Write(r.Data.Bytes())
+	return nil
 }

--- a/render/render.go
+++ b/render/render.go
@@ -13,6 +13,7 @@ type Render interface {
 var (
 	_ Render     = JSON{}
 	_ Render     = IndentedJSON{}
+	_ Render     = RawJSON{}
 	_ Render     = XML{}
 	_ Render     = String{}
 	_ Render     = Redirect{}

--- a/utils_test.go
+++ b/utils_test.go
@@ -78,7 +78,7 @@ func TestFilterFlags(t *testing.T) {
 }
 
 func TestFunctionName(t *testing.T) {
-	assert.Equal(t, nameOfFunction(somefunction), "github.com/gin-gonic/gin.somefunction")
+	assert.Equal(t, nameOfFunction(somefunction), TestPath+"/gin.somefunction")
 }
 
 func somefunction() {


### PR DESCRIPTION
please consider RawJSON  pull request.  I needed it for a case where I already had the JSON in a byte slice and I just wanted to write it out without incurring additional overhead costs of unmarshalling then re-marshalling it.  This is useful for cases such as redis with lua returning the raw JSON bytes of when you use a library like https://github.com/pquerna/ffjson where you need better performance for JSON.  

I also replaced the hardcoded test paths in the assertions so that it is easier for contributors to run the tests.