### PR TITLE
drop dependence on golang.org/x/net/context.Context

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-contrib/sse"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"context"
 )
 
 var _ context.Context = &Context{}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -96,13 +96,6 @@
 			"revisionTime": "2017-06-19T06:03:41Z"
 		},
 		{
-			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",
-			"comment": "release-branch.go1.7",
-			"path": "golang.org/x/net/context",
-			"revision": "d4c55e66d8c3a2f3382d264b08e3e3454a66355a",
-			"revisionTime": "2016-10-18T08:54:36Z"
-		},
-		{
 			"checksumSHA1": "S0DP7Pn7sZUmXc55IzZnNvERu6s=",
 			"path": "golang.org/x/sync/errgroup",
 			"revision": "8e0aa688b654ef28caa72506fa5ec8dba9fc7690",


### PR DESCRIPTION
now is 2018,  go1.10 released. May be, it does not necessary for checking the implementation of the x/net/context.Context interface. Just stand lib is enough.