### PR TITLE
Support upload single or multiple files.

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -53,6 +53,37 @@ func must(err error) {
 	}
 }
 
+func TestContextFormFile(t *testing.T) {
+	buf := new(bytes.Buffer)
+	mw := multipart.NewWriter(buf)
+	w, err := mw.CreateFormFile("file", "test")
+	if assert.NoError(t, err) {
+		w.Write([]byte("test"))
+	}
+	mw.Close()
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest("POST", "/", buf)
+	c.Request.Header.Set("Content-Type", mw.FormDataContentType())
+	f, err := c.FormFile("file")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "test", f.Filename)
+	}
+}
+
+func TestContextMultipartForm(t *testing.T) {
+	buf := new(bytes.Buffer)
+	mw := multipart.NewWriter(buf)
+	mw.WriteField("foo", "bar")
+	mw.Close()
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest("POST", "/", buf)
+	c.Request.Header.Set("Content-Type", mw.FormDataContentType())
+	f, err := c.MultipartForm()
+	if assert.NoError(t, err) {
+		assert.NotNil(t, f)
+	}
+}
+
 func TestContextReset(t *testing.T) {
 	router := New()
 	c := router.allocateContext()


### PR DESCRIPTION
Fixed #774 

## upload single file:

```go
package main

import (
	"github.com/gin-gonic/gin"
	"log"
	"net/http"
)

func main() {
	router := gin.Default()
	router.POST("/upload", func(c *gin.Context) {
		// single file
		file, _ := c.FormFile("file")
		log.Println(file.Filename)

		c.String(http.StatusOK, "Uploaded...")
	})
	router.Run(":8080")
}
```

curl command:

```sh
curl -X POST http://localhost:8080/upload -F "file=@/Users/mtk10671/z.sh" -H "Content-Type: multipart/form-data"
```

## upload multiple file:

```go
package main

import (
	"github.com/gin-gonic/gin"
	"log"
	"net/http"
)

func main() {
	router := gin.Default()
	router.POST("/upload", func(c *gin.Context) {
		// Multipart form
		form, _ := c.MultipartForm()
		files := form.File["upload[]"]

		for _, file := range files {
			log.Println(file.Filename)
		}
		c.String(http.StatusOK, "Uploaded...")
	})
	router.Run(":8080")
}
```

curl command:

```sh
curl -X POST http://localhost:8080/upload -F "upload[]=@/Users/mtk10671/z.sh" -F "upload[]=@/Users/mtk10671/z.sh" -H "Content-Type: multipart/form-data"
```

cc @selvam347 @tboerger @javierprovecho @andreynering

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>