### PR TITLE
Dont change log flags

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -10,10 +10,6 @@ import (
 	"log"
 )
 
-func init() {
-	log.SetFlags(0)
-}
-
 // IsDebugging returns true if the framework is running in debug mode.
 // Use SetMode(gin.Release) to switch to disable the debug mode.
 func IsDebugging() bool {


### PR DESCRIPTION
Gin changes the log package default flags. This removes that code.

The downside of this fix is that it will change log formatting for users who have not been explicitly resetting the log flags.
