### PR TITLE
fix go master branch(1.11+) error about Query and Form

### DIFF
--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -1215,3 +1215,17 @@ func requestWithBody(method, path, body string) (req *http.Request) {
 	req, _ = http.NewRequest(method, path, bytes.NewBufferString(body))
 	return
 }
+
+func TestResetForm(t *testing.T) {
+	m := make(map[string][]string)
+	m["a"] = []string{"hi"}
+	m["k=v&id=main&id=omit&array[]=first&array[]=second&ids[i]=111&ids[j]=3.14"] = []string{""}
+
+	res := resetForm(m)
+	assert.Equal(t, []string{"hi"}, res["a"])
+	assert.Equal(t, []string{"v"}, res["k"])
+	assert.Equal(t, []string{"main", "omit"}, res["id"])
+	assert.Equal(t, []string{"first", "second"}, res["array[]"])
+	assert.Equal(t, []string{"111"}, res["ids[i]"])
+	assert.Equal(t, []string{"3.14"}, res["ids[j]"])
+}

--- a/binding/form.go
+++ b/binding/form.go
@@ -4,7 +4,10 @@
 
 package binding
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
 
 const defaultMemory = 32 * 1024 * 1024
 
@@ -21,7 +24,7 @@ func (formBinding) Bind(req *http.Request, obj interface{}) error {
 		return err
 	}
 	req.ParseMultipartForm(defaultMemory)
-	if err := mapForm(obj, req.Form); err != nil {
+	if err := mapForm(obj, resetForm(req.Form)); err != nil {
 		return err
 	}
 	return validate(obj)
@@ -53,4 +56,20 @@ func (formMultipartBinding) Bind(req *http.Request, obj interface{}) error {
 		return err
 	}
 	return validate(obj)
+}
+
+func resetForm(f map[string][]string) map[string][]string {
+	dicts := make(map[string][]string)
+	for k, v := range f {
+		lists := strings.Split(k, "&")
+		if len(lists) == 1 {
+			dicts[k] = v
+			continue
+		}
+		for _, vv := range lists {
+			p := strings.Split(vv, "=")
+			dicts[p[0]] = append(dicts[p[0]], p[1])
+		}
+	}
+	return dicts
 }

--- a/context.go
+++ b/context.go
@@ -354,7 +354,7 @@ func (c *Context) QueryArray(key string) []string {
 // GetQueryArray returns a slice of strings for a given query key, plus
 // a boolean value whether at least one value exists for the given key.
 func (c *Context) GetQueryArray(key string) ([]string, bool) {
-	if values, ok := c.Request.URL.Query()[key]; ok && len(values) > 0 {
+	if values, ok := c.resetQuery()[key]; ok && len(values) > 0 {
 		return values, true
 	}
 	return []string{}, false
@@ -369,7 +369,7 @@ func (c *Context) QueryMap(key string) map[string]string {
 // GetQueryMap returns a map for a given query key, plus a boolean value
 // whether at least one value exists for the given key.
 func (c *Context) GetQueryMap(key string) (map[string]string, bool) {
-	return c.get(c.Request.URL.Query(), key)
+	return c.get(c.resetQuery(), key)
 }
 
 // PostForm returns the specified key from a POST urlencoded form or multipart form
@@ -446,6 +446,23 @@ func (c *Context) GetPostFormMap(key string) (map[string]string, bool) {
 	}
 
 	return dicts, exist
+}
+
+func (c *Context) resetQuery() map[string][]string {
+	dicts := make(map[string][]string)
+	url := c.Request.URL.Query()
+	for k, v := range url {
+		lists := strings.Split(k, "&")
+		if len(lists) == 1 {
+			dicts[k] = v
+			continue
+		}
+		for _, vv := range lists {
+			p := strings.Split(vv, "=")
+			dicts[p[0]] = append(dicts[p[0]], p[1])
+		}
+	}
+	return dicts
 }
 
 // get is an internal method and returns a map which satisfy conditions.


### PR DESCRIPTION
@javierprovecho @appleboy please review the pull request which add `resetQuery` instead of `c.Request.URL.Query` and `resetForm` instead of `req.Form`. Related to go master pull request https://github.com/golang/go/commit/1040626c0ce4a1bc2b312aa0866ffeb2ff53c1ab#diff-9667474d33400190658e4758cf28dbf5

TODO: And I think we should add `internal` package which reduce duplicated code and avoid circular dependencies. also see #1504 

go master branch error, maybe because `url.Values` change, go 1.10.x OK, print `c.Request.URL.Query()` and `c.Request.Form` log:

```go
url.Values{"ids[a]":[]string{"hi"}, "ids[b]":[]string{"3.14"}, "both":[]string{"GET"}, "id":[]string{"main", "omit"}, "array[]":[]string{"first", "second"}}
```

go master error, print `c.Request.URL.Query()` and `c.Request.Form` log:

```go
url.Values{"both=GET&id=main&id=omit&array[]=first&array[]=second&ids[a]=hi&ids[b]=3.14":[]string{""}}
```