### PR TITLE
fix AbortWithStatus(),delete c.Writer.WriteHeaderNow()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/*
 !vendor/vendor.json
 coverage.out
 count.out
+.idea/

--- a/context.go
+++ b/context.go
@@ -125,7 +125,7 @@ func (c *Context) Abort() {
 // For example, a failed attempt to authenticate a request could use: context.AbortWithStatus(401).
 func (c *Context) AbortWithStatus(code int) {
 	c.Status(code)
-	c.Writer.WriteHeaderNow()
+	//c.Writer.WriteHeaderNow()
 	c.Abort()
 }
 


### PR DESCRIPTION
In the same handler ,c.AbortWithStatus() cannot termination procedure. so ,if without c.Writer.WriteHeaderNow(), the http status can be replaced or not.
  because i only want to return the http status 200ok,other error codes can be placed in the reply JSON.