### PR TITLE
"/" (slash) as REST param does not work

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -78,6 +78,7 @@ type (
 		// handler.
 		HandleMethodNotAllowed bool
 		ForwardedByClientIP    bool
+		UseRawPath	       bool
 	}
 )
 
@@ -102,6 +103,7 @@ func New() *Engine {
 		HandleMethodNotAllowed: false,
 		ForwardedByClientIP:    true,
 		trees:                  make(methodTrees, 0, 9),
+		UseRawPath:		false,
 	}
 	engine.RouterGroup.engine = engine
 	engine.pool.New = func() interface{} {
@@ -270,6 +272,9 @@ func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (engine *Engine) handleHTTPRequest(context *Context) {
 	httpMethod := context.Request.Method
 	path := context.Request.URL.Path
+	if (engine.UseRawPath && len(context.Request.URL.RawPath) > 0 ) {
+		path = context.Request.URL.RawPath
+	}
 
 	// Find root of the tree for the given HTTP method
 	t := engine.trees


### PR DESCRIPTION
If we pass parameter to the REST function containing "/" (slash), then the param is not accepted, and results in an error. This seems to indicate that escaping special characters like "/" (slash) was not built in the gin framework. 

```
eg:- if we built an api like "/api/apps/{id}", then for a value of {id} as "/hello/world", it does not work. 
```

I added a Boolean `UseRawPath` to the `struct Engine` that if set to true, extracts the RawPath from the URL. The `handleHTTPRequest` is modified to include the check if `UseRawPath` is toggled or not.
