### PR TITLE
Add support of pointers in form binding

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -112,6 +112,12 @@ func setWithProperType(valueKind reflect.Kind, val string, structField reflect.V
 		return setFloatField(val, 64, structField)
 	case reflect.String:
 		structField.SetString(val)
+	case reflect.Ptr:
+		if !structField.Elem().IsValid() {
+			structField.Set(reflect.New(structField.Type().Elem()))
+		}
+		structFieldElem := structField.Elem()
+		return setWithProperType(structFieldElem.Kind(), val, structFieldElem)
 	default:
 		return errors.New("Unknown type")
 	}


### PR DESCRIPTION
Useful in case if you need to bind the form to the following structure:

```
type input struct {
	Field *string `form:"field" binding:"omitempty,max=128"`
}
```