### PR TITLE
Make Group return IRouter

### DIFF
--- a/ginS/gins.go
+++ b/ginS/gins.go
@@ -49,7 +49,7 @@ func NoMethod(handlers ...gin.HandlerFunc) {
 
 // Group creates a new router group. You should add all the routes that have common middlwares or the same path prefix.
 // For example, all the routes that use a common middlware for authorization could be grouped.
-func Group(relativePath string, handlers ...gin.HandlerFunc) *gin.RouterGroup {
+func Group(relativePath string, handlers ...gin.HandlerFunc) gin.IRouter {
 	return engine().Group(relativePath, handlers...)
 }
 

--- a/routergroup.go
+++ b/routergroup.go
@@ -14,7 +14,7 @@ import (
 // IRouter defines all router handle interface includes single and group router.
 type IRouter interface {
 	IRoutes
-	Group(string, ...HandlerFunc) *RouterGroup
+	Group(string, ...HandlerFunc) IRouter
 }
 
 // IRoutes defines all router handle interface.
@@ -55,7 +55,7 @@ func (group *RouterGroup) Use(middleware ...HandlerFunc) IRoutes {
 
 // Group creates a new router group. You should add all the routes that have common middlwares or the same path prefix.
 // For example, all the routes that use a common middlware for authorization could be grouped.
-func (group *RouterGroup) Group(relativePath string, handlers ...HandlerFunc) *RouterGroup {
+func (group *RouterGroup) Group(relativePath string, handlers ...HandlerFunc) IRouter {
 	return &RouterGroup{
 		Handlers: group.combineHandlers(handlers),
 		basePath: group.calculateAbsolutePath(relativePath),

--- a/routergroup_test.go
+++ b/routergroup_test.go
@@ -17,14 +17,14 @@ func init() {
 
 func TestRouterGroupBasic(t *testing.T) {
 	router := New()
-	group := router.Group("/hola", func(c *Context) {})
+	group := router.Group("/hola", func(c *Context) {}).(*RouterGroup)
 	group.Use(func(c *Context) {})
 
 	assert.Len(t, group.Handlers, 2)
 	assert.Equal(t, "/hola", group.BasePath())
 	assert.Equal(t, router, group.engine)
 
-	group2 := group.Group("manu")
+	group2 := group.Group("manu").(*RouterGroup)
 	group2.Use(func(c *Context) {}, func(c *Context) {})
 
 	assert.Len(t, group2.Handlers, 4)
@@ -44,10 +44,10 @@ func TestRouterGroupBasicHandle(t *testing.T) {
 
 func performRequestInGroup(t *testing.T, method string) {
 	router := New()
-	v1 := router.Group("v1", func(c *Context) {})
+	v1 := router.Group("v1", func(c *Context) {}).(*RouterGroup)
 	assert.Equal(t, "/v1", v1.BasePath())
 
-	login := v1.Group("/login/", func(c *Context) {}, func(c *Context) {})
+	login := v1.Group("/login/", func(c *Context) {}, func(c *Context) {}).(*RouterGroup)
 	assert.Equal(t, "/v1/login/", login.BasePath())
 
 	handler := func(c *Context) {


### PR DESCRIPTION
Hi

This PR addresses #421

This change increases extensibility and flexibility. This change would facilitate mocking of IRouter.

This replaces old attempt here https://github.com/gin-gonic/gin/pull/725