### PR TITLE
ci: use matrix for adding env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: go
+
 sudo: false
-go:
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
-  - 1.11.x
-  - master
 
 matrix:
   fast_finish: true
+  include:
+  - go: 1.6.x
+  - go: 1.7.x
+  - go: 1.8.x
+  - go: 1.9.x
+  - go: 1.10.x
+  - go: 1.11.x
+  - go: 1.11.x
+    env: GO111MODULE=on
+  - go: master
 
 git:
   depth: 10


### PR DESCRIPTION
travis ci about environment: https://docs.travis-ci.com/user/environment-variables/
Because go1.11 need to set env `GO111MODULE=on` when use `go mod`, so update `.travis.yml` and use matrix.