### PR TITLE
feat(server): Implements RunFd method

### DIFF
--- a/gin_integration_test.go
+++ b/gin_integration_test.go
@@ -134,6 +134,42 @@ func TestBadUnixSocket(t *testing.T) {
 	assert.Error(t, router.RunUnix("#/tmp/unix_unit_test"))
 }
 
+func TestFileDescriptor(t *testing.T) {
+	router := New()
+
+	addr, err := net.ResolveTCPAddr("tcp", ":8000")
+	assert.NoError(t, err)
+	listener, err := net.ListenTCP("tcp", addr)
+	assert.NoError(t, err)
+	socketFile, err := listener.File()
+	assert.NoError(t, err)
+
+	go func() {
+		router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
+		assert.NoError(t, router.RunFd(int(socketFile.Fd())))
+	}()
+	// have to wait for the goroutine to start and run the server
+	// otherwise the main thread will complete
+	time.Sleep(5 * time.Millisecond)
+
+	c, err := net.Dial("tcp", "localhost:8000")
+	assert.NoError(t, err)
+
+	fmt.Fprintf(c, "GET /example HTTP/1.0\r\n\r\n")
+	scanner := bufio.NewScanner(c)
+	var response string
+	for scanner.Scan() {
+		response += scanner.Text()
+	}
+	assert.Contains(t, response, "HTTP/1.0 200", "should get a 200")
+	assert.Contains(t, response, "it worked", "resp body should match")
+}
+
+func TestBadFileDescriptor(t *testing.T) {
+	router := New()
+	assert.Error(t, router.RunFd(0))
+}
+
 func TestWithHttptestWithAutoSelectedPort(t *testing.T) {
 	router := New()
 	router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })


### PR DESCRIPTION
Renewed the pr https://github.com/gin-gonic/gin/pull/526.

----
I use gin http.Server under [circus](http://circus.readthedocs.org/en/latest/) which is a socket manager.
I need to run http.Server through a file descriptor, so implemented `RunFd` method.

When using other socket managers (e.g. [einhorn](https://stripe.com/blog/meet-einhorn)), maybe work well.
### Usage

``` go
package main

import (
    "flag"
    "github.com/yyoshiki41/gin"
)

var (
    fd = flag.Int("fd", -1, "")
)

func main() {
    flag.Parse()

    r := gin.Default()
    // Ping test
    r.GET("/ping", func(c *gin.Context) {
        c.String(200, "pong")
    })
    // Method arg is the file descriptor number(int).
    r.RunFd(*fd)
}
```

and, `circus.ini` example is below.

``` ini
[circus]
statsd = 1

[watcher:webapp]
cmd = ./main -fd $(circus.sockets.web)
numprocesses = 1
use_sockets = True

[socket:web]
host = 127.0.0.1
port = 8080
```
### Demo

``` shell
$ circusd circus.ini
2016-02-03 11:07:13 circus[46347] [INFO] Starting master on pid 46347
2016-02-03 11:07:13 circus[46347] [INFO] sockets started
2016-02-03 11:07:13 circus[46347] [INFO] Arbiter now waiting for commands
2016-02-03 11:07:13 circus[46347] [INFO] webapp started
2016-02-03 11:07:13 circus[46347] [INFO] circusd-stats started
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:   export GIN_MODE=release
 - using code:  gin.SetMode(gin.ReleaseMode)

[GIN-debug] GET    /ping                     --> main.main.func1 (3 handlers)
[GIN-debug] Listening and serving HTTP on fd@5
2016-02-03 11:07:13 circus[46354] [INFO] Starting the stats streamer
```

``` shell
# Ping test
$ curl localhost:8080/ping
pong

# Other terminal
[GIN] 2016/02/03 - 11:08:11 | 200 |    2.571629ms | 127.0.0.1 |   GET     /ping
```

thx :sunny:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gin-gonic/gin/1609)
<!-- Reviewable:end -->
