### PR TITLE
Don't log requests

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/http/httputil"
 	"runtime"
 	"time"
 )
@@ -38,7 +39,12 @@ func RecoveryWithWriter(out io.Writer) HandlerFunc {
 			if err := recover(); err != nil {
 				if logger != nil {
 					stack := stack(3)
-					logger.Printf("[Recovery] %s panic recovered:\n%s\n%s%s", timeFormat(time.Now()), err, stack, reset)
+					if IsDebugging() {
+						httprequest, _ := httputil.DumpRequest(c.Request, false)
+						logger.Printf("[Recovery] %s panic recovered:\n%s\n%s\n%s%s", timeFormat(time.Now()), string(httprequest), err, stack, reset)
+					} else {
+						logger.Printf("[Recovery] %s panic recovered:\n%s\n%s%s", timeFormat(time.Now()), err, stack, reset)
+					}
 				}
 				c.AbortWithStatus(http.StatusInternalServerError)
 			}

--- a/recovery.go
+++ b/recovery.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/http/httputil"
 	"runtime"
 	"time"
 )
@@ -39,8 +38,7 @@ func RecoveryWithWriter(out io.Writer) HandlerFunc {
 			if err := recover(); err != nil {
 				if logger != nil {
 					stack := stack(3)
-					httprequest, _ := httputil.DumpRequest(c.Request, false)
-					logger.Printf("[Recovery] %s panic recovered:\n%s\n%s\n%s%s", timeFormat(time.Now()), string(httprequest), err, stack, reset)
+					logger.Printf("[Recovery] %s panic recovered:\n%s\n%s%s", timeFormat(time.Now()), err, stack, reset)
 				}
 				c.AbortWithStatus(http.StatusInternalServerError)
 			}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -27,6 +27,15 @@ func TestPanicInHandler(t *testing.T) {
 	assert.Contains(t, buffer.String(), "panic recovered")
 	assert.Contains(t, buffer.String(), "Oupps, Houston, we have a problem")
 	assert.Contains(t, buffer.String(), "TestPanicInHandler")
+
+	// Debug mode prints the request
+	SetMode(DebugMode)
+	// RUN
+	w = performRequest(router, "GET", "/recovery")
+	// TEST
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, buffer.String(), "GET /recovery")
+
 }
 
 // TestPanicWithAbort assert that panic has been recovered even if context.Abort was used.

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -24,7 +24,7 @@ func TestPanicInHandler(t *testing.T) {
 	w := performRequest(router, "GET", "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
-	assert.Contains(t, buffer.String(), "GET /recovery")
+	assert.Contains(t, buffer.String(), "panic recovered")
 	assert.Contains(t, buffer.String(), "Oupps, Houston, we have a problem")
 	assert.Contains(t, buffer.String(), "TestPanicInHandler")
 }

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -27,6 +27,7 @@ func TestPanicInHandler(t *testing.T) {
 	assert.Contains(t, buffer.String(), "panic recovered")
 	assert.Contains(t, buffer.String(), "Oupps, Houston, we have a problem")
 	assert.Contains(t, buffer.String(), "TestPanicInHandler")
+	assert.NotContains(t, buffer.String(), "GET /recovery")
 
 	// Debug mode prints the request
 	SetMode(DebugMode)


### PR DESCRIPTION
Fixes #1331

HTTP logging leaks sensitive request information.

This PR removes HTTP request logging during panics.