### PR TITLE
Support time.Time on form binding

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"reflect"
 	"strconv"
+	"time"
 )
 
 func mapForm(ptr interface{}, form map[string][]string) error {
@@ -52,6 +53,12 @@ func mapForm(ptr interface{}, form map[string][]string) error {
 			}
 			val.Field(i).Set(slice)
 		} else {
+			if _, isTime := structField.Interface().(time.Time); isTime {
+				if err := setTimeField(inputValue[0], typeField, structField); err != nil {
+					return err
+				}
+				continue
+			}
 			if err := setWithProperType(typeField.Type.Kind(), inputValue[0], structField); err != nil {
 				return err
 			}
@@ -138,6 +145,26 @@ func setFloatField(val string, bitSize int, field reflect.Value) error {
 		field.SetFloat(floatVal)
 	}
 	return err
+}
+
+func setTimeField(val string, structField reflect.StructField, value reflect.Value) error {
+	timeFormat := structField.Tag.Get("time_format")
+	if timeFormat == "" {
+		return errors.New("Blank time format")
+	}
+
+	l := time.Local
+	if isUTC, _ := strconv.ParseBool(structField.Tag.Get("time_utc")); isUTC {
+		l = time.UTC
+	}
+
+	t, err := time.ParseInLocation(timeFormat, val, l)
+	if err != nil {
+		return err
+	}
+
+	value.Set(reflect.ValueOf(t))
+	return nil
 }
 
 // Don't pass in pointers to bind to. Can lead to bugs. See:


### PR DESCRIPTION
It's required to inform the format:

```go
type T struct{
        Time time.Time `form:"a_time" time_format:"02/01/2006"`
}
```

The default location is `time.Local`. If a `utc` tag is given, localtion is `time.UTC`:

```go
type T struct{
        Time time.Time `form:"a_time" time_format:"02/01/2006" utc:"1"`
}
```

If user input is blank (`""`), then `form.Time.IsZero()` will return `true`.