### PR TITLE
move golang.org/x/net/context.Context interface

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-contrib/sse"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"context"
 )
 
 var _ context.Context = &Context{}


### PR DESCRIPTION
Keeping up with the context.go, move golang.org/x/net/context.Context interface