### PR TITLE
feat: change json lib to jsoniter

### DIFF
--- a/binding/json.go
+++ b/binding/json.go
@@ -5,8 +5,9 @@
 package binding
 
 import (
-	"encoding/json"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 )
 
 type jsonBinding struct{}

--- a/binding/json.go
+++ b/binding/json.go
@@ -7,8 +7,10 @@ package binding
 import (
 	"net/http"
 
-	json "github.com/json-iterator/go"
+	"github.com/json-iterator/go"
 )
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 type jsonBinding struct{}
 

--- a/context_test.go
+++ b/context_test.go
@@ -582,8 +582,8 @@ func TestContextRenderIndentedJSON(t *testing.T) {
 	c.IndentedJSON(201, H{"foo": "bar", "bar": "foo", "nested": H{"foo": "bar"}})
 
 	assert.Equal(t, w.Code, 201)
-	assert.Equal(t, w.Body.String(), "{\n    \"bar\": \"foo\",\n    \"foo\": \"bar\",\n    \"nested\": {\n        \"foo\": \"bar\"\n    }\n}")
-	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/json; charset=utf-8")
+	assert.Equal(t, "{\n    \"foo\":\"bar\",\n    \"bar\":\"foo\",\n    \"nested\":{\n        \"foo\":\"bar\"\n    }\n}", w.Body.String())
+	assert.Equal(t, "application/json; charset=utf-8", w.HeaderMap.Get("Content-Type"))
 }
 
 // Tests that no Custom JSON is rendered if code is 204
@@ -595,7 +595,7 @@ func TestContextRenderNoContentIndentedJSON(t *testing.T) {
 
 	assert.Equal(t, 204, w.Code)
 	assert.Equal(t, "", w.Body.String())
-	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/json; charset=utf-8")
+	assert.Equal(t, "application/json; charset=utf-8", w.HeaderMap.Get("Content-Type"))
 }
 
 // Tests that the response is serialized as Secure JSON

--- a/context_test.go
+++ b/context_test.go
@@ -582,7 +582,7 @@ func TestContextRenderIndentedJSON(t *testing.T) {
 	c.IndentedJSON(201, H{"foo": "bar", "bar": "foo", "nested": H{"foo": "bar"}})
 
 	assert.Equal(t, w.Code, 201)
-	assert.Equal(t, "{\n    \"foo\":\"bar\",\n    \"bar\":\"foo\",\n    \"nested\":{\n        \"foo\":\"bar\"\n    }\n}", w.Body.String())
+	assert.Equal(t, "{\n    \"bar\":\"foo\",\n    \"foo\":\"bar\",\n    \"nested\":{\n        \"foo\":\"bar\"\n    }\n}", w.Body.String())
 	assert.Equal(t, "application/json; charset=utf-8", w.HeaderMap.Get("Content-Type"))
 }
 

--- a/errors.go
+++ b/errors.go
@@ -6,9 +6,10 @@ package gin
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"reflect"
+
+	json "github.com/json-iterator/go"
 )
 
 type ErrorType uint64

--- a/errors.go
+++ b/errors.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"reflect"
 
-	json "github.com/json-iterator/go"
+	"github.com/json-iterator/go"
 )
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 type ErrorType uint64
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -91,7 +91,7 @@ Error #03: third
 		H{"error": "third", "status": "400"},
 	})
 	jsonBytes, _ := json.Marshal(errs)
-	assert.Equal(t, string(jsonBytes), "[{\"error\":\"first\"},{\"error\":\"second\",\"meta\":\"some data\"},{\"error\":\"third\",\"status\":\"400\"}]")
+	assert.Equal(t, "[{\"error\":\"first\"},{\"meta\":\"some data\",\"error\":\"second\"},{\"status\":\"400\",\"error\":\"third\"}]", string(jsonBytes))
 	errs = errorMsgs{
 		{Err: errors.New("first"), Type: ErrorTypePrivate},
 	}

--- a/errors_test.go
+++ b/errors_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"testing"
 
-	json "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,7 +31,7 @@ func TestError(t *testing.T) {
 	})
 
 	jsonBytes, _ := json.Marshal(err)
-	assert.Equal(t, "{\"meta\":\"some data\",\"error\":\"test error\"}", string(jsonBytes))
+	assert.Equal(t, "{\"error\":\"test error\",\"meta\":\"some data\"}", string(jsonBytes))
 
 	err.SetMeta(H{
 		"status": "200",
@@ -91,7 +90,7 @@ Error #03: third
 		H{"error": "third", "status": "400"},
 	})
 	jsonBytes, _ := json.Marshal(errs)
-	assert.Equal(t, "[{\"error\":\"first\"},{\"meta\":\"some data\",\"error\":\"second\"},{\"status\":\"400\",\"error\":\"third\"}]", string(jsonBytes))
+	assert.Equal(t, "[{\"error\":\"first\"},{\"error\":\"second\",\"meta\":\"some data\"},{\"error\":\"third\",\"status\":\"400\"}]", string(jsonBytes))
 	errs = errorMsgs{
 		{Err: errors.New("first"), Type: ErrorTypePrivate},
 	}

--- a/errors_test.go
+++ b/errors_test.go
@@ -5,10 +5,10 @@
 package gin
 
 import (
-	"encoding/json"
 	"errors"
 	"testing"
 
+	json "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -32,7 +32,7 @@ func TestError(t *testing.T) {
 	})
 
 	jsonBytes, _ := json.Marshal(err)
-	assert.Equal(t, string(jsonBytes), "{\"error\":\"test error\",\"meta\":\"some data\"}")
+	assert.Equal(t, "{\"meta\":\"some data\",\"error\":\"test error\"}", string(jsonBytes))
 
 	err.SetMeta(H{
 		"status": "200",

--- a/render/json.go
+++ b/render/json.go
@@ -6,8 +6,9 @@ package render
 
 import (
 	"bytes"
-	"encoding/json"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 )
 
 type JSON struct {

--- a/render/json.go
+++ b/render/json.go
@@ -8,8 +8,10 @@ import (
 	"bytes"
 	"net/http"
 
-	json "github.com/json-iterator/go"
+	"github.com/json-iterator/go"
 )
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 type JSON struct {
 	Data interface{}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -34,6 +34,12 @@
 			"revisionTime": "2017-06-01T23:02:30Z"
 		},
 		{
+			"checksumSHA1": "gWQ2ncPI6qpTwS3e6/ShPwUP1uo=",
+			"path": "github.com/json-iterator/go",
+			"revision": "b1afefe0580e6e818dd50da9593f477c80ccd67d",
+			"revisionTime": "2017-07-07T13:43:33Z"
+		},
+		{
 			"checksumSHA1": "9if9IBLsxkarJ804NPWAzgskIAk=",
 			"path": "github.com/manucorporat/stats",
 			"revision": "8f2d6ace262eba462e9beb552382c98be51d807b",


### PR DESCRIPTION
A high-performance 100% compatible drop-in replacement of "encoding/json"

https://github.com/json-iterator/go

cc @javierprovecho @tboerger 

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>