### PR TITLE
Keep the logic of handling errors in render

### DIFF
--- a/render/redirect.go
+++ b/render/redirect.go
@@ -5,6 +5,7 @@
 package render
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -17,7 +18,7 @@ type Redirect struct {
 
 func (r Redirect) Render(w http.ResponseWriter) error {
 	if (r.Code < 300 || r.Code > 308) && r.Code != 201 {
-		panic(fmt.Sprintf("Cannot redirect with status code %d", r.Code))
+		return errors.New(fmt.Sprintf("Cannot redirect with status code %d", r.Code))
 	}
 	http.Redirect(w, r.Request, r.Location, r.Code)
 	return nil

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -62,12 +62,13 @@ func TestRenderJSON(t *testing.T) {
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
 }
 
-func TestRenderJSONPanics(t *testing.T) {
+func TestRenderJSONFail(t *testing.T) {
 	w := httptest.NewRecorder()
 	data := make(chan int)
 
 	// json: unsupported type: chan int
-	assert.Panics(t, func() { (JSON{data}).Render(w) })
+	err := (JSON{data}).Render(w)
+	assert.Error(t, err)
 }
 
 func TestRenderIndentedJSON(t *testing.T) {
@@ -84,7 +85,7 @@ func TestRenderIndentedJSON(t *testing.T) {
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
 }
 
-func TestRenderIndentedJSONPanics(t *testing.T) {
+func TestRenderIndentedJSONFail(t *testing.T) {
 	w := httptest.NewRecorder()
 	data := make(chan int)
 
@@ -258,7 +259,8 @@ func TestRenderRedirect(t *testing.T) {
 	}
 
 	w = httptest.NewRecorder()
-	assert.Panics(t, func() { data2.Render(w) })
+	err = data2.Render(w)
+	assert.Error(t, err)
 
 	// only improve coverage
 	data2.WriteContentType(w)

--- a/render/text.go
+++ b/render/text.go
@@ -18,19 +18,20 @@ type String struct {
 var plainContentType = []string{"text/plain; charset=utf-8"}
 
 func (r String) Render(w http.ResponseWriter) error {
-	WriteString(w, r.Format, r.Data)
-	return nil
+	return WriteString(w, r.Format, r.Data)
 }
 
 func (r String) WriteContentType(w http.ResponseWriter) {
 	writeContentType(w, plainContentType)
 }
 
-func WriteString(w http.ResponseWriter, format string, data []interface{}) {
+func WriteString(w http.ResponseWriter, format string, data []interface{}) error {
+	var err error
 	writeContentType(w, plainContentType)
 	if len(data) > 0 {
-		fmt.Fprintf(w, format, data...)
+		_, err = fmt.Fprintf(w, format, data...)
 	} else {
-		io.WriteString(w, format)
+		_, err = io.WriteString(w, format)
 	}
+	return err
 }

--- a/render/yaml.go
+++ b/render/yaml.go
@@ -24,8 +24,8 @@ func (r YAML) Render(w http.ResponseWriter) error {
 		return err
 	}
 
-	w.Write(bytes)
-	return nil
+	_, err = w.Write(bytes)
+	return err
 }
 
 func (r YAML) WriteContentType(w http.ResponseWriter) {


### PR DESCRIPTION
Keep the logic of handling errors in render 

### 1. About Render function, methods of handling the error are different

[data.go#L15](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/render/data.go#L15) data return err 
[html.go#L69](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/render/html.go#L69) html return err      
[json.go#L59](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/render/json.go#L59) IndentedJSON return err          
[json.go#L91](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/render/json.go#L91) JsonpJSON return err 
[msgpack.go#L23](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/render/msgpack.go#L23) MsgPack return err
[reader.go#L17](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/render/reader.go#L17) Reader return err
[xml.go#L18](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/render/xml.go#L18) XML return err
[yaml.go#L19](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/render/yaml.go#L19) YAML return err  

[json.go#L38](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/render/json.go#L38) JSON panic   
[text.go#L20](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/render/text.go#L20) Text return nil (Actually，"write" maybe cause error. Please see the second part)   


Actually，there is already a outter place to focus on the error [context.go#L661](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/context.go#L661)
```
func (c *Context) Render(code int, r render.Render) {
	c.Status(code)

	if !bodyAllowedForStatus(code) {
		r.WriteContentType(c.Writer)
		c.Writer.WriteHeaderNow()
		return
	}

	if err := r.Render(c.Writer); err != nil {
		panic(err)
	}
}
```
so I see, it is right if all "function Render" in "render folder"  return err.   
And the outter `context.go` handle this err.


### 2. Some code ignore err in "render", like this 
 [text.go#L29](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/render/text.go#L29) "fmt.Fprintf" and "io.WriteString" ignore the error

[json.go#L59](https://github.com/gin-gonic/gin/blob/bf7803815b0baa22ff7a10457932882dfbf09925/render/json.go#L59)  "write" ignore the error

and so on.


Based on the above two points, I pull this request.
If you think it's unnecessary, I will close this.
Thx.