### PR TITLE
add import path to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ go:
   - 1.4.2
   - tip
 
+go_import_path: github.com/gin-gonic/gin
+
 script:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
I want to send it from the test with travis-ci before sending a pull request.
In the case of gin, it is an error to test the repository that was fork in travis-ci.
https://travis-ci.org/178inaba/gin/jobs/105072041
This is I think because there is assumed test the import path "github.com/gin-gonic/gin".
So, we added a setting to fix the import path of golang set of travis-ci.
When you add test of travis-ci was movement successfully.
https://travis-ci.org/178inaba/gin/jobs/105225833

PS Thank you for always maintains a gin.
