### PR TITLE
Fix typo on gin_test.go

### DIFF
--- a/gin_test.go
+++ b/gin_test.go
@@ -244,7 +244,7 @@ func TestListOfRoutes(t *testing.T) {
 func assertRoutePresent(t *testing.T, gotRoutes RoutesInfo, wantRoute RouteInfo) {
 	for _, gotRoute := range gotRoutes {
 		if gotRoute.Path == wantRoute.Path && gotRoute.Method == wantRoute.Method {
-			assert.Regexp(t, wantRoute.Path, gotRoute.Path)
+			assert.Regexp(t, wantRoute.Handler, gotRoute.Handler)
 			return
 		}
 	}


### PR DESCRIPTION
Fixes #550, change a duplicate assert on the Path of the route by an assert on Handler name associated with the route.