### PR TITLE
Fixed Content-Type problem when `BindWith()` fails. Resolves #633.

### DIFF
--- a/context.go
+++ b/context.go
@@ -297,7 +297,7 @@ func (c *Context) BindJSON(obj interface{}) error {
 // See the binding package.
 func (c *Context) BindWith(obj interface{}, b binding.Binding) error {
 	if err := b.Bind(c.Request, obj); err != nil {
-		c.AbortWithError(400, err).SetType(ErrorTypeBind)
+		c.Error(err).SetType(ErrorTypeBind)
 		return err
 	}
 	return nil


### PR DESCRIPTION
Single-line fix! See #633.
