### PR TITLE
check parameter in path

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -21,6 +21,7 @@ const (
 )
 
 var (
+	default400Body   = []byte("400 parameter invalid")
 	default404Body   = []byte("404 page not found")
 	default405Body   = []byte("405 method not allowed")
 	defaultAppEngine bool
@@ -346,6 +347,13 @@ func (engine *Engine) handleHTTPRequest(c *Context) {
 			root := t[i].root
 			// Find route in tree
 			handlers, params, tsr := root.getValue(path, c.Params, unescape)
+			// Check parameter in path
+			for _, item := range params {
+				if ":"+item.Key == item.Value {
+					serveError(c, http.StatusBadRequest, default400Body)
+					return
+				}
+			}
 			if handlers != nil {
 				c.handlers = handlers
 				c.Params = params

--- a/gin_integration_test.go
+++ b/gin_integration_test.go
@@ -133,3 +133,22 @@ func TestWithHttptestWithAutoSelectedPort(t *testing.T) {
 
 // 	testRequest(t, "http://localhost:8033/example")
 // }
+
+func TestParameterInPath(t *testing.T) {
+	router := New()
+
+	go func() {
+		router.GET("/user/:name", func(c *Context) { c.String(http.StatusOK, "it worked") })
+		assert.NoError(t, router.Run(":4123"))
+	}()
+	// have to wait for the goroutine to start and run the server
+	// otherwise the main thread will complete
+	time.Sleep(5 * time.Millisecond)
+
+	resp, err := http.Get("http://localhost:4123/user/:name")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "400 Bad Request", resp.Status, "should get a 400")
+	testRequest(t, "http://localhost:4123/user/gin")
+}


### PR DESCRIPTION
Gin takes `:` and `name` as tag of parameter in path, such as `http://localhost:4123/user/:name`. If gin get the request `http://localhost:4123/user/:name`, gin will accept it, it will be better if gin respond with 400 because the format `:name` should be only used by gin clearly.