### PR TITLE
Add intellij idea gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Godeps/*
 !Godeps/Godeps.json
 coverage.out
 count.out
+.idea/


### PR DESCRIPTION
Let programmers who are using Intellij IDEA as golang IDE do not commit the IDEA's configuration folder.