### PR TITLE
resolve #368 add option to UseNumber() in gin.Context.BindJSON()

### DIFF
--- a/binding/json.go
+++ b/binding/json.go
@@ -10,7 +10,10 @@ import (
 	"github.com/json-iterator/go"
 )
 
-var json = jsoniter.ConfigCompatibleWithStandardLibrary
+var (
+	json                   = jsoniter.ConfigCompatibleWithStandardLibrary
+	EnableDecoderUseNumber = false
+)
 
 type jsonBinding struct{}
 
@@ -20,6 +23,9 @@ func (jsonBinding) Name() string {
 
 func (jsonBinding) Bind(req *http.Request, obj interface{}) error {
 	decoder := json.NewDecoder(req.Body)
+	if EnableDecoderUseNumber {
+		decoder.UseNumber()
+	}
 	if err := decoder.Decode(obj); err != nil {
 		return err
 	}

--- a/mode.go
+++ b/mode.go
@@ -64,6 +64,10 @@ func DisableBindValidation() {
 	binding.Validator = nil
 }
 
+func EnableJsonDecoderUseNumber() {
+	binding.EnableDecoderUseNumber = true
+}
+
 func Mode() string {
 	return modeName
 }

--- a/mode_test.go
+++ b/mode_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gin-gonic/gin/binding"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,4 +34,10 @@ func TestSetMode(t *testing.T) {
 	assert.Equal(t, Mode(), TestMode)
 
 	assert.Panics(t, func() { SetMode("unknown") })
+}
+
+func TestEnableJsonDecoderUseNumber(t *testing.T) {
+	assert.False(t, binding.EnableDecoderUseNumber)
+	EnableJsonDecoderUseNumber()
+	assert.True(t, binding.EnableDecoderUseNumber)
 }


### PR DESCRIPTION
resolve #368  
I added an option EnableJsonDecoderUseNumber, so that you can choose whether or not to enable UseNumber in the JSON decoder.
Please review. 