### PR TITLE
doc(graceful-shutdown): failure to ListenAndServe should be a reason to exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1324,8 +1324,8 @@ func main() {
 
 	go func() {
 		// service connections
-		if err := srv.ListenAndServe(); err != nil {
-			log.Printf("listen: %s\n", err)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("listen: %s\n", err)
 		}
 	}()
 

--- a/examples/graceful-shutdown/graceful-shutdown/server.go
+++ b/examples/graceful-shutdown/graceful-shutdown/server.go
@@ -27,8 +27,8 @@ func main() {
 
 	go func() {
 		// service connections
-		if err := srv.ListenAndServe(); err != nil {
-			log.Printf("listen: %s\n", err)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("listen: %s\n", err)
 		}
 	}()
 


### PR DESCRIPTION
In "graceful-shutdown" examples, ListenAndServe errors are checked but just to be logged.
If port is already used by another program, program will start, fail to bind, but still run, waiting for a sigterm.

Also handling error "ErrServerClosed" which is triggered by Shutdown and should be considered as a legit error.