### PR TITLE
flush operation will overwrite the origin status code

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -110,5 +110,6 @@ func (w *responseWriter) CloseNotify() <-chan bool {
 
 // Flush implements the http.Flush interface.
 func (w *responseWriter) Flush() {
+	w.WriteHeaderNow()
 	w.ResponseWriter.(http.Flusher).Flush()
 }

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -113,3 +113,19 @@ func TestResponseWriterHijack(t *testing.T) {
 
 	w.Flush()
 }
+
+func TestResponseWriterFlush(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writer := &responseWriter{}
+		writer.reset(w)
+
+		writer.WriteHeader(http.StatusInternalServerError)
+		writer.Flush()
+	}))
+	defer testServer.Close()
+
+	// should return 500
+	resp, err := http.Get(testServer.URL)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}


### PR DESCRIPTION
The status of responseWriter will be overwrite if flush was called. This is caused by the Flush of http.response.Flush().