### PR TITLE
Added HandleContext to re-enter soft-rewritten Requests.

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -267,6 +267,15 @@ func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	engine.pool.Put(c)
 }
 
+// Re-enter a context that has been rewritten.
+// This can be done by setting c.Request.Path to your new target.
+// Disclaimer: You can loop yourself to death with this, use wisely.
+func (engine *Engine) HandleContext(c *Context) {
+	c.reset()
+	engine.handleHTTPRequest(c)
+	engine.pool.Put(c)
+}
+
 func (engine *Engine) handleHTTPRequest(context *Context) {
 	httpMethod := context.Request.Method
 	path := context.Request.URL.Path


### PR DESCRIPTION
Dear gin committers, thanks for your great and awesome work. Unfortunately i've hit a corner case to which i didn't find a sufficient solution and would like to share my fix with the community.

We are rewriting a large pile of fu^Wold PHP Code from a project i just was put upon. The problem being that this is highly SEO-crap-stuff that the URLs that have been used in the past, need to work exactly like they are, because they have been pimped, yadda yadda blah.

Anyway, i could not convince them that using a better URL Scheme with 3xx would be probably better. So technically the problem is that they have URLs with multiple parameters within one /-segment. Imagine /:categoryName-at-:city . Now since i have all the categories and cities in the database, i tried adding them all, but that didnt work out to well as it took a few hours to load all categories for all the cities. Now i hot-fixed it to be /:category/at/:city and rewrite my Request in the NotFoundHandler and stick it back into gin with .HandleContext.

Hope this either gets merged or helps someone else.
