### PR TITLE
Made it possible to use custom functions in HTML templates via template.FuncMap

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -45,6 +45,7 @@ type (
 	Engine struct {
 		RouterGroup
 		HTMLRender  render.HTMLRender
+		HTMLFuncs   *template.FuncMap
 		allNoRoute  HandlersChain
 		allNoMethod HandlersChain
 		noRoute     HandlersChain
@@ -122,21 +123,27 @@ func (engine *Engine) allocateContext() *Context {
 }
 
 func (engine *Engine) LoadHTMLGlob(pattern string) {
+	if engine.HTMLFuncs == nil {
+		engine.HTMLFuncs = &template.FuncMap{}
+	}
+
 	if IsDebugging() {
-		debugPrintLoadTemplate(template.Must(template.ParseGlob(pattern)))
-		engine.HTMLRender = render.HTMLDebug{Glob: pattern}
+		debugPrintLoadTemplate(template.Must(template.New("main").Funcs(*engine.HTMLFuncs).ParseGlob(pattern)))
+		engine.HTMLRender = render.HTMLDebug{Glob: pattern, Fmap: engine.HTMLFuncs}
 	} else {
-		templ := template.Must(template.ParseGlob(pattern))
-		engine.SetHTMLTemplate(templ)
+		engine.SetHTMLTemplate(template.Must(template.New("main").Funcs(*engine.HTMLFuncs).ParseGlob(pattern)))
 	}
 }
 
 func (engine *Engine) LoadHTMLFiles(files ...string) {
+	if engine.HTMLFuncs == nil {
+		engine.HTMLFuncs = &template.FuncMap{}
+	}
+
 	if IsDebugging() {
-		engine.HTMLRender = render.HTMLDebug{Files: files}
+		engine.HTMLRender = render.HTMLDebug{Files: files, Fmap: engine.HTMLFuncs}
 	} else {
-		templ := template.Must(template.ParseFiles(files...))
-		engine.SetHTMLTemplate(templ)
+		engine.SetHTMLTemplate(template.Must(template.New("main").Funcs(*engine.HTMLFuncs).ParseFiles(files...)))
 	}
 }
 

--- a/render/html.go
+++ b/render/html.go
@@ -16,11 +16,13 @@ type (
 
 	HTMLProduction struct {
 		Template *template.Template
+		Fmap     *template.FuncMap
 	}
 
 	HTMLDebug struct {
 		Files []string
 		Glob  string
+		Fmap  *template.FuncMap
 	}
 
 	HTML struct {
@@ -47,13 +49,15 @@ func (r HTMLDebug) Instance(name string, data interface{}) Render {
 		Data:     data,
 	}
 }
+
 func (r HTMLDebug) loadTemplate() *template.Template {
 	if len(r.Files) > 0 {
-		return template.Must(template.ParseFiles(r.Files...))
+		return template.Must(template.New("main").Funcs(*r.Fmap).ParseFiles(r.Files...))
 	}
 	if len(r.Glob) > 0 {
-		return template.Must(template.ParseGlob(r.Glob))
+		return template.Must(template.New("main").Funcs(*r.Fmap).ParseGlob(r.Glob))
 	}
+
 	panic("the HTML debug render was created without files or glob pattern")
 }
 


### PR DESCRIPTION
Hi there,

I'm using gin for an international website where HTML templates need to be localized. Go's html/template can do this via custom functions that are to be injected before parsing or loading the template files.

Ideally I'd have patched this feature into HTMLRender but the fact that its interface is used in many other renderers prohibited it, so you can now set the custom functions in Engine and the HTML renderer picks them up when loading the templates.

Cheers,
Tobias