### PR TITLE
readme: remove console image and add fold button

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 [![Sourcegraph](https://sourcegraph.com/github.com/gin-gonic/gin/-/badge.svg)](https://sourcegraph.com/github.com/gin-gonic/gin?badge)
 [![Open Source Helpers](https://www.codetriage.com/gin-gonic/gin/badges/users.svg)](https://www.codetriage.com/gin-gonic/gin)
 
-Gin is a web framework written in Go (Golang). It features a martini-like API with much better performance, up to 40 times faster thanks to [httprouter](https://github.com/julienschmidt/httprouter). If you need performance and good productivity, you will love Gin.
+Gin is a web framework written in Go (Golang).
 
-![Gin console logger](https://gin-gonic.github.io/gin/other/console.png)
+Gin features a martini-like API with much better performance, up to 40 times faster thanks to [httprouter](https://github.com/julienschmidt/httprouter).
+
+If you need performance and good productivity, you will love Gin.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ import "net/http"
 
 ### Use a vendor tool like [Govendor](https://github.com/kardianos/govendor)
 
+<details>
+<summary>How to use govendor tool details?</summary>
+
 1. `go get` govendor
 
 ```sh
@@ -116,6 +119,8 @@ $ curl https://raw.githubusercontent.com/gin-gonic/gin/master/examples/basic/mai
 ```sh
 $ go run main.go
 ```
+
+</details>
 
 ## Prerequisite
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ import "net/http"
 ### Use a vendor tool like [Govendor](https://github.com/kardianos/govendor)
 
 <details>
+
 <summary>How to use govendor tool details?</summary>
 
 1. `go get` govendor
@@ -156,6 +157,10 @@ $ go run example.go
 
 ## Benchmarks
 
+<details>
+
+<summary>See gin performance details</summary>
+
 Gin uses a custom version of [HttpRouter](https://github.com/julienschmidt/httprouter)
 
 [See all benchmarks](/BENCHMARKS.md)
@@ -195,6 +200,8 @@ BenchmarkVulcan_GithubAll                   |    5000    |   394253    |   19894
 - (3): Heap Memory (B/op), lower is better
 - (4): Average Allocations per Repetition (allocs/op), lower is better
 
+</details>
+
 ## Gin v1. stable
 
 - [x] Zero allocation router.
@@ -205,11 +212,17 @@ BenchmarkVulcan_GithubAll                   |    5000    |   394253    |   19894
 
 ## Build with [jsoniter](https://github.com/json-iterator/go)
 
+<details>
+
+<summary>How to use jsoniter on your gin project?</summary>
+
 Gin uses `encoding/json` as default json package but you can change to [jsoniter](https://github.com/json-iterator/go) by build from other tags.
 
 ```sh
 $ go build -tags=jsoniter .
 ```
+
+</details>
 
 ## API Examples
 
@@ -1844,6 +1857,10 @@ func main() {
 
 ## Testing
 
+<details>
+
+<summary>How to test your gin code?</summary>
+
 The `net/http/httptest` package is preferable way for HTTP testing.
 
 ```go
@@ -1887,6 +1904,8 @@ func TestPingRoute(t *testing.T) {
 	assert.Equal(t, "pong", w.Body.String())
 }
 ```
+
+</details>
 
 ## Users
 


### PR DESCRIPTION
- remove console image on the top of readme, I think it's not important, but need review.
- add fold button which reduce readme document length, it will fold some less important content.

like this:

![image](https://user-images.githubusercontent.com/4488261/45086254-50190480-b135-11e8-938a-a6a219e5490c.png)
