### PR TITLE
fix bug, return err when failed binding bool

### DIFF
--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -91,6 +91,10 @@ type FooStructForSliceMapType struct {
 	SliceMapFoo []map[string]interface{} `form:"slice_map_foo"`
 }
 
+type FooStructForBoolType struct {
+	BoolFoo bool `form:"bool_foo"`
+}
+
 type FooBarStructForIntType struct {
 	IntFoo int `form:"int_foo"`
 	IntBar int `form:"int_bar" binding:"required"`
@@ -447,6 +451,12 @@ func TestBindingQueryFail2(t *testing.T) {
 	testQueryBindingFail(t, "GET",
 		"/?map_foo=", "/?bar2=foo",
 		"map_foo=unused", "")
+}
+
+func TestBindingQueryBoolFail(t *testing.T) {
+	testQueryBindingBoolFail(t, "GET",
+		"/?bool_foo=fasl", "/?bar2=foo",
+		"bool_foo=unused", "")
 }
 
 func TestBindingXML(t *testing.T) {
@@ -1055,6 +1065,19 @@ func testQueryBindingFail(t *testing.T, method, path, badPath, body, badBody str
 	assert.Equal(t, "query", b.Name())
 
 	obj := FooStructForMapType{}
+	req := requestWithBody(method, path, body)
+	if method == "POST" {
+		req.Header.Add("Content-Type", MIMEPOSTForm)
+	}
+	err := b.Bind(req, &obj)
+	assert.Error(t, err)
+}
+
+func testQueryBindingBoolFail(t *testing.T, method, path, badPath, body, badBody string) {
+	b := Query
+	assert.Equal(t, "query", b.Name())
+
+	obj := FooStructForBoolType{}
 	req := requestWithBody(method, path, body)
 	if method == "POST" {
 		req.Header.Add("Content-Type", MIMEPOSTForm)

--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -161,7 +161,7 @@ func setBoolField(val string, field reflect.Value) error {
 	if err == nil {
 		field.SetBool(boolVal)
 	}
-	return nil
+	return err
 }
 
 func setFloatField(val string, bitSize int, field reflect.Value) error {


### PR DESCRIPTION
Hello all, I find a bug in gin.

Reproduce this like below:


```
type A struct {
        INum int64 `form:"numvalue"`
}

type B struct {
        IBool bool `form:"boolvalue"`
}

func handleParaNum(c *gin.Context) {
        var a A
        err := c.ShouldBindQuery(&a)
        if err != nil {
                c.String(200, "cause an err=%s", err.Error())
        } else {
                c.String(200, "bind ok")
        }
        return

}

func handleParaBool(c *gin.Context) {
        var b B
        err := c.ShouldBindQuery(&b)
        if err != nil {
                c.String(200, "cause an err=%s", err.Error())
        } else {
                c.String(200, "bind ok")
        }
        return
}

func main() {
        route := gin.Default()
        route.GET("/test_error_num", handleParaNum)
        route.GET("/test_error_bool", handleParaBool)
        route.Run(":8085")
}
```

And tow cmds, 
```
[root@localhost ~]# curl localhost:8085/test_error_num?numvalue=3s   
cause an err=strconv.ParseInt: parsing "3s": invalid syntax
[root@localhost ~]# curl localhost:8085/test_error_bool?boolvalue=fal
bind ok
```
But the second reply is not what we expect, then I review the source code. 

Get the point
[form_mapping.go#L164](https://github.com/gin-gonic/gin/blob/bd4f73af679e7d645f6d0277258fa360eda96f2d/binding/form_mapping.go#L164)

```
func setBoolField(val string, field reflect.Value) error {
	if val == "" {
		val = "false"
	}
	boolVal, err := strconv.ParseBool(val)
	if err == nil {
		field.SetBool(boolVal)
	}
	return nil
}
```
The code ignore the error (return nil), which is not right  


