### PR TITLE
separate type define

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -13,15 +13,15 @@ import (
 // AuthUserKey is the cookie name for user credential in basic auth
 const AuthUserKey = "user"
 
-type (
-	// Accounts defines a key/value for user/pass list of authorized logins
-	Accounts map[string]string
-	authPair struct {
-		Value string
-		User  string
-	}
-	authPairs []authPair
-)
+// Accounts defines a key/value for user/pass list of authorized logins
+type Accounts map[string]string
+
+type authPair struct {
+	Value string
+	User  string
+}
+
+type authPairs []authPair
 
 func (a authPairs) searchCredential(authValue string) (string, bool) {
 	if len(authValue) == 0 {

--- a/errors.go
+++ b/errors.go
@@ -23,15 +23,13 @@ const (
 	ErrorTypeNu            = 2
 )
 
-type (
-	Error struct {
-		Err  error
-		Type ErrorType
-		Meta interface{}
-	}
+type Error struct {
+	Err  error
+	Type ErrorType
+	Meta interface{}
+}
 
-	errorMsgs []*Error
-)
+type errorMsgs []*Error
 
 var _ error = &Error{}
 

--- a/fs.go
+++ b/fs.go
@@ -9,14 +9,13 @@ import (
 	"os"
 )
 
-type (
-	onlyfilesFS struct {
-		fs http.FileSystem
-	}
-	neuteredReaddirFile struct {
-		http.File
-	}
-)
+type onlyfilesFS struct {
+	fs http.FileSystem
+}
+
+type neuteredReaddirFile struct {
+	http.File
+}
 
 // Dir returns a http.Filesystem that can be used by http.FileServer(). It is used internally
 // in router.Static().

--- a/gin.go
+++ b/gin.go
@@ -33,67 +33,66 @@ func (c HandlersChain) Last() HandlerFunc {
 	return nil
 }
 
-type (
-	RoutesInfo []RouteInfo
-	RouteInfo  struct {
-		Method  string
-		Path    string
-		Handler string
-	}
+type RouteInfo struct {
+	Method  string
+	Path    string
+	Handler string
+}
 
-	// Engine is the framework's instance, it contains the muxer, middleware and configuration settings.
-	// Create an instance of Engine, by using New() or Default()
-	Engine struct {
-		RouterGroup
-		delims      render.Delims
-		HTMLRender  render.HTMLRender
-		FuncMap     template.FuncMap
-		allNoRoute  HandlersChain
-		allNoMethod HandlersChain
-		noRoute     HandlersChain
-		noMethod    HandlersChain
-		pool        sync.Pool
-		trees       methodTrees
+type RoutesInfo []RouteInfo
 
-		// Enables automatic redirection if the current route can't be matched but a
-		// handler for the path with (without) the trailing slash exists.
-		// For example if /foo/ is requested but a route only exists for /foo, the
-		// client is redirected to /foo with http status code 301 for GET requests
-		// and 307 for all other request methods.
-		RedirectTrailingSlash bool
+// Engine is the framework's instance, it contains the muxer, middleware and configuration settings.
+// Create an instance of Engine, by using New() or Default()
+type Engine struct {
+	RouterGroup
+	delims      render.Delims
+	HTMLRender  render.HTMLRender
+	FuncMap     template.FuncMap
+	allNoRoute  HandlersChain
+	allNoMethod HandlersChain
+	noRoute     HandlersChain
+	noMethod    HandlersChain
+	pool        sync.Pool
+	trees       methodTrees
 
-		// If enabled, the router tries to fix the current request path, if no
-		// handle is registered for it.
-		// First superfluous path elements like ../ or // are removed.
-		// Afterwards the router does a case-insensitive lookup of the cleaned path.
-		// If a handle can be found for this route, the router makes a redirection
-		// to the corrected path with status code 301 for GET requests and 307 for
-		// all other request methods.
-		// For example /FOO and /..//Foo could be redirected to /foo.
-		// RedirectTrailingSlash is independent of this option.
-		RedirectFixedPath bool
+	// Enables automatic redirection if the current route can't be matched but a
+	// handler for the path with (without) the trailing slash exists.
+	// For example if /foo/ is requested but a route only exists for /foo, the
+	// client is redirected to /foo with http status code 301 for GET requests
+	// and 307 for all other request methods.
+	RedirectTrailingSlash bool
 
-		// If enabled, the router checks if another method is allowed for the
-		// current route, if the current request can not be routed.
-		// If this is the case, the request is answered with 'Method Not Allowed'
-		// and HTTP status code 405.
-		// If no other Method is allowed, the request is delegated to the NotFound
-		// handler.
-		HandleMethodNotAllowed bool
-		ForwardedByClientIP    bool
+	// If enabled, the router tries to fix the current request path, if no
+	// handle is registered for it.
+	// First superfluous path elements like ../ or // are removed.
+	// Afterwards the router does a case-insensitive lookup of the cleaned path.
+	// If a handle can be found for this route, the router makes a redirection
+	// to the corrected path with status code 301 for GET requests and 307 for
+	// all other request methods.
+	// For example /FOO and /..//Foo could be redirected to /foo.
+	// RedirectTrailingSlash is independent of this option.
+	RedirectFixedPath bool
 
-		// #726 #755 If enabled, it will thrust some headers starting with
-		// 'X-AppEngine...' for better integration with that PaaS.
-		AppEngine bool
+	// If enabled, the router checks if another method is allowed for the
+	// current route, if the current request can not be routed.
+	// If this is the case, the request is answered with 'Method Not Allowed'
+	// and HTTP status code 405.
+	// If no other Method is allowed, the request is delegated to the NotFound
+	// handler.
+	HandleMethodNotAllowed bool
+	ForwardedByClientIP    bool
 
-		// If enabled, the url.RawPath will be used to find parameters.
-		UseRawPath bool
-		// If true, the path value will be unescaped.
-		// If UseRawPath is false (by default), the UnescapePathValues effectively is true,
-		// as url.Path gonna be used, which is already unescaped.
-		UnescapePathValues bool
-	}
-)
+	// #726 #755 If enabled, it will thrust some headers starting with
+	// 'X-AppEngine...' for better integration with that PaaS.
+	AppEngine bool
+
+	// If enabled, the url.RawPath will be used to find parameters.
+	UseRawPath bool
+	// If true, the path value will be unescaped.
+	// If UseRawPath is false (by default), the UnescapePathValues effectively is true,
+	// as url.Path gonna be used, which is already unescaped.
+	UnescapePathValues bool
+}
 
 var _ IRouter = &Engine{}
 

--- a/response_writer.go
+++ b/response_writer.go
@@ -16,36 +16,34 @@ const (
 	defaultStatus = 200
 )
 
-type (
-	ResponseWriter interface {
-		http.ResponseWriter
-		http.Hijacker
-		http.Flusher
-		http.CloseNotifier
+type ResponseWriter interface {
+	http.ResponseWriter
+	http.Hijacker
+	http.Flusher
+	http.CloseNotifier
 
-		// Returns the HTTP response status code of the current request.
-		Status() int
+	// Returns the HTTP response status code of the current request.
+	Status() int
 
-		// Returns the number of bytes already written into the response http body.
-		// See Written()
-		Size() int
+	// Returns the number of bytes already written into the response http body.
+	// See Written()
+	Size() int
 
-		// Writes the string into the response body.
-		WriteString(string) (int, error)
+	// Writes the string into the response body.
+	WriteString(string) (int, error)
 
-		// Returns true if the response body was already written.
-		Written() bool
+	// Returns true if the response body was already written.
+	Written() bool
 
-		// Forces to write the http header (status code + headers).
-		WriteHeaderNow()
-	}
+	// Forces to write the http header (status code + headers).
+	WriteHeaderNow()
+}
 
-	responseWriter struct {
-		http.ResponseWriter
-		size   int
-		status int
-	}
-)
+type responseWriter struct {
+	http.ResponseWriter
+	size   int
+	status int
+}
 
 var _ ResponseWriter = &responseWriter{}
 

--- a/routergroup.go
+++ b/routergroup.go
@@ -11,39 +11,37 @@ import (
 	"strings"
 )
 
-type (
-	IRouter interface {
-		IRoutes
-		Group(string, ...HandlerFunc) *RouterGroup
-	}
+type IRouter interface {
+	IRoutes
+	Group(string, ...HandlerFunc) *RouterGroup
+}
 
-	IRoutes interface {
-		Use(...HandlerFunc) IRoutes
+type IRoutes interface {
+	Use(...HandlerFunc) IRoutes
 
-		Handle(string, string, ...HandlerFunc) IRoutes
-		Any(string, ...HandlerFunc) IRoutes
-		GET(string, ...HandlerFunc) IRoutes
-		POST(string, ...HandlerFunc) IRoutes
-		DELETE(string, ...HandlerFunc) IRoutes
-		PATCH(string, ...HandlerFunc) IRoutes
-		PUT(string, ...HandlerFunc) IRoutes
-		OPTIONS(string, ...HandlerFunc) IRoutes
-		HEAD(string, ...HandlerFunc) IRoutes
+	Handle(string, string, ...HandlerFunc) IRoutes
+	Any(string, ...HandlerFunc) IRoutes
+	GET(string, ...HandlerFunc) IRoutes
+	POST(string, ...HandlerFunc) IRoutes
+	DELETE(string, ...HandlerFunc) IRoutes
+	PATCH(string, ...HandlerFunc) IRoutes
+	PUT(string, ...HandlerFunc) IRoutes
+	OPTIONS(string, ...HandlerFunc) IRoutes
+	HEAD(string, ...HandlerFunc) IRoutes
 
-		StaticFile(string, string) IRoutes
-		Static(string, string) IRoutes
-		StaticFS(string, http.FileSystem) IRoutes
-	}
+	StaticFile(string, string) IRoutes
+	Static(string, string) IRoutes
+	StaticFS(string, http.FileSystem) IRoutes
+}
 
-	// RouterGroup is used internally to configure router, a RouterGroup is associated with a prefix
-	// and an array of handlers (middleware)
-	RouterGroup struct {
-		Handlers HandlersChain
-		basePath string
-		engine   *Engine
-		root     bool
-	}
-)
+// RouterGroup is used internally to configure router, a RouterGroup is associated with a prefix
+// and an array of handlers (middleware)
+type RouterGroup struct {
+	Handlers HandlersChain
+	basePath string
+	engine   *Engine
+	root     bool
+}
 
 var _ IRouter = &RouterGroup{}
 


### PR DESCRIPTION
I have read some source codes of official go, I not found it use nesting `type` to define `struct` or `interface`, so commit this pr, thanks!
And it's better to avoid unnecessary indentation.