### PR TITLE
Group returns IRouter

### DIFF
--- a/ginS/gins.go
+++ b/ginS/gins.go
@@ -46,7 +46,7 @@ func NoMethod(handlers ...HandlerFunc) {
 
 // Group creates a new router group. You should add all the routes that have common middlwares or the same path prefix.
 // For example, all the routes that use a common middlware for authorization could be grouped.
-func Group(relativePath string, handlers ...HandlerFunc) *RouterGroup {
+func Group(relativePath string, handlers ...HandlerFunc) IRouter {
 	return engine().Group(relativePath, handlers...)
 }
 

--- a/routergroup.go
+++ b/routergroup.go
@@ -14,7 +14,7 @@ import (
 type (
 	IRouter interface {
 		IRoutes
-		Group(string, ...HandlerFunc) *RouterGroup
+		Group(string, ...HandlerFunc) IRouter
 	}
 
 	IRoutes interface {
@@ -55,7 +55,7 @@ func (group *RouterGroup) Use(middleware ...HandlerFunc) IRoutes {
 
 // Group creates a new router group. You should add all the routes that have common middlwares or the same path prefix.
 // For example, all the routes that use a common middlware for authorization could be grouped.
-func (group *RouterGroup) Group(relativePath string, handlers ...HandlerFunc) *RouterGroup {
+func (group *RouterGroup) Group(relativePath string, handlers ...HandlerFunc) IRouter {
 	return &RouterGroup{
 		Handlers: group.combineHandlers(handlers),
 		basePath: group.calculateAbsolutePath(relativePath),

--- a/routergroup_test.go
+++ b/routergroup_test.go
@@ -16,14 +16,14 @@ func init() {
 
 func TestRouterGroupBasic(t *testing.T) {
 	router := New()
-	group := router.Group("/hola", func(c *Context) {})
+	group := router.Group("/hola", func(c *Context) {}).(*RouterGroup)
 	group.Use(func(c *Context) {})
 
 	assert.Len(t, group.Handlers, 2)
 	assert.Equal(t, group.BasePath(), "/hola")
 	assert.Equal(t, group.engine, router)
 
-	group2 := group.Group("manu")
+	group2 := group.Group("manu").(*RouterGroup)
 	group2.Use(func(c *Context) {}, func(c *Context) {})
 
 	assert.Len(t, group2.Handlers, 4)
@@ -43,10 +43,10 @@ func TestRouterGroupBasicHandle(t *testing.T) {
 
 func performRequestInGroup(t *testing.T, method string) {
 	router := New()
-	v1 := router.Group("v1", func(c *Context) {})
+	v1 := router.Group("v1", func(c *Context) {}).(*RouterGroup)
 	assert.Equal(t, v1.BasePath(), "/v1")
 
-	login := v1.Group("/login/", func(c *Context) {}, func(c *Context) {})
+	login := v1.Group("/login/", func(c *Context) {}, func(c *Context) {}).(*RouterGroup)
 	assert.Equal(t, login.BasePath(), "/v1/login/")
 
 	handler := func(c *Context) {


### PR DESCRIPTION
Hi

This PR addresses https://github.com/gin-gonic/gin/issues/421

This change increases extensibility and flexibility.  This change would facilitate mocking of `IRouter`.

Thanks for the consideration.  Cheers.
