### PR TITLE
RawPath and Unescape URL parameters

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -5,6 +5,7 @@
 package gin
 
 import (
+	"net/url"
 	"strings"
 	"unicode"
 )
@@ -363,7 +364,7 @@ func (n *node) insertChild(numParams uint8, path string, fullPath string, handle
 // If no handle can be found, a TSR (trailing slash redirect) recommendation is
 // made if a handle exists with an extra (without the) trailing slash for the
 // given path.
-func (n *node) getValue(path string, po Params) (handlers HandlersChain, p Params, tsr bool) {
+func (n *node) getValue(path string, po Params, unescapeValues bool) (handlers HandlersChain, p Params, tsr bool) {
 	p = po
 walk: // Outer loop for walking the tree
 	for {
@@ -407,6 +408,12 @@ walk: // Outer loop for walking the tree
 					p = p[:i+1] // expand slice within preallocated capacity
 					p[i].Key = n.path[1:]
 					p[i].Value = path[:end]
+					// as it is a path parameter, unescape value
+					if unescapeValues {
+						if val, err := url.QueryUnescape(path[:end]); err == nil {
+							p[i].Value = val
+						}
+					}
 
 					// we need to go deeper!
 					if end < len(path) {


### PR DESCRIPTION
This patch aims to fix issue #722 and PR #640 .

I'm currently developing an API with URL parameters with, for example : 
GET /user/:username

By assuming that username can contains special encoded parameters : 
- Jon%20Doe
- Slash%2FMe

The first one is not decoded by using c.Params("username").
The second one, using '/' is currently not working at all.

Using the '*' character does not fix the issue as I've got sub routes : 
GET /user/:username/infos

Feel free to comment. It aims to be a not-breaking change.