### PR TITLE
Support disable console color

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ BenchmarkZeus_GithubAll 		| 2000 		| 944234 	| 300688 	| 2648
 
 ```go
 func main() {
+	// Disable Console Color
+	// gin.DisableConsoleColor()
+
 	// Creates a gin router with default middleware:
 	// logger and recovery (crash-free) middleware
 	router := gin.Default()

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -7,6 +7,8 @@ import (
 var DB = make(map[string]string)
 
 func main() {
+	// Disable Console Color
+	// gin.DisableConsoleColor()
 	r := gin.Default()
 
 	// Ping test

--- a/logger.go
+++ b/logger.go
@@ -14,15 +14,20 @@ import (
 )
 
 var (
-	green   = string([]byte{27, 91, 57, 55, 59, 52, 50, 109})
-	white   = string([]byte{27, 91, 57, 48, 59, 52, 55, 109})
-	yellow  = string([]byte{27, 91, 57, 55, 59, 52, 51, 109})
-	red     = string([]byte{27, 91, 57, 55, 59, 52, 49, 109})
-	blue    = string([]byte{27, 91, 57, 55, 59, 52, 52, 109})
-	magenta = string([]byte{27, 91, 57, 55, 59, 52, 53, 109})
-	cyan    = string([]byte{27, 91, 57, 55, 59, 52, 54, 109})
-	reset   = string([]byte{27, 91, 48, 109})
+	green        = string([]byte{27, 91, 57, 55, 59, 52, 50, 109})
+	white        = string([]byte{27, 91, 57, 48, 59, 52, 55, 109})
+	yellow       = string([]byte{27, 91, 57, 55, 59, 52, 51, 109})
+	red          = string([]byte{27, 91, 57, 55, 59, 52, 49, 109})
+	blue         = string([]byte{27, 91, 57, 55, 59, 52, 52, 109})
+	magenta      = string([]byte{27, 91, 57, 55, 59, 52, 53, 109})
+	cyan         = string([]byte{27, 91, 57, 55, 59, 52, 54, 109})
+	reset        = string([]byte{27, 91, 48, 109})
+	disableColor = false
 )
+
+func DisableConsoleColor() {
+	disableColor = true
+}
 
 func ErrorLogger() HandlerFunc {
 	return ErrorLoggerT(ErrorTypeAny)
@@ -49,7 +54,7 @@ func Logger() HandlerFunc {
 func LoggerWithWriter(out io.Writer, notlogged ...string) HandlerFunc {
 	isTerm := true
 
-	if w, ok := out.(*os.File); !ok || !isatty.IsTerminal(w.Fd()) {
+	if w, ok := out.(*os.File); !ok || !isatty.IsTerminal(w.Fd()) || disableColor {
 		isTerm = false
 	}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -132,3 +132,10 @@ func TestSkippingPaths(t *testing.T) {
 	performRequest(router, "GET", "/skipped")
 	assert.Contains(t, buffer.String(), "")
 }
+
+func TestDisableConsoleColor(t *testing.T) {
+	New()
+	assert.False(t, disableColor)
+	DisableConsoleColor()
+	assert.True(t, disableColor)
+}


### PR DESCRIPTION
Fixed #769 

```go
package main

import (
	"github.com/gin-gonic/gin"
)

func main() {
	// Disable Console Color
	gin.DisableConsoleColor()
	r := gin.Default()

	// Ping test
	r.GET("/ping", func(c *gin.Context) {
		c.String(200, "pong")
	})
}
```