### PR TITLE
"/" (slash) as REST param does not work

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/gin.go
+++ b/gin.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gin-gonic/gin/render"
 )
 
-// Framework's version
+// Version is Framework's version
 const Version = "v1.0rc2"
 
 var default404Body = []byte("404 page not found")
@@ -78,6 +78,9 @@ type (
 		// handler.
 		HandleMethodNotAllowed bool
 		ForwardedByClientIP    bool
+		// If enabled, the path using RawPath in net.url.URL.RawPath
+		// RawPath dose not decode path.
+		UseRawPath	       bool
 	}
 )
 
@@ -102,6 +105,7 @@ func New() *Engine {
 		HandleMethodNotAllowed: false,
 		ForwardedByClientIP:    true,
 		trees:                  make(methodTrees, 0, 9),
+		UseRawPath:		false,
 	}
 	engine.RouterGroup.engine = engine
 	engine.pool.New = func() interface{} {
@@ -147,19 +151,19 @@ func (engine *Engine) SetHTMLTemplate(templ *template.Template) {
 	engine.HTMLRender = render.HTMLProduction{Template: templ}
 }
 
-// Adds handlers for NoRoute. It return a 404 code by default.
+// NoRoute adds handlers for NoRoute. It return a 404 code by default.
 func (engine *Engine) NoRoute(handlers ...HandlerFunc) {
 	engine.noRoute = handlers
 	engine.rebuild404Handlers()
 }
 
-// Sets the handlers called when... TODO
+// NoMethod sets the handlers called when... TODO
 func (engine *Engine) NoMethod(handlers ...HandlerFunc) {
 	engine.noMethod = handlers
 	engine.rebuild405Handlers()
 }
 
-// Attachs a global middleware to the router. ie. the middleware attached though Use() will be
+// Use attachs a global middleware to the router. ie. the middleware attached though Use() will be
 // included in the handlers chain for every single request. Even 404, 405, static files...
 // For example, this is the right place for a logger or error management middleware.
 func (engine *Engine) Use(middleware ...HandlerFunc) IRoutes {
@@ -270,6 +274,10 @@ func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (engine *Engine) handleHTTPRequest(context *Context) {
 	httpMethod := context.Request.Method
 	path := context.Request.URL.Path
+	if (engine.UseRawPath && len(context.Request.URL.RawPath) > 0 ) {
+		path = context.Request.URL.RawPath
+	}
+
 
 	// Find root of the tree for the given HTTP method
 	t := engine.trees


### PR DESCRIPTION
If we pass parameter to the REST function containing "/" (slash), then the param is not accepted, and results in an error. This seems to indicate that escaping special characters like "/" (slash) was not built in the gin framework. 

```
eg:- if we built an api like "/api/apps/{id}", then for a value of {id} as "/hello/world", it does not work. 
```

I added a Boolean ```UseRawPath``` to the ```struct Engine``` that if set to true, extracts the RawPath from the URL. The ```handleHTTPRequest``` is modified to include the check if ```UseRawPath``` is toggled or not.


