### PR TITLE
utils:  use strings.Split instead of strings.IndexByte

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -103,10 +103,7 @@ func parseAccept(acceptHeader string) []string {
 	parts := strings.Split(acceptHeader, ",")
 	out := make([]string, 0, len(parts))
 	for _, part := range parts {
-		if index := strings.IndexByte(part, ';'); index >= 0 {
-			part = part[0:index]
-		}
-		if part = strings.TrimSpace(part); part != "" {
+		if part = strings.TrimSpace(strings.Split(part, ";")[0]); part != "" {
 			out = append(out, part)
 		}
 	}


### PR DESCRIPTION
And I test them benchmark:

code:

```go
# stringsbench.go
package stringsbench

import "strings"

func index(part string) string {
	if index := strings.IndexByte(part, ';'); index >= 0 {
		if part := strings.TrimSpace(strings.Split(part, ";")[0]); part != "" {
			return part[0:index]
		}
	}
	return ""
}

func split(part string) string {
	return strings.Split(part, ";")[0]
}
```

```go
# stringsbench_test.go
package stringsbench

import (
	"testing"
)

func BenchmarkIndex(b *testing.B) {
	b.RunParallel(func(pb *testing.PB) {
		for pb.Next() {
			index("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8")
		}
	})
}

func BenchmarkSplit(b *testing.B) {
	b.RunParallel(func(pb *testing.PB) {
		for pb.Next() {
			split("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8")
		}
	})
}
```

And the result:

```shell
➜  strings go test --bench=.
goos: darwin
goarch: amd64
BenchmarkIndex-8   	30000000	        46.1 ns/op
BenchmarkSplit-8   	50000000	        35.9 ns/op
PASS
ok  	_/Users/tianou/strings	3.271s
➜  strings go test --bench=.
goos: darwin
goarch: amd64
BenchmarkIndex-8   	30000000	        44.2 ns/op
BenchmarkSplit-8   	50000000	        34.7 ns/op
PASS
ok  	_/Users/tianou/strings	3.156s
➜  strings go test --bench=.
goos: darwin
goarch: amd64
BenchmarkIndex-8   	30000000	        45.6 ns/op
BenchmarkSplit-8   	50000000	        35.3 ns/op
PASS
ok  	_/Users/tianou/strings	3.230s
```