### PR TITLE
Remove type attribute from HTML script tag to be consistent with the …

### DIFF
--- a/examples/realtime-advanced/resources/room_login.templ.html
+++ b/examples/realtime-advanced/resources/room_login.templ.html
@@ -22,7 +22,7 @@
         <!-- Primjs -->
         <link href="/static/prismjs.min.css" rel="stylesheet">
 
-        <script type="text/javascript">
+        <script>
             $(document).ready(function() { 
               StartRealtime({{.roomid}}, {{.timestamp}});
             });


### PR DESCRIPTION
…rest of the codebase.

The `<script>` tag is used to define a client-side script (JavaScript).  The "type" attribute is required in HTML 4, but optional in HTML5.
