### PR TITLE
Set default time format in form binding

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -178,7 +178,7 @@ func setFloatField(val string, bitSize int, field reflect.Value) error {
 func setTimeField(val string, structField reflect.StructField, value reflect.Value) error {
 	timeFormat := structField.Tag.Get("time_format")
 	if timeFormat == "" {
-		return errors.New("Blank time format")
+		timeFormat = time.RFC3339
 	}
 
 	if val == "" {


### PR DESCRIPTION
To make things working in line with `encoding/json` decoder, I'd suggest to set default time format as `time.RFC3339`.

```
type input struct {
	Field time.Time `form:"field" json:"time"`
}
```

This will make values bound in the same way as if you are using structures as above and different bindings depending on the request type.