### PR TITLE
Remove net/http optional import from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,6 @@ BenchmarkZeus_GithubAll 		| 2000 		| 944234 	| 300688 	| 2648
     import "gopkg.in/gin-gonic/gin.v1"
     ```
 
-3. (Optional) Import `net/http`. This is required for example if using constants such as `http.StatusOK`.
-
-    ```go
-    import "net/http"
-    ```
-
 ## API Examples
 
 #### Using GET, POST, PUT, PATCH, DELETE and OPTIONS


### PR DESCRIPTION
Just throwing this out there..

But I feel like this step might be causing more confusion that it is helping. In this approach I think it's better to **under** prescribe than to **over** prescribe.

If the user is getting errors about a missing library, that is expected behavior, if a user is getting errors about an unused library, that is noise.

Just my opinion.. So I figured I would throw the PR out there.. 
