### PR TITLE
Adjust log format to cater for ipv6 values

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -103,7 +103,7 @@ func LoggerWithWriter(out io.Writer, notlogged ...string) HandlerFunc {
 				path = path + "?" + raw
 			}
 
-			fmt.Fprintf(out, "[GIN] %v |%s %3d %s| %13v | %15s |%s %-7s %s %s\n%s",
+			fmt.Fprintf(out, "[GIN] %v |%s %3d %s| %13v | %39s |%s %-7s %s %s\n%s",
 				end.Format("2006/01/02 - 15:04:05"),
 				statusColor, statusCode, resetColor,
 				latency,


### PR DESCRIPTION
Should fix #1267 

The length might seem drastic, but from [what I understand](https://github.com/gin-gonic/gin/issues/1267) a v6 IP might actually grow up to that length:

> IPv6 addresses are represented as eight groups of four hexadecimal digits with the groups being separated by colons, for example 2001:0db8:0000:0042:0000:8a2e:0370:7334, but methods to abbreviate this full notation exist.

