### PR TITLE
fix default log format

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -80,7 +80,7 @@ func LoggerWithWriter(out io.Writer, notlogged ...string) HandlerFunc {
 				statusColor, statusCode, reset,
 				latency,
 				clientIP,
-				methodColor, reset, method,
+				methodColor, method, reset,
 				path,
 				comment,
 			)


### PR DESCRIPTION
`reset` field should be after `method` in LoggerWithWriter function.
