### PR TITLE
add GetHeader() to easily get header in Request

### DIFF
--- a/context.go
+++ b/context.go
@@ -391,7 +391,7 @@ func (c *Context) Header(key, value string) {
 }
 
 // GetHeader is a shortcut for c.Request.Header.Get(key)
-// It get the header in th request.
+// It gets the header in the request.
 func (c *Context) GetHeader(key string) {
         return c.Request.Header.Get(key)
 }

--- a/context.go
+++ b/context.go
@@ -390,6 +390,12 @@ func (c *Context) Header(key, value string) {
 	}
 }
 
+// GetHeader is a shortcut for c.Request.Header.Get(key)
+// It get the header in th request.
+func (c *Context) GetHeader(key string) {
+        return c.Request.Header.Get(key)
+}
+
 func (c *Context) SetCookie(
 	name string,
 	value string,

--- a/context.go
+++ b/context.go
@@ -392,7 +392,7 @@ func (c *Context) Header(key, value string) {
 
 // GetHeader is a shortcut for c.Request.Header.Get(key)
 // It gets the header in the request.
-func (c *Context) GetHeader(key string) {
+func (c *Context) GetHeader(key string) string {
         return c.Request.Header.Get(key)
 }
 


### PR DESCRIPTION
GetHeader is a shortcut for c.Request.Header.Get(key)

It gets the header in the request.

If there are no such header, it will just return "".