### PR TITLE
Default writers must be io.Writers

### DIFF
--- a/mode.go
+++ b/mode.go
@@ -5,6 +5,7 @@
 package gin
 
 import (
+	"io"
 	"os"
 
 	"github.com/gin-gonic/gin/binding"
@@ -30,8 +31,8 @@ const (
 // To support coloring in Windows use:
 // 		import "github.com/mattn/go-colorable"
 // 		gin.DefaultWriter = colorable.NewColorableStdout()
-var DefaultWriter = os.Stdout
-var DefaultErrorWriter = os.Stderr
+var DefaultWriter io.Writer = os.Stdout
+var DefaultErrorWriter io.Writer = os.Stderr
 
 var ginMode = debugCode
 var modeName = DebugMode


### PR DESCRIPTION
Quote from docs
> DefaultWriter is the default io.Writer

But DefaultWriter has type `*os.File`, so i can't run code like this:
```
package main

import (
    "github.com/gin-gonic/gin"
    "io/ioutil"
)

func main() {
    gin.DefaultWriter = ioutil.Discard
}
```

```
$ go run main.go 
# command-line-arguments
./main.go:9: cannot use ioutil.Discard (type io.Writer) as type *os.File in assignment: need type assertion
```

It broke in [this](https://github.com/gin-gonic/gin/commit/9e930b9bdd5a29bac38fb491ffac4e7ea84b825d#diff-fd98eaa389d204eaf86f6913742c7551L34) commit