### PR TITLE
Fix README markdown for h4s

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ func main() {
 ```
 
 
-###Multipart/Urlencoded binding
+### Multipart/Urlencoded binding
 ```go
 package main
 
@@ -451,7 +451,7 @@ func main() {
 }
 ```
 
-####Serving static files
+#### Serving static files
 
 ```go
 func main() {
@@ -465,7 +465,7 @@ func main() {
 }
 ```
 
-####HTML rendering
+#### HTML rendering
 
 Using LoadHTMLTemplates()
 


### PR DESCRIPTION
In order for these to appear correctly after conversion to HTML there
needs to be a space after the #'s.  This PR just adds them to the
README.