### PR TITLE
Fix the formatting so that the README renders correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-
-#Gin Web Framework
+# Gin Web Framework
 
 <img align="right" src="https://raw.githubusercontent.com/gin-gonic/gin/master/logo.jpg">
+
 [![Build Status](https://travis-ci.org/gin-gonic/gin.svg)](https://travis-ci.org/gin-gonic/gin)
 [![codecov](https://codecov.io/gh/gin-gonic/gin/branch/master/graph/badge.svg)](https://codecov.io/gh/gin-gonic/gin)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gin-gonic/gin)](https://goreportcard.com/report/github.com/gin-gonic/gin)


### PR DESCRIPTION
The README looked a little janky so I fixed the formatting so that it renders properly on GitHub.

| Before | After |
| ------- | ----- |
| <img width="985" alt="screen shot 2017-03-25 at 16 25 35" src="https://cloud.githubusercontent.com/assets/564113/24325818/b7216bc2-1177-11e7-96dd-54ea5a2a9c7f.png"> | <img width="997" alt="screen shot 2017-03-25 at 16 26 58" src="https://cloud.githubusercontent.com/assets/564113/24325830/e97a730c-1177-11e7-916b-89b7bbde3a54.png"> |

Thanks!

