### PR TITLE
fix(travis): remove using the development version of Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ go:
   - 1.6.x
   - 1.7.x
   - 1.8.x
-  - master
 
 git:
   depth: 3


### PR DESCRIPTION
Because the latest development version of Go don't pass pre-existing unit test. We should only use stable version.

```
--- FAIL: TestRouterNotFound (0.00s)
	Error Trace:	routes_test.go:396
	Error:		Not equal: 
			expected: "map[Location:[/path] Content-Type:[text/html; charset=utf-8]]"
			received: "map[Location:[/path]]"
```
See:
- https://travis-ci.org/gin-gonic/gin/jobs/262113482
- https://travis-ci.org/gin-gonic/gin/jobs/262229709
- https://travis-ci.org/gin-gonic/gin/jobs/263348918
- https://travis-ci.org/gin-gonic/gin/jobs/263774413