### PR TITLE
Fix #198

### DIFF
--- a/context.go
+++ b/context.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/gin-gonic/gin/binding"
 	"github.com/gin-gonic/gin/render"
-	"github.com/manucorporat/sse"
+	"gopkg.in/gin-contrib/sse.v0"
 )
 
 // Content-Type MIME of the most common data formats
@@ -404,6 +404,19 @@ func (c *Context) requestHeader(key string) string {
 /******** RESPONSE RENDERING ********/
 /************************************/
 
+// bodyAllowedForStatus is a copy of http.bodyAllowedForStatus non-exported function
+func bodyAllowedForStatus(status int) bool {
+	switch {
+	case status >= 100 && status <= 199:
+		return false
+	case status == 204:
+		return false
+	case status == 304:
+		return false
+	}
+	return true
+}
+
 func (c *Context) Status(code int) {
 	c.writermem.WriteHeader(code)
 }
@@ -453,6 +466,13 @@ func (c *Context) Cookie(name string) (string, error) {
 
 func (c *Context) Render(code int, r render.Render) {
 	c.Status(code)
+
+	if !bodyAllowedForStatus(code) {
+		r.WriteContentType(c.Writer)
+		c.Writer.WriteHeaderNow()
+		return
+	}
+
 	if err := r.Render(c.Writer); err != nil {
 		panic(err)
 	}
@@ -477,10 +497,7 @@ func (c *Context) IndentedJSON(code int, obj interface{}) {
 // JSON serializes the given struct as JSON into the response body.
 // It also sets the Content-Type as "application/json".
 func (c *Context) JSON(code int, obj interface{}) {
-	c.Status(code)
-	if err := render.WriteJSON(c.Writer, obj); err != nil {
-		panic(err)
-	}
+	c.Render(code, render.JSON{Data: obj})
 }
 
 // XML serializes the given struct as XML into the response body.
@@ -496,8 +513,7 @@ func (c *Context) YAML(code int, obj interface{}) {
 
 // String writes the given string into the response body.
 func (c *Context) String(code int, format string, values ...interface{}) {
-	c.Status(code)
-	render.WriteString(c.Writer, format, values)
+	c.Render(code, render.String{Format: format, Data: values})
 }
 
 // Redirect returns a HTTP redirect to the specific location.

--- a/context_test.go
+++ b/context_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/manucorporat/sse"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
+	"gopkg.in/gin-contrib/sse.v0"
 )
 
 var _ context.Context = &Context{}
@@ -394,6 +394,18 @@ func TestContextRenderJSON(t *testing.T) {
 	assert.Equal(t, "application/json; charset=utf-8", w.HeaderMap.Get("Content-Type"))
 }
 
+// Tests that no JSON is rendered if code is 204
+func TestContextRenderNoContentJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.JSON(204, H{"foo": "bar"})
+
+	assert.Equal(t, 204, w.Code)
+	assert.Equal(t, "", w.Body.String())
+	assert.Equal(t, "application/json; charset=utf-8", w.HeaderMap.Get("Content-Type"))
+}
+
 // Tests that the response is serialized as JSON
 // we change the content-type before
 func TestContextRenderAPIJSON(t *testing.T) {
@@ -408,6 +420,19 @@ func TestContextRenderAPIJSON(t *testing.T) {
 	assert.Equal(t, "application/vnd.api+json", w.HeaderMap.Get("Content-Type"))
 }
 
+// Tests that no Custom JSON is rendered if code is 204
+func TestContextRenderNoContentAPIJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Header("Content-Type", "application/vnd.api+json")
+	c.JSON(204, H{"foo": "bar"})
+
+	assert.Equal(t, 204, w.Code)
+	assert.Equal(t, "", w.Body.String())
+	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/vnd.api+json")
+}
+
 // Tests that the response is serialized as JSON
 // and Content-Type is set to application/json
 func TestContextRenderIndentedJSON(t *testing.T) {
@@ -418,6 +443,18 @@ func TestContextRenderIndentedJSON(t *testing.T) {
 
 	assert.Equal(t, w.Code, 201)
 	assert.Equal(t, w.Body.String(), "{\n    \"bar\": \"foo\",\n    \"foo\": \"bar\",\n    \"nested\": {\n        \"foo\": \"bar\"\n    }\n}")
+	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/json; charset=utf-8")
+}
+
+// Tests that no Custom JSON is rendered if code is 204
+func TestContextRenderNoContentIndentedJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.IndentedJSON(204, H{"foo": "bar", "bar": "foo", "nested": H{"foo": "bar"}})
+
+	assert.Equal(t, 204, w.Code)
+	assert.Equal(t, "", w.Body.String())
 	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/json; charset=utf-8")
 }
 
@@ -436,6 +473,20 @@ func TestContextRenderHTML(t *testing.T) {
 	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "text/html; charset=utf-8")
 }
 
+// Tests that no HTML is rendered if code is 204
+func TestContextRenderNoContentHTML(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, router := CreateTestContext(w)
+	templ := template.Must(template.New("t").Parse(`Hello {{.name}}`))
+	router.SetHTMLTemplate(templ)
+
+	c.HTML(204, "t", H{"name": "alexandernyquist"})
+
+	assert.Equal(t, 204, w.Code)
+	assert.Equal(t, "", w.Body.String())
+	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "text/html; charset=utf-8")
+}
+
 // TestContextXML tests that the response is serialized as XML
 // and Content-Type is set to application/xml
 func TestContextRenderXML(t *testing.T) {
@@ -449,6 +500,18 @@ func TestContextRenderXML(t *testing.T) {
 	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/xml; charset=utf-8")
 }
 
+// Tests that no XML is rendered if code is 204
+func TestContextRenderNoContentXML(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.XML(204, H{"foo": "bar"})
+
+	assert.Equal(t, 204, w.Code)
+	assert.Equal(t, "", w.Body.String())
+	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/xml; charset=utf-8")
+}
+
 // TestContextString tests that the response is returned
 // with Content-Type set to text/plain
 func TestContextRenderString(t *testing.T) {
@@ -459,6 +522,18 @@ func TestContextRenderString(t *testing.T) {
 
 	assert.Equal(t, w.Code, 201)
 	assert.Equal(t, w.Body.String(), "test string 2")
+	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "text/plain; charset=utf-8")
+}
+
+// Tests that no String is rendered if code is 204
+func TestContextRenderNoContentString(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.String(204, "test %s %d", "string", 2)
+
+	assert.Equal(t, 204, w.Code)
+	assert.Equal(t, "", w.Body.String())
 	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "text/plain; charset=utf-8")
 }
 
@@ -476,6 +551,19 @@ func TestContextRenderHTMLString(t *testing.T) {
 	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "text/html; charset=utf-8")
 }
 
