### PR TITLE
Add spacing around headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 
-#Gin Web Framework
+# Gin Web Framework
 
 <img align="right" src="https://raw.githubusercontent.com/gin-gonic/gin/master/logo.jpg">
+
 [![Build Status](https://travis-ci.org/gin-gonic/gin.svg)](https://travis-ci.org/gin-gonic/gin)
 [![codecov](https://codecov.io/gh/gin-gonic/gin/branch/master/graph/badge.svg)](https://codecov.io/gh/gin-gonic/gin)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gin-gonic/gin)](https://goreportcard.com/report/github.com/gin-gonic/gin)
@@ -153,6 +154,7 @@ func main() {
 ```
 
 #### Querystring parameters
+
 ```go
 func main() {
 	router := gin.Default()
@@ -247,6 +249,7 @@ func main() {
 ```
 
 #### Grouping routes
+
 ```go
 func main() {
 	router := gin.Default()
@@ -279,6 +282,7 @@ Use
 ```go
 r := gin.New()
 ```
+
 instead of
 
 ```go
@@ -287,6 +291,7 @@ r := gin.Default()
 
 
 #### Using middleware
+
 ```go
 func main() {
 	// Creates a router without any middleware by default
@@ -372,7 +377,8 @@ func main() {
 ```
 
 
-###Multipart/Urlencoded binding
+### Multipart/Urlencoded binding
+
 ```go
 package main
 
@@ -450,7 +456,7 @@ func main() {
 }
 ```
 
-####Serving static files
+#### Serving static files
 
 ```go
 func main() {
@@ -464,7 +470,7 @@ func main() {
 }
 ```
 
-####HTML rendering
+#### HTML rendering
 
 Using LoadHTMLTemplates()
 
@@ -597,6 +603,7 @@ func main() {
 ```
 
 #### Using BasicAuth() middleware
+
 ```go
 // simulate some private data
 var secrets = gin.H{
@@ -636,6 +643,7 @@ func main() {
 
 
 #### Goroutines inside a middleware
+
 When starting inside a middleware or handler, you **SHOULD NOT** use the original context inside it, you have to use a read-only copy.
 
 ```go


### PR DESCRIPTION
Most probably due to enforcing the new formal Markdown spec [1], the readme wasn't displayed correctly anymore.

[1]: https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown