### PR TITLE
Fix #216: Enable to call binding multiple times in some formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Gin is a web framework written in Go (Golang). It features a martini-like API wi
     - [Graceful restart or stop](#graceful-restart-or-stop)
     - [Build a single binary with templates](#build-a-single-binary-with-templates)
     - [Bind form-data request with custom struct](#bind-form-data-request-with-custom-struct)
+    - [Try to bind body into different structs](#try-to-bind-body-into-different-structs)
 - [Testing](#testing)
 - [Users](#users--)
 
@@ -1553,6 +1554,64 @@ type StructZ struct {
 ```
 
 In a word, only support nested custom struct which have no `form` now.
+
+### Try to bind body into different structs
+
+The normal methods for binding request body consumes `c.Request.Body` and they
+cannot be called multiple times.
+
+```go
+type formA struct {
+  Foo string `json:"foo" xml:"foo" binding:"required"`
+}
+
+type formB struct {
+  Bar string `json:"bar" xml:"bar" binding:"required"`
+}
+
+func SomeHandler(c *gin.Context) {
+  objA := formA{}
+  objB := formB{}
+  // This c.ShouldBind consumes c.Request.Body and it cannot be reused.
+  if errA := c.ShouldBind(&objA); errA == nil {
+    c.String(http.StatusOK, `the body should be formA`)
+  // Always an error is occurred by this because c.Request.Body is EOF now.
+  } else if errB := c.ShouldBind(&objB); errB == nil {
+    c.String(http.StatusOK, `the body should be formB`)
+  } else {
+    ...
+  }
+}
+```
+
+For this, you can use `c.ShouldBindBodyWith`.
+
+```go
+func SomeHandler(c *gin.Context) {
+  objA := formA{}
+  objB := formB{}
+  // This reads c.Request.Body and stores the result into the context.
+  if errA := c.ShouldBindBodyWith(&objA, binding.JSON); errA == nil {
+    c.String(http.StatusOK, `the body should be formA`)
+  // At this time, it reuses body stored in the context.
+  } else if errB := c.ShouldBindBodyWith(&objB, binding.JSON); errB == nil {
+    c.String(http.StatusOK, `the body should be formB JSON`)
+  // And it can accepts other formats
+  } else if errB2 := c.ShouldBindBodyWith(&objB, binding.XML); errB2 == nil {
+    c.String(http.StatusOK, `the body should be formB XML`)
+  } else {
+    ...
+  }
+}
+```
+
+* `c.ShouldBindBodyWith` stores body into the context before binding. This has
+a slight impact to performance, so you should not use this method if you are
+enough to call binding at once.
+* This feature is only needed for some formats -- `JSON`, `XML`, `MsgPack`,
+`ProtoBuf`. For other formats, `Query`, `Form`, `FormPost`, `FormMultipart`,
+can be called by `c.ShouldBind()` multiple times without any damage to
+performance (See [#1341](https://github.com/gin-gonic/gin/pull/1341)).
 
 ## Testing
 

--- a/binding/binding.go
+++ b/binding/binding.go
@@ -29,6 +29,13 @@ type Binding interface {
 	Bind(*http.Request, interface{}) error
 }
 
+// BindingBody adds BindBody method to Binding.  BindBody is similar with Bind,
+// but it reads the body from supplied bytes instead of req.Body.
+type BindingBody interface {
+	Binding
+	BindBody([]byte, interface{}) error
+}
+
 // StructValidator is the minimal interface which needs to be implemented in
 // order for it to be used as the validator engine for ensuring the correctness
 // of the reqest. Gin provides a default implementation for this using

--- a/binding/binding.go
+++ b/binding/binding.go
@@ -29,7 +29,7 @@ type Binding interface {
 	Bind(*http.Request, interface{}) error
 }
 
-// BindingBody adds BindBody method to Binding.  BindBody is similar with Bind,
+// BindingBody adds BindBody method to Binding. BindBody is similar with Bind,
 // but it reads the body from supplied bytes instead of req.Body.
 type BindingBody interface {
 	Binding

--- a/binding/binding_body_test.go
+++ b/binding/binding_body_test.go
@@ -1,0 +1,67 @@
+package binding
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/gin-gonic/gin/binding/example"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/ugorji/go/codec"
+)
+
+func TestBindingBody(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		binding BindingBody
+		body    string
+		want    string
+	}{
+		{
+			name:    "JSON bidning",
+			binding: JSON,
+			body:    `{"foo":"FOO"}`,
+		},
+		{
+			name:    "XML bidning",
+			binding: XML,
+			body: `<?xml version="1.0" encoding="UTF-8"?>
+<root>
+   <foo>FOO</foo>
+</root>`,
+		},
+		{
+			name:    "MsgPack binding",
+			binding: MsgPack,
+			body:    msgPackBody(t),
+		},
+	} {
+		t.Logf("testing: %s", tt.name)
+		req := requestWithBody("POST", "/", tt.body)
+		form := FooStruct{}
+		body, _ := ioutil.ReadAll(req.Body)
+		assert.NoError(t, tt.binding.BindBody(body, &form))
+		assert.Equal(t, FooStruct{"FOO"}, form)
+	}
+}
+
+func msgPackBody(t *testing.T) string {
+	test := FooStruct{"FOO"}
+	h := new(codec.MsgpackHandle)
+	buf := bytes.NewBuffer(nil)
+	assert.NoError(t, codec.NewEncoder(buf, h).Encode(test))
+	return buf.String()
+}
+
+func TestBindingBodyProto(t *testing.T) {
+	test := example.Test{
+		Label: proto.String("FOO"),
+	}
+	data, _ := proto.Marshal(&test)
+	req := requestWithBody("POST", "/", string(data))
+	form := example.Test{}
+	body, _ := ioutil.ReadAll(req.Body)
+	assert.NoError(t, ProtoBuf.BindBody(body, &form))
+	assert.Equal(t, test, form)
+}

--- a/binding/json.go
+++ b/binding/json.go
@@ -5,6 +5,8 @@
 package binding
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 
 	"github.com/gin-gonic/gin/json"
@@ -22,7 +24,15 @@ func (jsonBinding) Name() string {
 }
 
 func (jsonBinding) Bind(req *http.Request, obj interface{}) error {
-	decoder := json.NewDecoder(req.Body)
+	return decodeJSON(req.Body, obj)
+}
+
+func (jsonBinding) BindBody(body []byte, obj interface{}) error {
+	return decodeJSON(bytes.NewReader(body), obj)
+}
+
+func decodeJSON(r io.Reader, obj interface{}) error {
+	decoder := json.NewDecoder(r)
 	if EnableDecoderUseNumber {
 		decoder.UseNumber()
 	}

--- a/binding/msgpack.go
+++ b/binding/msgpack.go
@@ -5,6 +5,8 @@
 package binding
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 
 	"github.com/ugorji/go/codec"
@@ -17,7 +19,16 @@ func (msgpackBinding) Name() string {
 }
 
 func (msgpackBinding) Bind(req *http.Request, obj interface{}) error {
-	if err := codec.NewDecoder(req.Body, new(codec.MsgpackHandle)).Decode(&obj); err != nil {
+	return decodeMsgPack(req.Body, obj)
+}
+
+func (msgpackBinding) BindBody(body []byte, obj interface{}) error {
+	return decodeMsgPack(bytes.NewReader(body), obj)
+}
+
+func decodeMsgPack(r io.Reader, obj interface{}) error {
+	cdc := new(codec.MsgpackHandle)
+	if err := codec.NewDecoder(r, cdc).Decode(&obj); err != nil {
 		return err
 	}
 	return validate(obj)

--- a/binding/protobuf.go
+++ b/binding/protobuf.go
@@ -17,19 +17,20 @@ func (protobufBinding) Name() string {
 	return "protobuf"
 }
 
-func (protobufBinding) Bind(req *http.Request, obj interface{}) error {
-
+func (b protobufBinding) Bind(req *http.Request, obj interface{}) error {
 	buf, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		return err
 	}
+	return b.BindBody(buf, obj)
+}
 
-	if err = proto.Unmarshal(buf, obj.(proto.Message)); err != nil {
+func (protobufBinding) BindBody(body []byte, obj interface{}) error {
+	if err := proto.Unmarshal(body, obj.(proto.Message)); err != nil {
 		return err
 	}
-
-	//Here it's same to return validate(obj), but util now we cann't add `binding:""` to the struct
-	//which automatically generate by gen-proto
+	// Here it's same to return validate(obj), but util now we cann't add
+	// `binding:""` to the struct which automatically generate by gen-proto
 	return nil
-	//return validate(obj)
+	// return validate(obj)
 }

--- a/binding/xml.go
+++ b/binding/xml.go
@@ -5,7 +5,9 @@
 package binding
 
 import (
+	"bytes"
 	"encoding/xml"
+	"io"
 	"net/http"
 )
 
@@ -16,7 +18,14 @@ func (xmlBinding) Name() string {
 }
 
 func (xmlBinding) Bind(req *http.Request, obj interface{}) error {
-	decoder := xml.NewDecoder(req.Body)
+	return decodeXML(req.Body, obj)
+}
+
+func (xmlBinding) BindBody(body []byte, obj interface{}) error {
+	return decodeXML(bytes.NewReader(body), obj)
+}
+func decodeXML(r io.Reader, obj interface{}) error {
+	decoder := xml.NewDecoder(r)
 	if err := decoder.Decode(obj); err != nil {
 		return err
 	}

--- a/context.go
+++ b/context.go
@@ -512,7 +512,7 @@ func (c *Context) ShouldBindWith(obj interface{}, b binding.Binding) error {
 // ShouldBindBodyWith is similar with ShouldBindWith, but it stores the request
 // body into the context, and reuse when it is called again.
 //
-// NOTE: This method reads the body before binding.  So you should use
+// NOTE: This method reads the body before binding. So you should use
 // ShouldBindWith for better performance if you need to call only once.
 func (c *Context) ShouldBindBodyWith(
 	obj interface{}, bb binding.BindingBody,

--- a/context.go
+++ b/context.go
@@ -31,7 +31,7 @@ const (
 	MIMEPlain             = binding.MIMEPlain
 	MIMEPOSTForm          = binding.MIMEPOSTForm
 	MIMEMultipartPOSTForm = binding.MIMEMultipartPOSTForm
-	BindBodyBytesKey      = "github.com/gin-gonic/gin/bindBodyBytes"
+	BodyBytesKey          = "github.com/gin-gonic/gin/bodyBytes"
 )
 
 const abortIndex int8 = math.MaxInt8 / 2
@@ -518,7 +518,7 @@ func (c *Context) ShouldBindBodyWith(
 	obj interface{}, bb binding.BindingBody,
 ) (err error) {
 	var body []byte
-	if cb, ok := c.Get(BindBodyBytesKey); ok {
+	if cb, ok := c.Get(BodyBytesKey); ok {
 		if cbb, ok := cb.([]byte); ok {
 			body = cbb
 		}
@@ -528,7 +528,7 @@ func (c *Context) ShouldBindBodyWith(
 		if err != nil {
 			return err
 		}
-		c.Set(BindBodyBytesKey, body)
+		c.Set(BodyBytesKey, body)
 	}
 	return bb.BindBody(body, obj)
 }

--- a/context.go
+++ b/context.go
@@ -31,7 +31,7 @@ const (
 	MIMEPlain             = binding.MIMEPlain
 	MIMEPOSTForm          = binding.MIMEPOSTForm
 	MIMEMultipartPOSTForm = binding.MIMEMultipartPOSTForm
-	BodyBytesKey          = "github.com/gin-gonic/gin/bodyBytes"
+	BodyBytesKey          = "_gin-gonic/gin/bodybyteskey"
 )
 
 const abortIndex int8 = math.MaxInt8 / 2

--- a/context.go
+++ b/context.go
@@ -31,6 +31,7 @@ const (
 	MIMEPlain             = binding.MIMEPlain
 	MIMEPOSTForm          = binding.MIMEPOSTForm
 	MIMEMultipartPOSTForm = binding.MIMEMultipartPOSTForm
+	BodyBytesKey          = "github.com/gin-gonic/gin/bodyBytes"
 )
 
 const abortIndex int8 = math.MaxInt8 / 2
@@ -506,6 +507,30 @@ func (c *Context) ShouldBindQuery(obj interface{}) error {
 // See the binding package.
 func (c *Context) ShouldBindWith(obj interface{}, b binding.Binding) error {
 	return b.Bind(c.Request, obj)
+}
+
+// ShouldBindBodyWith is similar with ShouldBindWith, but it stores the request
+// body into the context, and reuse when it is called again.
+//
+// NOTE: This method reads the body before binding.  So you should use
+// ShouldBindWith for better performance if you need to call only once.
+func (c *Context) ShouldBindBodyWith(
+	obj interface{}, bb binding.BindingBody,
+) (err error) {
+	var body []byte
+	if cb, ok := c.Get(BodyBytesKey); ok {
+		if cbb, ok := cb.([]byte); ok {
+			body = cbb
+		}
+	}
+	if body == nil {
+		body, err = ioutil.ReadAll(c.Request.Body)
+		if err != nil {
+			return err
+		}
+		c.Set(BodyBytesKey, body)
+	}
+	return bb.BindBody(body, obj)
 }
 
 // ClientIP implements a best effort algorithm to return the real client IP, it parses

--- a/context.go
+++ b/context.go
@@ -31,7 +31,7 @@ const (
 	MIMEPlain             = binding.MIMEPlain
 	MIMEPOSTForm          = binding.MIMEPOSTForm
 	MIMEMultipartPOSTForm = binding.MIMEMultipartPOSTForm
-	BodyBytesKey          = "github.com/gin-gonic/gin/bodyBytes"
+	BindBodyBytesKey      = "github.com/gin-gonic/gin/bindBodyBytes"
 )
 
 const abortIndex int8 = math.MaxInt8 / 2
@@ -518,7 +518,7 @@ func (c *Context) ShouldBindBodyWith(
 	obj interface{}, bb binding.BindingBody,
 ) (err error) {
 	var body []byte
-	if cb, ok := c.Get(BodyBytesKey); ok {
+	if cb, ok := c.Get(BindBodyBytesKey); ok {
 		if cbb, ok := cb.([]byte); ok {
 			body = cbb
 		}
@@ -528,7 +528,7 @@ func (c *Context) ShouldBindBodyWith(
 		if err != nil {
 			return err
 		}
-		c.Set(BodyBytesKey, body)
+		c.Set(BindBodyBytesKey, body)
 	}
 	return bb.BindBody(body, obj)
 }


### PR DESCRIPTION
close #216 

## Reported problems

#216 says some formats in requests' body cannot be bound into different structs by calling multiple times.

```go
type modelA struct {
  Foo string `form:"foo" json:"foo" binding:"required"`
  Bar int64  `form:"bar" json:"bar" binding:"required"`
}

type modelB struct {
  Hoge string `form:"hoge" json:"hoge" xml:"hoge" binding:"required"`
  Fuga int64  `form:"fuga" json:"fuga" xml:"fuga" binding:"required"`
}

func main() {
  r := gin.New()
  r.POST("/json", func(c *gin.Context) {
    fa, fb := modelA{}, modelB{}
    if aerr := c.ShouldBindWith(&fa, binding.JSON); aerr == nil {
      c.JSON(http.StatusOK, gin.H{"form": fa})
    } else if berr := c.ShouldBindWith(&fb, binding.JSON); berr == nil {
      c.JSON(http.StatusOK, gin.H{"form": fb})
    } else {
      c.AbortWithStatusJSON(
        http.StatusBadRequest,
        gin.H{
          "errors": gin.H{
            "modelA": aerr.Error(),
            "modelB": berr.Error(),
          },
        },
      )
    }
  })
  r.Run("0:8080")
}
```

```sh
# modelA can be bound successfully
$ curl -X POST -d '{"foo":"AAA","bar":123}' 0:8080/json | jq
{
  "form": {
    "foo": "AAA",
    "bar": 123
  }
}

# but modelB cannot
$ curl -X POST -d '{"hoge":"BBB","fuga":123}' 0:8080/json | jq
{
  "errors": {
    "modelA": "Key: 'modelA.Bar' Error:Field validation for 'Bar' failed on the 'req
ired' tag\nKey: 'modelA.Foo' Error:Field validation for 'Foo' failed on the 'require
' tag",
    "modelB": "EOF"
  }
}
```

## Proposal to solve this

This PR solves this by adding a new interface `binding.BindingBody` & a new method `c.ShouldBindBodyWith`.

```go
...
    // use ShouldBindBodyWith
    if aerr := c.ShouldBindBodyWith(&fa, binding.JSON); aerr == nil {
      c.JSON(http.StatusOK, gin.H{"form": fa})
    } else if berr := c.ShouldBindBodyWith(&fb, binding.JSON); berr == nil {
      c.JSON(http.StatusOK, gin.H{"form": fb})
    } else {
...
```

```sh
# successfully modelB bound
$ curl -X POST -d '{"hoge":"BBB","fuga":123}' 0:8080/json | jq
{
  "form": {
    "hoge": "BBB",
    "fuga": 123
  }
}
```

And you can mix different formats.

```go
...
    if aerr := c.ShouldBindBodyWith(&fa, binding.JSON); aerr == nil {
      c.JSON(http.StatusOK, gin.H{"form": fa})
    } else if berr := c.ShouldBindBodyWith(&fb, binding.XML); berr == nil {
      c.JSON(http.StatusOK, gin.H{"form": fb})
    } else {
...
```

```sh
$ curl -X POST -d '<?xml version="1.0" encoding="UTF-8"?>\n<root>\n<fuga>123</fuga>\n<hoge>BBB</hoge>\n</root>' 0:8080/json | jq
{
  "form": {
    "hoge": "BBB",
    "fuga": 123
  }
}
```

I added implementations for JSON, XML, msgpack and protobuf.  Other formats, query & forms, are already available to be called multiple times, because they uses parsed `req.Form (url.Values)` instead of `req.Body`.

## Question

* If you prefer to this feature, I will add unit tests.
* I'm worrying about cool naming for `bind.BindingBody`, `c.ShouldBindBodyWith`.  I'm happy if you give better names.