### PR TITLE
Move golang.org/x/net/context.Context interface implementation check to tests

### DIFF
--- a/context.go
+++ b/context.go
@@ -17,7 +17,6 @@ import (
 	"github.com/gin-gonic/gin/binding"
 	"github.com/gin-gonic/gin/render"
 	"github.com/manucorporat/sse"
-	"golang.org/x/net/context"
 )
 
 // Content-Type MIME of the most common data formats
@@ -49,8 +48,6 @@ type Context struct {
 	Errors   errorMsgs
 	Accepted []string
 }
-
-var _ context.Context = &Context{}
 
 /************************************/
 /********** CONTEXT CREATION ********/

--- a/context_test.go
+++ b/context_test.go
@@ -17,7 +17,10 @@ import (
 
 	"github.com/manucorporat/sse"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
 )
+
+var _ context.Context = &Context{}
 
 // Unit tests TODO
 // func (c *Context) File(filepath string) {


### PR DESCRIPTION
The only reason to import "golang.org/x/net/context" package is to check that `*gin.Context` implements `context.Context` interface. But this implies fetching whole "golang.org/x/net" package tree using `go get`. So moving this check to `context_test.go` is reasonable.
This also resolves issues #469 and #684.
