### PR TITLE
Added gin.LoggerDisk which logs to screen and a file

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"time"
+	"net"
 )
 
 var (
@@ -43,9 +44,68 @@ func ErrorLoggerT(typ ErrorType) HandlerFunc {
 func Logger() HandlerFunc {
 	return LoggerWithWriter(DefaultWriter)
 }
+func LoggerDisk(LogFile io.Writer) HandlerFunc {
+	return LoggerWithDisk(DefaultWriter,LogFile)
+}
 
 // Instance a Logger middleware with the specified writter buffer.
 // Example: os.Stdout, a file opened in write mode, a socket...
+func LoggerWithDisk(out io.Writer, accesslog io.Writer, notlogged ...string) HandlerFunc {
+	var skip map[string]struct{}
+
+	if length := len(notlogged); length > 0 {
+		skip = make(map[string]struct{}, length)
+
+		for _, path := range notlogged {
+			skip[path] = struct{}{}
+		}
+	}
+
+	return func(c *Context) {
+		// Start timer
+		start := time.Now()
+		path := c.Request.URL.Path
+
+		// Process request
+		c.Next()
+
+		// Log only when path is not being skipped
+		if _, ok := skip[path]; !ok {
+			// Stop timer
+			end := time.Now()
+			latency := end.Sub(start)
+
+			clientIP := c.ClientIP()
+			clientHost,_ := net.LookupAddr(clientIP)
+			method := c.Request.Method
+			statusCode := c.Writer.Status()
+			statusColor := colorForStatus(statusCode)
+			methodColor := colorForMethod(method)
+			comment := c.Errors.ByType(ErrorTypePrivate).String()
+
+			fmt.Fprintf(accesslog, "[GIN] %v | %3d | %13v | %s | %s | %-6s %s\n%s",
+				end.Format("2006/01/02 - 15:04:05"),
+				statusCode,
+				latency,
+				clientIP,
+				clientHost[0],
+				method,
+				path,
+				comment,
+			)
+			fmt.Fprintf(out, "[GIN] %v |%s %3d %s| %13v | %s | %s |%s  %s %-6s %s\n%s",
+				end.Format("2006/01/02 - 15:04:05"),
+				statusColor, statusCode, reset,
+				latency,
+				clientIP,
+				clientHost[0],
+				methodColor, reset, method,
+				path,
+				comment,
+			)
+		}
+	}
+}
 func LoggerWithWriter(out io.Writer, notlogged ...string) HandlerFunc {
 	var skip map[string]struct{}
 
@@ -72,17 +132,19 @@ func LoggerWithWriter(out io.Writer, notlogged ...string) HandlerFunc {
 			latency := end.Sub(start)
 
 			clientIP := c.ClientIP()
+			clientHost,_ := net.LookupAddr(clientIP)
 			method := c.Request.Method
 			statusCode := c.Writer.Status()
 			statusColor := colorForStatus(statusCode)
 			methodColor := colorForMethod(method)
 			comment := c.Errors.ByType(ErrorTypePrivate).String()
 
-			fmt.Fprintf(out, "[GIN] %v |%s %3d %s| %13v | %s |%s  %s %-7s %s\n%s",
+			fmt.Fprintf(out, "[GIN] %v |%s %3d %s| %13v | %s | %s |%s  %s %-6s %s\n%s",
 				end.Format("2006/01/02 - 15:04:05"),
 				statusColor, statusCode, reset,
 				latency,
 				clientIP,
+				clientHost[0],
 				methodColor, reset, method,
 				path,
 				comment,


### PR DESCRIPTION
Added a clone function of gin.Logger() called gin.LoggerDisk(LogFile io.Writer) which accepts an io.Writer parameter to write to. LoggerDisk() will write to os.Stdout like normal and also write to file. I also added a hostname lookup field which I think is useful. 

Example usage: 

```
var f io.Writer
var err error
logfilename := fmt.Sprint(APP_DIRECTORY, "/log/access.log")

if _, err = os.Stat(logfilename); os.IsExist(err) {
  f, err = os.Open(logfilename)
} else {
  f, err = os.Create(logfilename)
}

router.Use(gin.LoggerDisk(f))
```