### PR TITLE
The url.RawPath used when engine.UseRawPath is set to true.

### DIFF
--- a/routes_test.go
+++ b/routes_test.go
@@ -400,3 +400,42 @@ func TestRouterNotFound(t *testing.T) {
 	w = performRequest(router, "GET", "/")
 	assert.Equal(t, w.Code, 404)
 }
+
+func TestRouteRawPath(t *testing.T) {
+	route := New()
+	route.UseRawPath = true
+
+	route.POST("/project/:name/build/:num", func(c *Context) {
+		name := c.Params.ByName("name")
+		num := c.Params.ByName("num")
+
+		assert.Equal(t, c.Param("name"), name)
+		assert.Equal(t, c.Param("num"), num)
+
+		assert.Equal(t, "Some/Other/Project", name)
+		assert.Equal(t, "222", num)
+	})
+
+	w := performRequest(route, "POST", "/project/Some%2FOther%2FProject/build/222")
+	assert.Equal(t, w.Code, 200)
+}
+
+func TestRouteRawPathNoUnescape(t *testing.T) {
+	route := New()
+	route.UseRawPath = true
+	route.UnescapePathValues = false
+
+	route.POST("/project/:name/build/:num", func(c *Context) {
+		name := c.Params.ByName("name")
+		num := c.Params.ByName("num")
+
+		assert.Equal(t, c.Param("name"), name)
+		assert.Equal(t, c.Param("num"), num)
+
+		assert.Equal(t, "Some%2FOther%2FProject", name)
+		assert.Equal(t, "333", num)
+	})
+
+	w := performRequest(route, "POST", "/project/Some%2FOther%2FProject/build/333")
+	assert.Equal(t, w.Code, 200)
+}

--- a/tree.go
+++ b/tree.go
@@ -5,6 +5,7 @@
 package gin
 
 import (
+	"net/url"
 	"strings"
 	"unicode"
 )
