### PR TITLE
fix(tests): TestDebugPrintLoadTemplate use assert.Regep instead of assert.Equal

### DIFF
--- a/debug_test.go
+++ b/debug_test.go
@@ -74,7 +74,7 @@ func TestDebugPrintLoadTemplate(t *testing.T) {
 
 	templ := template.Must(template.New("").Delims("{[{", "}]}").ParseGlob("./fixtures/basic/hello.tmpl"))
 	debugPrintLoadTemplate(templ)
-	assert.Equal(t, w.String(), "[GIN-debug] Loaded HTML Templates (2): \n\t- \n\t- hello.tmpl\n\n")
+	assert.Regexp(t, `^\[GIN-debug\] Loaded HTML Templates \(2\): \n(\t- \n|\t- hello\.tmpl\n){2}\n`, w.String())
 }
 
 func TestDebugPrintWARNINGSetHTMLTemplate(t *testing.T) {


### PR DESCRIPTION
 Sometimes travis will build error because `TestDebugPrintLoadTemplate` templates print-order not guaranteed.

travis ref:
- https://travis-ci.org/gin-gonic/gin/jobs/249505506
- https://travis-ci.org/gin-gonic/gin/jobs/249296346
- https://travis-ci.org/gin-gonic/gin/jobs/249505506