### PR TITLE
Fix indent of routes debug prints

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -24,7 +24,7 @@ func debugPrintRoute(httpMethod, absolutePath string, handlers HandlersChain) {
 	if IsDebugging() {
 		nuHandlers := len(handlers)
 		handlerName := nameOfFunction(handlers.Last())
-		debugPrint("%-5s %-25s --> %s (%d handlers)\n", httpMethod, absolutePath, handlerName, nuHandlers)
+		debugPrint("%-6s %-25s --> %s (%d handlers)\n", httpMethod, absolutePath, handlerName, nuHandlers)
 	}
 }
 

--- a/debug_test.go
+++ b/debug_test.go
@@ -63,7 +63,7 @@ func TestDebugPrintRoutes(t *testing.T) {
 	defer teardown()
 
 	debugPrintRoute("GET", "/path/to/route/:param", HandlersChain{func(c *Context) {}, handlerNameTest})
-	assert.Equal(t, w.String(), "[GIN-debug] GET   /path/to/route/:param     --> github.com/gin-gonic/gin.handlerNameTest (2 handlers)\n")
+	assert.Equal(t, w.String(), "[GIN-debug] GET    /path/to/route/:param     --> github.com/gin-gonic/gin.handlerNameTest (2 handlers)\n")
 }
 
 func setup(w io.Writer) {


### PR DESCRIPTION
'DELETE' is 6 chars and breaks indent of the routes dump (only 5 chars were reserved for the HTTP method).