@@ -363,7 +364,7 @@ func (n *node) insertChild(numParams uint8, path string, fullPath string, handle
 // If no handle can be found, a TSR (trailing slash redirect) recommendation is
 // made if a handle exists with an extra (without the) trailing slash for the
 // given path.
-func (n *node) getValue(path string, po Params) (handlers HandlersChain, p Params, tsr bool) {
+func (n *node) getValue(path string, po Params, unescape bool) (handlers HandlersChain, p Params, tsr bool) {
 	p = po
 walk: // Outer loop for walking the tree
 	for {
@@ -406,7 +407,15 @@ walk: // Outer loop for walking the tree
 					i := len(p)
 					p = p[:i+1] // expand slice within preallocated capacity
 					p[i].Key = n.path[1:]
-					p[i].Value = path[:end]
+					val := path[:end]
+					if unescape {
+						var err error
+						if p[i].Value, err = url.QueryUnescape(val); err != nil {
+							p[i].Value = val // fallback, in case of error
+						}
+					} else {
+						p[i].Value = val
+					}
 
 					// we need to go deeper!
 					if end < len(path) {
@@ -440,7 +449,14 @@ walk: // Outer loop for walking the tree
 					i := len(p)
 					p = p[:i+1] // expand slice within preallocated capacity
 					p[i].Key = n.path[2:]
-					p[i].Value = path
+					if unescape {
+						var err error
+						if p[i].Value, err = url.QueryUnescape(path); err != nil {
+							p[i].Value = path // fallback, in case of error
+						}
+					} else {
+						p[i].Value = path
+					}
 
 					handlers = n.handlers
 					return

--- a/tree_test.go
+++ b/tree_test.go
@@ -37,9 +37,14 @@ type testRequests []struct {
 	ps         Params
 }
 
-func checkRequests(t *testing.T, tree *node, requests testRequests) {
+func checkRequests(t *testing.T, tree *node, requests testRequests, unescapes ...bool) {
+	unescape := false
+	if len(unescapes) >= 1 {
+		unescape = unescapes[0]
+	}
+
 	for _, request := range requests {
-		handler, ps, _ := tree.getValue(request.path, nil)
+		handler, ps, _ := tree.getValue(request.path, nil, unescape)
 
 		if handler == nil {
 			if !request.nilHandler {
@@ -192,6 +197,45 @@ func TestTreeWildcard(t *testing.T) {
 		{"/info/gordon/public", false, "/info/:user/public", Params{Param{"user", "gordon"}}},
 		{"/info/gordon/project/go", false, "/info/:user/project/:project", Params{Param{"user", "gordon"}, Param{"project", "go"}}},
 	})
+
+	checkPriorities(t, tree)
+	checkMaxParams(t, tree)
+}
+
+func TestUnescapeParameters(t *testing.T) {
+	tree := &node{}
+
+	routes := [...]string{
+		"/",
+		"/cmd/:tool/:sub",
+		"/cmd/:tool/",
+		"/src/*filepath",
+		"/search/:query",
+		"/files/:dir/*filepath",
+		"/info/:user/project/:project",
+		"/info/:user",
+	}
+	for _, route := range routes {
+		tree.addRoute(route, fakeHandler(route))
+	}
+
+	//printChildren(tree, "")
+	unescape := true
+	checkRequests(t, tree, testRequests{
+		{"/", false, "/", nil},
+		{"/cmd/test/", false, "/cmd/:tool/", Params{Param{"tool", "test"}}},
+		{"/cmd/test", true, "", Params{Param{"tool", "test"}}},
+		{"/src/some/file.png", false, "/src/*filepath", Params{Param{"filepath", "/some/file.png"}}},
+		{"/src/some/file+test.png", false, "/src/*filepath", Params{Param{"filepath", "/some/file test.png"}}},
+		{"/src/some/file++++%%%%test.png", false, "/src/*filepath", Params{Param{"filepath", "/some/file++++%%%%test.png"}}},
+		{"/src/some/file%2Ftest.png", false, "/src/*filepath", Params{Param{"filepath", "/some/file/test.png"}}},
+		{"/search/someth!ng+in+ünìcodé", false, "/search/:query", Params{Param{"query", "someth!ng in ünìcodé"}}},
+		{"/info/gordon/project/go", false, "/info/:user/project/:project", Params{Param{"user", "gordon"}, Param{"project", "go"}}},
+		{"/info/slash%2Fgordon", false, "/info/:user", Params{Param{"user", "slash/gordon"}}},
+		{"/info/slash%2Fgordon/project/Project%20%231", false, "/info/:user/project/:project", Params{Param{"user", "slash/gordon"}, Param{"project", "Project #1"}}},
+		{"/info/slash%%%%", false, "/info/:user", Params{Param{"user", "slash%%%%"}}},
+		{"/info/slash%%%%2Fgordon/project/Project%%%%20%231", false, "/info/:user/project/:project", Params{Param{"user", "slash%%%%2Fgordon"}, Param{"project", "Project%%%%20%231"}}},
+	}, unescape)
 
 	checkPriorities(t, tree)
 	checkMaxParams(t, tree)
@@ -430,7 +474,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/doc/",
 	}
 	for _, route := range tsrRoutes {
-		handler, _, tsr := tree.getValue(route, nil)
+		handler, _, tsr := tree.getValue(route, nil, false)
 		if handler != nil {
 			t.Fatalf("non-nil handler for TSR route '%s", route)
 		} else if !tsr {
@@ -447,7 +491,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/api/world/abc",
 	}
 	for _, route := range noTsrRoutes {
-		handler, _, tsr := tree.getValue(route, nil)
+		handler, _, tsr := tree.getValue(route, nil, false)
 		if handler != nil {
 			t.Fatalf("non-nil handler for No-TSR route '%s", route)
 		} else if tsr {
@@ -466,7 +510,7 @@ func TestTreeRootTrailingSlashRedirect(t *testing.T) {
 		t.Fatalf("panic inserting test route: %v", recv)
 	}
 
-	handler, _, tsr := tree.getValue("/", nil)
+	handler, _, tsr := tree.getValue("/", nil, false)
 	if handler != nil {
 		t.Fatalf("non-nil handler")
 	} else if tsr {
@@ -617,7 +661,7 @@ func TestTreeInvalidNodeType(t *testing.T) {
 
 	// normal lookup
 	recv := catchPanic(func() {
-		tree.getValue("/test", nil)
+		tree.getValue("/test", nil, false)
 	})
 	if rs, ok := recv.(string); !ok || rs != panicMsg {
 		t.Fatalf("Expected panic '"+panicMsg+"', got '%v'", recv)


### PR DESCRIPTION
Fix for #777, #640, #722.

Another try to make it faster into master :)
Almost same as #777 but handles one more case in tree.getValue.

@appleboy Please review it. With this (plus forcing UseRawPath) the drone became handling escaped params. Thanks!

Replaces #803