### PR TITLE
Remove an obsolete func in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ func main() {
 
 ####HTML rendering
 
-Using LoadHTMLTemplates()
+Using LoadHTMLGlob() or LoadHTMLFiles()
 
 ```go
 func main() {


### PR DESCRIPTION
Hi!

This pull request removes the obsolete func (`LoadHTMLTemplates`) in README.
