### PR TITLE
Added some comments to avoid having golint warnings

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -24,9 +24,10 @@ const (
 	ErrorTypePrivate ErrorType = 1 << 0
 	// ErrorTypePublic indicates a public error.
 	ErrorTypePublic ErrorType = 1 << 1
-	// ErrorTypeAny indicates other any error.
+	// ErrorTypeAny indicates any other error.
 	ErrorTypeAny ErrorType = 1<<64 - 1
-	ErrorTypeNu            = 2
+	// ErrorTypeNu indicates any other error.
+	ErrorTypeNu = 2
 )
 
 // Error represents a error's specification.
@@ -52,6 +53,7 @@ func (msg *Error) SetMeta(data interface{}) *Error {
 	return msg
 }
 
+// JSON creates a properly formated JSON
 func (msg *Error) JSON() interface{} {
 	json := H{}
 	if msg.Meta != nil {

--- a/mode.go
+++ b/mode.go
@@ -28,7 +28,7 @@ const (
 	testCode
 )
 
-// DefaultWriter is the default io.Writer used the Gin for debug output and
+// DefaultWriter is the default io.Writer used by Gin for debug output and
 // middleware output like Logger() or Recovery().
 // Note that both Logger and Recovery provides custom ways to configure their
 // output io.Writer.
@@ -36,6 +36,8 @@ const (
 // 		import "github.com/mattn/go-colorable"
 // 		gin.DefaultWriter = colorable.NewColorableStdout()
 var DefaultWriter io.Writer = os.Stdout
+
+// DefaultErrorWriter is the default io.Writer used by Gin to debug errors
 var DefaultErrorWriter io.Writer = os.Stderr
 
 var ginMode = debugCode


### PR DESCRIPTION
The following comments to vars, conts and method were added to pass  `golinter` with 100%.

![captura de pantalla 2018-10-31 a la s 15 23 37](https://user-images.githubusercontent.com/10160626/47819725-faba3780-dd20-11e8-978c-1b3ab7de26ed.png)

