### PR TITLE
Write header immediately in AbortWithStatus()

### DIFF
--- a/context.go
+++ b/context.go
@@ -115,6 +115,7 @@ func (c *Context) Abort() {
 // For example, a failed attempt to authentificate a request could use: context.AbortWithStatus(401).
 func (c *Context) AbortWithStatus(code int) {
 	c.Status(code)
+	c.Writer.WriteHeaderNow()
 	c.Abort()
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -545,7 +545,6 @@ func TestContextAbortWithStatus(t *testing.T) {
 	c, w, _ := CreateTestContext()
 	c.index = 4
 	c.AbortWithStatus(401)
-	c.Writer.WriteHeaderNow()
 
 	assert.Equal(t, c.index, abortIndex)
 	assert.Equal(t, c.Writer.Status(), 401)
@@ -596,7 +595,6 @@ func TestContextTypedError(t *testing.T) {
 func TestContextAbortWithError(t *testing.T) {
 	c, w, _ := CreateTestContext()
 	c.AbortWithError(401, errors.New("bad input")).SetMeta("some input")
-	c.Writer.WriteHeaderNow()
 
 	assert.Equal(t, w.Code, 401)
 	assert.Equal(t, c.index, abortIndex)

--- a/logger.go
+++ b/logger.go
@@ -28,12 +28,9 @@ func ErrorLogger() HandlerFunc {
 func ErrorLoggerT(typ ErrorType) HandlerFunc {
 	return func(c *Context) {
 		c.Next()
-		// avoid writting if we already wrote into the response body
-		if !c.Writer.Written() {
-			errors := c.Errors.ByType(typ)
-			if len(errors) > 0 {
-				c.JSON(-1, errors)
-			}
+		errors := c.Errors.ByType(typ)
+		if len(errors) > 0 {
+			c.JSON(-1, errors)
 		}
 	}
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -116,7 +116,7 @@ func TestErrorLogger(t *testing.T) {
 
 	w = performRequest(router, "GET", "/print")
 	assert.Equal(t, w.Code, 500)
-	assert.Equal(t, w.Body.String(), "hola!")
+	assert.Equal(t, w.Body.String(), "hola!{\"error\":\"this is an error\"}\n")
 }
 
 func TestSkippingPaths(t *testing.T) {

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -39,5 +39,5 @@ func TestPanicWithAbort(t *testing.T) {
 	// RUN
 	w := performRequest(router, "GET", "/recovery")
 	// TEST
-	assert.Equal(t, w.Code, 500) // NOT SURE
+	assert.Equal(t, w.Code, 400)
 }


### PR DESCRIPTION
Otherwise, caller needs to invoke WriteHeaderNow himself after
AbortWithStatus(), which is error-prone.

Also modified ErrorLoggerT() such that it always writes log to response
body. Otherwise calling AbortWithStatus() will fail to write body because
c.Writer.Written() is set true by WriteHeaderNow().

It addresses #585