### PR TITLE
Fix colored logger on windows

### DIFF
--- a/mode.go
+++ b/mode.go
@@ -28,9 +28,6 @@ const (
 // middleware output like Logger() or Recovery().
 // Note that both Logger and Recovery provides custom ways to configure their
 // output io.Writer.
-// To support coloring in Windows use:
-// 		import "github.com/mattn/go-colorable"
-// 		gin.DefaultWriter = colorable.NewColorableStdout()
 var DefaultWriter io.Writer = os.Stdout
 var DefaultErrorWriter io.Writer = os.Stderr
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -46,6 +46,12 @@
 			"revisionTime": "2015-05-31T20:46:25Z"
 		},
 		{
+			"checksumSHA1": "cTDA66oZUy18cIzJsU1diKq+9CE=",
+			"path": "github.com/mattn/go-colorable",
+			"revision": "ad5389df28cdac544c99bd7b9161a0b5b6ca9d1b",
+			"revisionTime": "2017-08-16T03:18:13Z"
+		},
+		{
 			"checksumSHA1": "U6lX43KDDlNOn+Z0Yyww+ZzHfFo=",
 			"path": "github.com/mattn/go-isatty",
 			"revision": "57fdcb988a5c543893cc61bce354a6e24ab70022",
@@ -91,7 +97,7 @@
 			"revisionTime": "2016-10-18T08:54:36Z"
 		},
 		{
-			"checksumSHA1": "TVEkpH3gq84iQ39I4R+mlDwjuVI=",
+			"checksumSHA1": "/oZpHfYc+ZgOwYAhlvcMhmETYpw=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "99f16d856c9836c42d24e7ab64ea72916925fa97",
 			"revisionTime": "2017-03-08T15:04:45Z"


### PR DESCRIPTION
In the previous version
```go
isTerm := true

if w, ok := out.(*os.File); !ok ||
	(os.Getenv("TERM") == "dumb" || (!isatty.IsTerminal(w.Fd()) && !isatty.IsCygwinTerminal(w.Fd()))) ||
	disableColor {
	isTerm = false
}
```

when `out` comes from `colorable.NewColorableStdout()` as [the doc suggested](https://github.com/gin-gonic/gin/blob/master/mode.go#L31), `out` will actually be `*colorable.Writer` type and will fail the type assertion `out.(*os.File)`, but `out` here, wrapped by `colorable`, is indeed a valid terminal that supports colors.

```go
package main

import (
	"fmt"
	"os"

	"github.com/mattn/go-colorable"
)

func main() {
	colored := colorable.NewColorableStdout()
	_, ok := colored.(*os.File)
	fmt.Println(ok) //=> false
}
```

Instead of judging whether `out` is an `io.Writer` wrapped by `colorable` or not in the case, I tried to utilize `github.com/mattn/go-colorable` directly here. Hopefully it's acceptable.

@mattn I think an `io.Writer` wrapped by `colorable` should be considered a terminal, but it may be hard to apply this to your `github.com/mattn/go-isatty`, as `github.com/mattn/go-colorable` depends on it and making the former depends on the latter may lead to circular reference.