### PR TITLE
Add support for Protobuf format response

### DIFF
--- a/context.go
+++ b/context.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gin-contrib/sse"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/gin-gonic/gin/render"
+	"github.com/golang/protobuf/proto"
 )
 
 // Content-Type MIME of the most common data formats.
@@ -833,6 +834,11 @@ func (c *Context) Stream(step func(w io.Writer) bool) {
 			}
 		}
 	}
+}
+
+// ProtoBuf serializes the given struct as ProtoBuf into the response body.
+func (c *Context) ProtoBuf(code int, obj proto.Message) {
+	c.Render(code, render.ProtoBuf{Data: obj})
 }
 
 /************************************/

--- a/context_test.go
+++ b/context_test.go
@@ -17,11 +17,14 @@ import (
 	"testing"
 	"time"
 
+	"io"
+
 	"github.com/gin-contrib/sse"
 	"github.com/gin-gonic/gin/binding"
+	pb "github.com/gin-gonic/gin/examples/grpc/pb"
+	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	"io"
 )
 
 var _ context.Context = &Context{}
@@ -951,6 +954,23 @@ func TestContextRenderYAML(t *testing.T) {
 	assert.Equal(t, 201, w.Code)
 	assert.Equal(t, "foo: bar\n", w.Body.String())
 	assert.Equal(t, "application/x-yaml; charset=utf-8", w.HeaderMap.Get("Content-Type"))
+}
+
+// TestContextRenderProtoBuf tests that the response is serialized as YAML
+// and Content-Type is set to application/x-protobuf
+// and we just use the example protobuf to check if the response is correct
+func TestContextRenderProtoBuf(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.ProtoBuf(201, &pb.HelloRequest{Name: "Hello"})
+
+	realProtoBuf, err := proto.Marshal(&pb.HelloRequest{Name: "Hello"})
+	assert.Nil(t, err)
+
+	assert.Equal(t, 201, w.Code)
+	assert.Equal(t, realProtoBuf, w.Body.Bytes())
+	assert.Equal(t, "application/x-protobuf", w.HeaderMap.Get("Content-Type"))
 }
 
 func TestContextHeaders(t *testing.T) {

--- a/render/protobuf.go
+++ b/render/protobuf.go
@@ -1,0 +1,33 @@
+// Copyright 2014 Manu Martinez-Almeida.  All rights reserved.
+// Use of this source code is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+package render
+
+import (
+	"net/http"
+
+	"github.com/golang/protobuf/proto"
+)
+
+type ProtoBuf struct {
+	Data proto.Message
+}
+
+var protobufContentType = []string{"application/x-protobuf"}
+
+func (r ProtoBuf) Render(w http.ResponseWriter) error {
+	r.WriteContentType(w)
+
+	bytes, err := proto.Marshal(r.Data)
+	if err != nil {
+		return err
+	}
+
+	w.Write(bytes)
+	return nil
+}
+
+func (r ProtoBuf) WriteContentType(w http.ResponseWriter) {
+	writeContentType(w, protobufContentType)
+}

--- a/render/render.go
+++ b/render/render.go
@@ -27,6 +27,7 @@ var (
 	_ Render     = MsgPack{}
 	_ Render     = Reader{}
 	_ Render     = AsciiJSON{}
+	_ Render     = ProtoBuf{}
 )
 
 func writeContentType(w http.ResponseWriter, value []string) {


### PR DESCRIPTION
`Gin` now have the `protobufBinding` function to check the request format, but didn't have a protobuf response function like `c.YAML()`.
In our company [ByteDance](http://bytedance.com/), the largest internet company using golang in China, we use `gin` to transfer __Protobuf__  instead of __Json__, we have to write some internal library to make some wrappers to achieve that, and the code is not elegant. So we really want such a feature.