+// Tests that no HTML String is rendered if code is 204
+func TestContextRenderNoContentHTMLString(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Header("Content-Type", "text/html; charset=utf-8")
+	c.String(204, "<html>%s %d</html>", "string", 3)
+
+	assert.Equal(t, 204, w.Code)
+	assert.Equal(t, "", w.Body.String())
+	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "text/html; charset=utf-8")
+}
+
 // TestContextData tests that the response can be written from `bytesting`
 // with specified MIME type
 func TestContextRenderData(t *testing.T) {
@@ -486,6 +574,18 @@ func TestContextRenderData(t *testing.T) {
 
 	assert.Equal(t, w.Code, 201)
 	assert.Equal(t, w.Body.String(), "foo,bar")
+	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "text/csv")
+}
+
+// Tests that no Custom Data is rendered if code is 204
+func TestContextRenderNoContentData(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Data(204, "text/csv", []byte(`foo,bar`))
+
+	assert.Equal(t, 204, w.Code)
+	assert.Equal(t, "", w.Body.String())
 	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "text/csv")
 }
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -10,8 +10,8 @@ import (
 
 	"testing"
 
-	"github.com/manucorporat/sse"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/gin-contrib/sse.v0"
 )
 
 func TestMiddlewareGeneralCase(t *testing.T) {

--- a/render/data.go
+++ b/render/data.go
@@ -11,10 +11,13 @@ type Data struct {
 	Data        []byte
 }
 
-func (r Data) Render(w http.ResponseWriter) error {
-	if len(r.ContentType) > 0 {
-		w.Header()["Content-Type"] = []string{r.ContentType}
-	}
-	w.Write(r.Data)
-	return nil
+// Render (Data) writes data with custom ContentType
+func (r Data) Render(w http.ResponseWriter) (err error) {
+	r.WriteContentType(w)
+	_, err = w.Write(r.Data)
+	return
+}
+
+func (r Data) WriteContentType(w http.ResponseWriter) {
+	writeContentType(w, []string{r.ContentType})
 }

--- a/render/html.go
+++ b/render/html.go
@@ -58,9 +58,14 @@ func (r HTMLDebug) loadTemplate() *template.Template {
 }
 
 func (r HTML) Render(w http.ResponseWriter) error {
-	writeContentType(w, htmlContentType)
+	r.WriteContentType(w)
+
 	if len(r.Name) == 0 {
 		return r.Template.Execute(w, r.Data)
 	}
 	return r.Template.ExecuteTemplate(w, r.Name, r.Data)
+}
+
+func (r HTML) WriteContentType(w http.ResponseWriter) {
+	writeContentType(w, htmlContentType)
 }

--- a/render/json.go
+++ b/render/json.go
@@ -34,7 +34,12 @@ func (r JSON) WriteContentType(w http.ResponseWriter) {
 
 func WriteJSON(w http.ResponseWriter, obj interface{}) error {
 	writeContentType(w, jsonContentType)
-	return json.NewEncoder(w).Encode(obj)
+	jsonBytes, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	w.Write(jsonBytes)
+	return nil
 }
 
 func (r IndentedJSON) Render(w http.ResponseWriter) error {

--- a/render/json.go
+++ b/render/json.go
@@ -21,12 +21,24 @@ type (
 
 var jsonContentType = []string{"application/json; charset=utf-8"}
 
-func (r JSON) Render(w http.ResponseWriter) error {
-	return WriteJSON(w, r.Data)
+func (r JSON) Render(w http.ResponseWriter) (err error) {
+	if err = WriteJSON(w, r.Data); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (r JSON) WriteContentType(w http.ResponseWriter) {
+	writeContentType(w, jsonContentType)
+}
+
+func WriteJSON(w http.ResponseWriter, obj interface{}) error {
+	writeContentType(w, jsonContentType)
+	return json.NewEncoder(w).Encode(obj)
 }
 
 func (r IndentedJSON) Render(w http.ResponseWriter) error {
-	writeContentType(w, jsonContentType)
+	r.WriteContentType(w)
 	jsonBytes, err := json.MarshalIndent(r.Data, "", "    ")
 	if err != nil {
 		return err
@@ -35,12 +47,6 @@ func (r IndentedJSON) Render(w http.ResponseWriter) error {
 	return nil
 }
 
-func WriteJSON(w http.ResponseWriter, obj interface{}) error {
+func (r IndentedJSON) WriteContentType(w http.ResponseWriter) {
 	writeContentType(w, jsonContentType)
-	jsonBytes, err := json.Marshal(obj)
-	if err != nil {
-		return err
-	}
-	w.Write(jsonBytes)
-	return nil
 }

--- a/render/redirect.go
+++ b/render/redirect.go
@@ -22,3 +22,5 @@ func (r Redirect) Render(w http.ResponseWriter) error {
 	http.Redirect(w, r.Request, r.Location, r.Code)
 	return nil
 }
+
+func (r Redirect) WriteContentType(http.ResponseWriter) {}

--- a/render/render.go
+++ b/render/render.go
@@ -8,6 +8,7 @@ import "net/http"
 
 type Render interface {
 	Render(http.ResponseWriter) error
+	WriteContentType(w http.ResponseWriter)
 }
 
 var (

--- a/render/text.go
+++ b/render/text.go
@@ -22,9 +22,12 @@ func (r String) Render(w http.ResponseWriter) error {
 	return nil
 }
 
+func (r String) WriteContentType(w http.ResponseWriter) {
+	writeContentType(w, plainContentType)
+}
+
 func WriteString(w http.ResponseWriter, format string, data []interface{}) {
 	writeContentType(w, plainContentType)
-
 	if len(data) > 0 {
 		fmt.Fprintf(w, format, data...)
 	} else {

--- a/render/xml.go
+++ b/render/xml.go
@@ -16,6 +16,10 @@ type XML struct {
 var xmlContentType = []string{"application/xml; charset=utf-8"}
 
 func (r XML) Render(w http.ResponseWriter) error {
-	writeContentType(w, xmlContentType)
+	r.WriteContentType(w)
 	return xml.NewEncoder(w).Encode(r.Data)
+}
+
+func (r XML) WriteContentType(w http.ResponseWriter) {
+	writeContentType(w, xmlContentType)
 }

--- a/render/yaml.go
+++ b/render/yaml.go
@@ -17,7 +17,7 @@ type YAML struct {
 var yamlContentType = []string{"application/x-yaml; charset=utf-8"}
 
 func (r YAML) Render(w http.ResponseWriter) error {
-	writeContentType(w, yamlContentType)
+	r.WriteContentType(w)
 
 	bytes, err := yaml.Marshal(r.Data)
 	if err != nil {
@@ -26,4 +26,8 @@ func (r YAML) Render(w http.ResponseWriter) error {
 
 	w.Write(bytes)
 	return nil
+}
+
+func (r YAML) WriteContentType(w http.ResponseWriter) {
+	writeContentType(w, yamlContentType)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -22,12 +22,6 @@
 			"revisionTime": "2016-11-17T03:31:26Z"
 		},
 		{
-			"checksumSHA1": "b0T0Hzd+zYk+OCDTFMps+jwa/nY=",
-			"path": "github.com/manucorporat/sse",
-			"revision": "ee05b128a739a0fb76c7ebd3ae4810c1de808d6d",
-			"revisionTime": "2016-01-26T18:01:36Z"
-		},
-		{
 			"checksumSHA1": "9if9IBLsxkarJ804NPWAzgskIAk=",
 			"path": "github.com/manucorporat/stats",
 			"revision": "8f2d6ace262eba462e9beb552382c98be51d807b",
@@ -65,6 +59,12 @@
 			"path": "golang.org/x/sys/unix",
 			"revision": "478fcf54317e52ab69f40bb4c7a1520288d7f7ea",
 			"revisionTime": "2016-12-05T15:46:50Z"
+		},
+		{
+			"checksumSHA1": "pyAPYrymvmZl0M/Mr4yfjOQjA8I=",
+			"path": "gopkg.in/gin-contrib/sse.v0",
+			"revision": "22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae",
+			"revisionTime": "2017-01-09T09:34:21Z"
 		},
 		{
 			"checksumSHA1": "39V1idWER42Lmcmg2Uy40wMzOlo=",


### PR DESCRIPTION
@appleboy @tboerger this is a solution for #198.

I'm intrigued why [`http.ResponseWriter`](https://golang.org/src/net/http/server.go?h=ResponseWriter#L86) is not returning [`http.ErrBodyNotAllowed`](https://golang.org/src/net/http/server.go?h=ErrBodyNotAllowed#L39).

I don't have time to look into it right now, hope you can, or we can review it later this weekend.

There is no breaking changes except to those who import directly the following:
- [github.com/gin-gonic/gin/render](https://github.com/gin-gonic/gin/tree/master/render)
- [github.com/manucorportat/sse](https://github.com/manucorporat/sse)

Maybe I'm leaving something behind, so more eyes on this are welcome.