### PR TITLE
Make "" mode being the same as debug mode

### DIFF
--- a/mode.go
+++ b/mode.go
@@ -53,6 +53,9 @@ func SetMode(value string) {
 	default:
 		panic("gin mode unknown: " + value)
 	}
+	if value == "" {
+		value = DebugMode
+	}
 	modeName = value
 }
 

--- a/mode_test.go
+++ b/mode_test.go
@@ -21,6 +21,10 @@ func TestSetMode(t *testing.T) {
 	assert.Equal(t, TestMode, Mode())
 	os.Unsetenv(ENV_GIN_MODE)
 
+	SetMode("")
+	assert.Equal(t, debugCode, ginMode)
+	assert.Equal(t, DebugMode, Mode())
+
 	SetMode(DebugMode)
 	assert.Equal(t, debugCode, ginMode)
 	assert.Equal(t, DebugMode, Mode())


### PR DESCRIPTION
Not setting mode explicitly sets gin into debug mode, but it does not
make it possible to retrieve gin mode as Debug since it's set to "".
Calling `gin.Mode()` returns "" even though gin is in debug mode.

The alternative approach is to change SetMode to not accept "" and make `init` function calling `SetMode(DebugMode)` explicitly when the mode is not defined. That would definitely change how SetMode reacts to inputs and could break some apps.