### PR TITLE
Clarify context.Abort docs

### DIFF
--- a/context.go
+++ b/context.go
@@ -101,10 +101,10 @@ func (c *Context) IsAborted() bool {
 	return c.index >= abortIndex
 }
 
-// Abort stops the system to continue calling the pending handlers in the chain.
-// Let's say you have an authorization middleware that validates if the request is authorized
-// if the authorization fails (the password does not match). This method (Abort()) should be called
-// in order to stop the execution of the actual handler.
+// Abort prevents pending handlers from being called. Note that this will not stop the current execution context.
+// Let's say you have an authorization middleware that validates that the current request is authorized. If the
+// authorization fails (ex: the password does not match), call Abort to ensure the remaining handlers
+// for this request are not called.
 func (c *Context) Abort() {
 	c.index = abortIndex
 }

--- a/context.go
+++ b/context.go
@@ -101,7 +101,7 @@ func (c *Context) IsAborted() bool {
 	return c.index >= abortIndex
 }
 
-// Abort prevents pending handlers from being called. Note that this will not stop the current execution context.
+// Abort prevents pending handlers from being called. Note that this will not stop the current handler.
 // Let's say you have an authorization middleware that validates that the current request is authorized. If the
 // authorization fails (ex: the password does not match), call Abort to ensure the remaining handlers
 // for this request are not called.


### PR DESCRIPTION
I took a stab at clarifying the `context.Abort` func. Seems there's some confusion for us newbies as to how it's supposed to be used.