### PR TITLE
Make logger use a yellow background and a darkgray text for legibility

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -17,7 +17,7 @@ import (
 var (
 	green        = string([]byte{27, 91, 57, 55, 59, 52, 50, 109})
 	white        = string([]byte{27, 91, 57, 48, 59, 52, 55, 109})
-	yellow       = string([]byte{27, 91, 57, 55, 59, 52, 51, 109})
+	yellow       = string([]byte{27, 91, 57, 48, 59, 52, 51, 109})
 	red          = string([]byte{27, 91, 57, 55, 59, 52, 49, 109})
 	blue         = string([]byte{27, 91, 57, 55, 59, 52, 52, 109})
 	magenta      = string([]byte{27, 91, 57, 55, 59, 52, 53, 109})

--- a/logger_test.go
+++ b/logger_test.go
@@ -85,7 +85,7 @@ func TestLogger(t *testing.T) {
 func TestColorForMethod(t *testing.T) {
 	assert.Equal(t, string([]byte{27, 91, 57, 55, 59, 52, 52, 109}), colorForMethod("GET"), "get should be blue")
 	assert.Equal(t, string([]byte{27, 91, 57, 55, 59, 52, 54, 109}), colorForMethod("POST"), "post should be cyan")
-	assert.Equal(t, string([]byte{27, 91, 57, 55, 59, 52, 51, 109}), colorForMethod("PUT"), "put should be yellow")
+	assert.Equal(t, string([]byte{27, 91, 57, 48, 59, 52, 51, 109}), colorForMethod("PUT"), "put should be yellow")
 	assert.Equal(t, string([]byte{27, 91, 57, 55, 59, 52, 49, 109}), colorForMethod("DELETE"), "delete should be red")
 	assert.Equal(t, string([]byte{27, 91, 57, 55, 59, 52, 50, 109}), colorForMethod("PATCH"), "patch should be green")
 	assert.Equal(t, string([]byte{27, 91, 57, 55, 59, 52, 53, 109}), colorForMethod("HEAD"), "head should be magenta")
@@ -96,7 +96,7 @@ func TestColorForMethod(t *testing.T) {
 func TestColorForStatus(t *testing.T) {
 	assert.Equal(t, string([]byte{27, 91, 57, 55, 59, 52, 50, 109}), colorForStatus(http.StatusOK), "2xx should be green")
 	assert.Equal(t, string([]byte{27, 91, 57, 48, 59, 52, 55, 109}), colorForStatus(http.StatusMovedPermanently), "3xx should be white")
-	assert.Equal(t, string([]byte{27, 91, 57, 55, 59, 52, 51, 109}), colorForStatus(http.StatusNotFound), "4xx should be yellow")
+	assert.Equal(t, string([]byte{27, 91, 57, 48, 59, 52, 51, 109}), colorForStatus(http.StatusNotFound), "4xx should be yellow")
 	assert.Equal(t, string([]byte{27, 91, 57, 55, 59, 52, 49, 109}), colorForStatus(2), "other things should be red")
 }
 


### PR DESCRIPTION
1. Why is this change neccesary?
White text on a yellow background was illegible with most terminal color schemes

2. How does it address the issue?
The white text was replaced with a bash compatible dark gray while keeping the
yellow background colour

3. What side effects does this change have?
Resolves #1552

Before:
![captura de pantalla 2018-09-25 a la s 17 09 01](https://user-images.githubusercontent.com/10160626/46046509-f7f77180-c0e6-11e8-9651-deffb9eacbbc.png)

After:
![captura de pantalla 2018-09-25 a la s 17 08 42](https://user-images.githubusercontent.com/10160626/46046481-da2a0c80-c0e6-11e8-8c38-10a20d90188b.png)