### PR TITLE
传参错误

### DIFF
--- a/binding/default_validator.go
+++ b/binding/default_validator.go
@@ -45,7 +45,7 @@ func (v *defaultValidator) Engine() interface{} {
 
 func (v *defaultValidator) lazyinit() {
 	v.once.Do(func() {
-		config := &validator.Config{TagName: "binding"}
-		v.validate = validator.New(config)
+		//config := &validator.Config{TagName: "binding"}
+		v.validate = validator.New()
 	})
 }


### PR DESCRIPTION
# xxx/vendor/github.com/gin-gonic/gin/binding
vendor/github.com/gin-gonic/gin/binding/default_validator.go:48:14: undefined: validator.Config
vendor/github.com/gin-gonic/gin/binding/default_validator.go:49:29: too many arguments in call to validator.New

