### PR TITLE
Use X-Forwarded-For before X-Real-Ip

### DIFF
--- a/context.go
+++ b/context.go
@@ -305,17 +305,18 @@ func (c *Context) BindWith(obj interface{}, b binding.Binding) error {
 
 // ClientIP implements a best effort algorithm to return the real client IP, it parses
 // X-Real-IP and X-Forwarded-For in order to work properly with reverse-proxies such us: nginx or haproxy.
+// Use X-Forwarded-For before X-Real-Ip as nginx uses X-Real-Ip with the proxy's IP.
 func (c *Context) ClientIP() string {
 	if c.engine.ForwardedByClientIP {
-		clientIP := strings.TrimSpace(c.requestHeader("X-Real-Ip"))
-		if len(clientIP) > 0 {
-			return clientIP
-		}
-		clientIP = c.requestHeader("X-Forwarded-For")
+		clientIP := c.requestHeader("X-Forwarded-For")
 		if index := strings.IndexByte(clientIP, ','); index >= 0 {
 			clientIP = clientIP[0:index]
 		}
 		clientIP = strings.TrimSpace(clientIP)
+		if len(clientIP) > 0 {
+			return clientIP
+		}
+		clientIP = strings.TrimSpace(c.requestHeader("X-Real-Ip"))
 		if len(clientIP) > 0 {
 			return clientIP
 		}


### PR DESCRIPTION
Nginx uses X-Real-Ip with its IP instead of the client's IP. Therefore, we should use X-Forwarded-For _before_ X-Real-Ip

You can try setting up and AWS ELB instance with the following code and see for yourself.

``` go
package main

import (
    "fmt"
    "log"
    "net/http"
    "strings"

    "github.com/gin-gonic/gin"
)

func main() {
    router := gin.Default()
    router.GET("/", func(c *gin.Context) {
        log.Printf("%s", strings.Split(c.Request.Header.Get("X-Forwarded-For"), ",")[0])
        log.Printf("%s", c.Request.Header.Get("X-Real-Ip"))
        log.Printf("%s", c.ClientIP())
        c.JSON(http.StatusOK, gin.H{})
    })

    router.Run(fmt.Sprintf("0.0.0.0:%d", 5000))
}
```
