### PR TITLE
Fix time.Time binding

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -152,6 +152,11 @@ func setTimeField(val string, structField reflect.StructField, value reflect.Val
 	if timeFormat == "" {
 		return errors.New("Blank time format")
 	}
+	
+	if val == "" {
+		value.Set(reflect.ValueOf(time.Time{}))
+		return nil
+	}
 
 	l := time.Local
 	if isUTC, _ := strconv.ParseBool(structField.Tag.Get("time_utc")); isUTC {


### PR DESCRIPTION
If a empty string is given(`""`), them time should be zero.