### PR TITLE
add gin panic time log

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http/httputil"
 	"runtime"
+	"time"
 )
 
 var (
@@ -38,7 +39,7 @@ func RecoveryWithWriter(out io.Writer) HandlerFunc {
 				if logger != nil {
 					stack := stack(3)
 					httprequest, _ := httputil.DumpRequest(c.Request, false)
-					logger.Printf("[Recovery] panic recovered:\n%s\n%s\n%s%s", string(httprequest), err, stack, reset)
+					logger.Printf("[Recovery] %s panic recovered:\n%s\n%s\n%s%s", timeFormat(time.Now()), string(httprequest), err, stack, reset)
 				}
 				c.AbortWithStatus(500)
 			}
@@ -106,4 +107,10 @@ func function(pc uintptr) []byte {
 	}
 	name = bytes.Replace(name, centerDot, dot, -1)
 	return name
+}
+
+func timeFormat(t time.Time) string {
+	var nowTime = time.Now()
+	var timeString = nowTime.Format("2006/01/02 - 15:04:05")
+	return timeString
 }

--- a/recovery.go
+++ b/recovery.go
@@ -110,7 +110,6 @@ func function(pc uintptr) []byte {
 }
 
 func timeFormat(t time.Time) string {
-	var nowTime = time.Now()
-	var timeString = nowTime.Format("2006/01/02 - 15:04:05")
+	var timeString = t.Format("2006/01/02 - 15:04:05")
 	return timeString
 }


### PR DESCRIPTION
I found that gin printed the current stack information in panic, but there was no time to print panic, and it was hard to know when the panic occurred.