### PR TITLE
use interface{} in map

### DIFF
--- a/context.go
+++ b/context.go
@@ -49,7 +49,7 @@ type Context struct {
 	engine *Engine
 
 	// Keys is a key/value pair exclusively for the context of each request.
-	Keys map[string]interface{}
+	Keys map[interface{}]interface{}
 
 	// Errors is a list of errors attached to all the handlers/middlewares who used this context.
 	Errors errorMsgs
@@ -178,30 +178,32 @@ func (c *Context) Error(err error) *Error {
 
 // Set is used to store a new key/value pair exclusively for this context.
 // It also lazy initializes  c.Keys if it was not used previously.
-func (c *Context) Set(key string, value interface{}) {
+func (c *Context) Set(key, value interface{}) {
 	if c.Keys == nil {
-		c.Keys = make(map[string]interface{})
+		c.Keys = make(map[interface{}]interface{})
 	}
 	c.Keys[key] = value
 }
 
 // Get returns the value for the given key, ie: (value, true).
 // If the value does not exists it returns (nil, false)
-func (c *Context) Get(key string) (value interface{}, exists bool) {
-	value, exists = c.Keys[key]
+func (c *Context) Get(key interface{}) (value interface{}, exists bool) {
+	if c.Keys != nil {
+		value, exists = c.Keys[key]
+	}
 	return
 }
 
 // MustGet returns the value for the given key if it exists, otherwise it panics.
-func (c *Context) MustGet(key string) interface{} {
+func (c *Context) MustGet(key interface{}) interface{} {
 	if value, exists := c.Get(key); exists {
 		return value
 	}
-	panic("Key \"" + key + "\" does not exist")
+	panic(fmt.Sprintf("Key %v does not exist", key))
 }
 
 // GetString returns the value associated with the key as a string.
-func (c *Context) GetString(key string) (s string) {
+func (c *Context) GetString(key interface{}) (s string) {
 	if val, ok := c.Get(key); ok && val != nil {
 		s, _ = val.(string)
 	}
@@ -209,7 +211,7 @@ func (c *Context) GetString(key string) (s string) {
 }
 
 // GetBool returns the value associated with the key as a boolean.
-func (c *Context) GetBool(key string) (b bool) {
+func (c *Context) GetBool(key interface{}) (b bool) {
 	if val, ok := c.Get(key); ok && val != nil {
 		b, _ = val.(bool)
 	}

--- a/context.go
+++ b/context.go
@@ -6,6 +6,7 @@ package gin
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math"


### PR DESCRIPTION
Prevents possible collision when using string keys, and uses package's data types.

Example usage:

```
package mypackage_with_keys

type _someKeyType int

const (
	CustomKey someKeyType = iota
	AnotherKey
)

func GetCustomData(c *Context) (...) {
	o, has := c.Get(CustomKey)
        .....
	return
}
```