### PR TITLE
Logger: skip ANSI color commands if output is not a tty

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -7,7 +7,10 @@ package gin
 import (
 	"fmt"
 	"io"
+	"os"
 	"time"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 var (
@@ -44,6 +47,11 @@ func Logger() HandlerFunc {
 // LoggerWithWriter instance a Logger middleware with the specified writter buffer.
 // Example: os.Stdout, a file opened in write mode, a socket...
 func LoggerWithWriter(out io.Writer, notlogged ...string) HandlerFunc {
+	isTerm := true
+	if outFile, ok := out.(*os.File); ok {
+		isTerm = terminal.IsTerminal(int(outFile.Fd()))
+	}
+
 	var skip map[string]struct{}
 
 	if length := len(notlogged); length > 0 {
@@ -71,8 +79,11 @@ func LoggerWithWriter(out io.Writer, notlogged ...string) HandlerFunc {
 			clientIP := c.ClientIP()
 			method := c.Request.Method
 			statusCode := c.Writer.Status()
-			statusColor := colorForStatus(statusCode)
-			methodColor := colorForMethod(method)
+			var statusColor, methodColor string
+			if isTerm {
+				statusColor = colorForStatus(statusCode)
+				methodColor = colorForMethod(method)
+			}
 			comment := c.Errors.ByType(ErrorTypePrivate).String()
 
 			fmt.Fprintf(out, "[GIN] %v |%s %3d %s| %13v | %s |%s  %s %-7s %s\n%s",


### PR DESCRIPTION
Here's a little improvement to the default logger so that the output isn't colorised if we're not outputting to a terminal. So, if we run with `./server | tee my.log` then instead of my log file looking like this:
```
[GIN] 2016/11/17 - 16:28:44 |^[[97;42m 200 ^[[0m|   24.459651ms | ::1 |^[[97;44m  ^[[0m GET     /
[GIN] 2016/11/17 - 16:28:44 |^[[97;42m 200 ^[[0m|  1.766299995s | ::1 |^[[97;44m  ^[[0m GET     /ws
[GIN] 2016/11/17 - 16:28:44 |^[[97;42m 200 ^[[0m|   11.265361ms | ::1 |^[[97;44m  ^[[0m GET     /static/favicon.gif
```

It looks like this:
```
[GIN] 2016/11/17 - 16:28:44 | 200 |   24.459651ms | ::1 |   GET     /
[GIN] 2016/11/17 - 16:28:44 | 200 |  1.766299995s | ::1 |   GET     /ws
[GIN] 2016/11/17 - 16:28:44 | 200 |   11.265361ms | ::1 |   GET     /static/favicon.gif
```

The same applies to any pipe. You can see this in action by just running `./server | cat`

This does add an extra dependency on `golang.org/x/crypto/ssh/terminal` but it's pretty widely used and stable. I did consider copying over the `IsTerminal` function, but there's a bit of tricky syscall magic there and I'd rather they take care of it.

The other change I could think you might want to do, is assume that it's not a terminal if it isn't a valid `*os.File`, so change line 50 to:
```go
isTerm := false
```
That might be nice for people funnelling their logs off to other random `io.Writer`s that don't want the ANSI code spam. But I've just kinda left it as it is for now.

Let me know what you think! Thanks 😄