### PR TITLE
Correct README.md syntax problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
+# Gin Web Framework
 
-#Gin Web Framework
-
-<img align="right" src="https://raw.githubusercontent.com/gin-gonic/gin/master/logo.jpg">
 [![Build Status](https://travis-ci.org/gin-gonic/gin.svg)](https://travis-ci.org/gin-gonic/gin)
 [![codecov](https://codecov.io/gh/gin-gonic/gin/branch/master/graph/badge.svg)](https://codecov.io/gh/gin-gonic/gin)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gin-gonic/gin)](https://goreportcard.com/report/github.com/gin-gonic/gin)
@@ -9,7 +7,7 @@
 [![Join the chat at https://gitter.im/gin-gonic/gin](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gin-gonic/gin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Gin is a web framework written in Go (Golang). It features a martini-like API with much better performance, up to 40 times faster thanks to [httprouter](https://github.com/julienschmidt/httprouter). If you need performance and good productivity, you will love Gin.
-
+<img align="right" src="https://raw.githubusercontent.com/gin-gonic/gin/master/logo.jpg">
 ![Gin console logger](https://gin-gonic.github.io/gin/other/console.png)
 
 ```sh
@@ -372,7 +370,7 @@ func main() {
 ```
 
 
-###Multipart/Urlencoded binding
+### Multipart/Urlencoded binding
 ```go
 package main
 
@@ -450,7 +448,7 @@ func main() {
 }
 ```
 
-####Serving static files
+#### Serving static files
 
 ```go
 func main() {
@@ -464,7 +462,7 @@ func main() {
 }
 ```
 
-####HTML rendering
+#### HTML rendering
 
 Using LoadHTMLTemplates()
 

--- a/logger.go
+++ b/logger.go
@@ -7,10 +7,7 @@ package gin
 import (
 	"fmt"
 	"io"
-	"os"
 	"time"
-
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 var (
@@ -47,11 +44,6 @@ func Logger() HandlerFunc {
 // LoggerWithWriter instance a Logger middleware with the specified writter buffer.
 // Example: os.Stdout, a file opened in write mode, a socket...
 func LoggerWithWriter(out io.Writer, notlogged ...string) HandlerFunc {
-	isTerm := true
-	if outFile, ok := out.(*os.File); ok {
-		isTerm = terminal.IsTerminal(int(outFile.Fd()))
-	}
-
 	var skip map[string]struct{}
 
 	if length := len(notlogged); length > 0 {
@@ -79,11 +71,8 @@ func LoggerWithWriter(out io.Writer, notlogged ...string) HandlerFunc {
 			clientIP := c.ClientIP()
 			method := c.Request.Method
 			statusCode := c.Writer.Status()
-			var statusColor, methodColor string
-			if isTerm {
-				statusColor = colorForStatus(statusCode)
-				methodColor = colorForMethod(method)
-			}
+			statusColor := colorForStatus(statusCode)
+			methodColor := colorForMethod(method)
 			comment := c.Errors.ByType(ErrorTypePrivate).String()
 
 			fmt.Fprintf(out, "[GIN] %v |%s %3d %s| %13v | %s |%s  %s %-7s %s\n%s",

--- a/logger.go
+++ b/logger.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 	"time"
 
 	"golang.org/x/crypto/ssh/terminal"
@@ -49,11 +48,8 @@ func Logger() HandlerFunc {
 // Example: os.Stdout, a file opened in write mode, a socket...
 func LoggerWithWriter(out io.Writer, notlogged ...string) HandlerFunc {
 	isTerm := true
-
-	if runtime.GOOS != "appengine" && runtime.GOOS != "netbsd" && runtime.GOOS != "openbsd" {
-		if outFile, ok := out.(*os.File); ok {
-			isTerm = terminal.IsTerminal(int(outFile.Fd()))
-		}
+	if outFile, ok := out.(*os.File); ok {
+		isTerm = terminal.IsTerminal(int(outFile.Fd()))
 	}
 
 	var skip map[string]struct{}


### PR DESCRIPTION
Pretty sure some things in README.md that previously rendered properly but were invalid Markdown syntax were broken when GitHub transitioned from Sundown to `cmark`. [More information is available here](https://githubengineering.com/a-formal-spec-for-github-markdown/).

This PR corrects the syntax errors and ensures that viewing the README.md on GitHub.com now correctly renders everything.