### PR TITLE
Add c.PostFormExists(key)

### DIFF
--- a/context.go
+++ b/context.go
@@ -198,6 +198,13 @@ func (c *Context) PostForm(key string) (va string) {
 	return
 }
 
+// PostFormExists returns `true` if field with given name exists in the form
+func (c *Context) PostFormExists(key string) (exists bool) {
+	_, exists = c.postForm(key)
+
+	return exists
+}
+
 // Param is a shortcut for c.Params.ByName(key)
 func (c *Context) Param(key string) string {
 	return c.Params.ByName(key)


### PR DESCRIPTION
Method `c.PostFormExists(key)` returns `true` if field with given name exists in the form.

Right now there is no way to check if field exists in the form or not.
The functionality needed for example for `PATCH` requests when result of binding to a `string` gives false positive for field existence check.

Let's say we have struct for binding:
```go
type UserPayload struct {
	Gender    string `json:"gender" form:"gender"`
}

...

var userPayload UserPayload
c.Bind(&userPayload)
```

Now if I `POST/PATCH/PUT` both empty user object `{}` or user object with empty field `{gender: ""}` 
`userPayload.Gender` will be equal to an empty string. 

Hope my explanation is clear, but please feel free with any questions.
Thanks.