### PR TITLE
ShouldBind counterparts for Bind methods

### DIFF
--- a/context.go
+++ b/context.go
@@ -482,6 +482,29 @@ func (c *Context) MustBindWith(obj interface{}, b binding.Binding) (err error) {
 	return
 }
 
+// ShouldBind checks the Content-Type to select a binding engine automatically,
+// Depending the "Content-Type" header different bindings are used:
+//     "application/json" --> JSON binding
+//     "application/xml"  --> XML binding
+// otherwise --> returns an error
+// It parses the request's body as JSON if Content-Type == "application/json" using JSON or XML as a JSON input.
+// It decodes the json payload into the struct specified as a pointer.
+// Like c.Bind() but this method does not set the response status code to 400 and abort if the json is not valid.
+func (c *Context) ShouldBind(obj interface{}) error {
+	b := binding.Default(c.Request.Method, c.ContentType())
+	return c.ShouldBindWith(obj, b)
+}
+
+// ShouldBindJSON is a shortcut for c.ShouldBindWith(obj, binding.JSON).
+func (c *Context) ShouldBindJSON(obj interface{}) error {
+	return c.ShouldBindWith(obj, binding.JSON)
+}
+
+// ShouldBindQuery is a shortcut for c.ShouldBindWith(obj, binding.Query).
+func (c *Context) ShouldBindQuery(obj interface{}) error {
+	return c.ShouldBindWith(obj, binding.Query)
+}
+
 // ShouldBindWith binds the passed struct pointer using the specified binding engine.
 // See the binding package.
 func (c *Context) ShouldBindWith(obj interface{}, b binding.Binding) error {


### PR DESCRIPTION
## Issue Description

Currently, the functions `ctx.Bind`, `ctx.BindJSON`, `ctx.BindQuery` all use `ctx.MustBindWith`.
In my opinion, the current implementation of `ctx.MustBindWith` has the following drawbacks. Note that this has been discussed before and I am including it here to avoid needing to crawl multiple issues, threads:
- **Lack of control**
  - It sets the HTTP status code as 400 and developer cannot set any other HTTP status code(ex: 422, `http.StatusUnprocessableEntity`)
  - It aborts the handler chain. Developer should be able to decide whether the resulting error is worth aborting or can be reconciled.
  - Cannot use repeated `Bind` as discussed in #811. Developer might want to bind query params and JSON body separately.
- **Possibly incorrect `Content-type` header** 
  - It sets the `Content-type` as `text/plain`
  - Neither `ctx.JSON` nor manually trying to set the content type header help. Instead we see this warning:
    ```
    [GIN-debug] [WARNING] Headers were already written. Wanted to override status code 400 with 422
    ```

## Proposal

For backward compatibility, we cannot change the behavior of existing bind methods. So this PR adds `ShouldBind` counterparts - `ctx.ShouldBind`, `ctx.ShouldBindJSON`, `ctx.ShouldBindQuery`. 

~Note that I have not yet updated the readme file and will do so depending on the outcome of the discussion here. I suggest that we switch over all examples on readme to use the `Should` equivalents.~
_All examples on readme have been updated to use `ShouldBind` methods. Also added section explaining difference between `Bind` and `ShouldBind` methods._
For example, this isn't going to work if there is a bind error:
```go
func startPage(c *gin.Context) {
    var person Person
    if c.BindQuery(&person) == nil {
        log.Println("====== Only Bind By Query String ======")
        log.Println(person.Name)
        log.Println(person.Address)
    }
    c.String(200, "Success") // Can cause `[GIN-debug] [WARNING] Headers were already written.`
}
```
I am new to Go 🙇 . I have pretty much duplicated the existing tests for bind methods with `Should` equivalents. Please let me know if anything needs to be changed.

Related issues - #629, #633, #662, #782, #811
Related PR - #636, #661
Closes #840