### PR TITLE
#567, #583 Added a link in a summary about multitemplate render

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,11 @@ func main() {
 ```
 
 
+#### Multitemplate
+
+Gin allow by default use only one html.Template. Check [a multitemplate render](https://github.com/gin-gonic/contrib/tree/master/renders/multitemplate) for using features like go 1.6 "block" template.
+
+
 #### Redirects
 
 Issuing a HTTP redirect is easy:


### PR DESCRIPTION
I didn't find links on other contribs in this summary. But I am sure it has to be here. 
**go1.6** "block" template feature was added in standard library. But gin don't allow by default several _html.Templates_. It misunderstood people who want to check new features.
