### PR TITLE
Updated the Model binding and validation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,15 +448,14 @@ Gin uses [**go-playground/validator.v8**](https://github.com/go-playground/valid
 
 Note that you need to set the corresponding binding tag on all fields you want to bind. For example, when binding from JSON, set `json:"fieldname"`.
 
-Also, Gin provides two sets of methods for binding:
-- **Type** - Must bind
-  - **Methods** - `Bind`, `BindJSON`, `BindQuery`
-  - **Behavior** - These methods use `MustBindWith` under the hood. If there is a binding error, the request is aborted with `c.AbortWithError(400, err).SetType(ErrorTypeBind)`. This sets the response status code to 400 and the `Content-Type` header is set to `text/plain; charset=utf-8`. Note that if you try to set the response code after this, it will result in a warning `[GIN-debug] [WARNING] Headers were already written. Wanted to override status code 400 with 422`. If you wish to have greater control over the behavior, consider using the `ShouldBind` equivalent method.
-- **Type** - Should bind
-  - **Methods** - `ShouldBind`, `ShouldBindJSON`, `ShouldBindQuery`
-  - **Behavior** - These methods use `ShouldBindWith` under the hood. If there is a binding error, the error is returned and it is the developer's responsibility to handle the request and error appropriately.
+Also, Gin provides methods for binding:  
+ - **Bind** - Uses the `MustBindWith` method under the hood passing the binding recognized from the `Content-Type` header.
+ - **BindJSON** - Uses the `MustBindWith` method under the hood as well, but passing the `binding.JSON` as the binding.
+ - **MustBindWith** - If there is a binding error, the request is aborted with `c.AbortWithError(400, err).SetType(ErrorTypeBind)`. This sets the response status code to 400 and the `Content-Type` header is set to `text/plain; charset=utf-8`. Note that if you try to set the response code after this, it will result in a warning `[GIN-debug] [WARNING] Headers were already written. Wanted to override status code 400 with 422`. If you wish to have greater control over the behavior, consider using the `ShouldBindWith` equivalent method.
+- **ShouldBindWith** - If there is a binding error, the error is returned and it is the developer's responsibility to handle the request and error appropriately.
 
-When using the Bind-method, Gin tries to infer the binder depending on the Content-Type header. If you are sure what you are binding, you can use `MustBindWith` or `ShouldBindWith`.
+When using the `Bind` method, Gin tries to infer the binder depending on the Content-Type header. 
+Possible bindings are: `jsonBinding`, `xmlBinding`, `formBinding`, `formPostBinding`, `formMultipartBinding`, `protobufBinding` and `msgpackBinding`.
 
 You can also specify that specific fields are required. If a field is decorated with `binding:"required"` and has a empty value when binding, an error will be returned.
 
@@ -473,7 +472,7 @@ func main() {
 	// Example for binding JSON ({"user": "manu", "password": "123"})
 	router.POST("/loginJSON", func(c *gin.Context) {
 		var json Login
-		if err := c.ShouldBindJSON(&json); err == nil {
+		if err := c.BindJSON(&json); err == nil {
 			if json.User == "manu" && json.Password == "123" {
 				c.JSON(http.StatusOK, gin.H{"status": "you are logged in"})
 			} else {
@@ -488,7 +487,7 @@ func main() {
 	router.POST("/loginForm", func(c *gin.Context) {
 		var form Login
 		// This will infer what binder to use depending on the content-type header.
-		if err := c.ShouldBind(&form); err == nil {
+		if err := c.Bind(&form); err == nil {
 			if form.User == "manu" && form.Password == "123" {
 				c.JSON(http.StatusOK, gin.H{"status": "you are logged in"})
 			} else {


### PR DESCRIPTION
The **Model binding and validation** section was outdated, showing the old methods that Gin does not provide anymore.
I've replaced the old ones with the new ones and changed the explanations of their functionality.