### PR TITLE
cookie SameSite support

### DIFF
--- a/context.go
+++ b/context.go
@@ -697,9 +697,13 @@ func (c *Context) GetRawData() ([]byte, error) {
 // SetCookie adds a Set-Cookie header to the ResponseWriter's headers.
 // The provided cookie must have a valid Name. Invalid cookies may be
 // silently dropped.
-func (c *Context) SetCookie(name, value string, maxAge int, path, domain string, secure, httpOnly bool) {
+func (c *Context) SetCookie(name, value string, maxAge int, path, domain string, secure, httpOnly bool, sameSiteOnly bool) {
 	if path == "" {
 		path = "/"
+	}
+	sameSite := http.SameSiteDefaultMode
+	if sameSiteOnly {
+		sameSite = http.SameSiteStrictMode
 	}
 	http.SetCookie(c.Writer, &http.Cookie{
 		Name:     name,
@@ -709,6 +713,7 @@ func (c *Context) SetCookie(name, value string, maxAge int, path, domain string,
 		Domain:   domain,
 		Secure:   secure,
 		HttpOnly: httpOnly,
+		SameSite: sameSite,
 	})
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -579,14 +579,14 @@ func TestContextPostFormMultipart(t *testing.T) {
 
 func TestContextSetCookie(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
-	c.SetCookie("user", "gin", 1, "/", "localhost", true, true)
-	assert.Equal(t, "user=gin; Path=/; Domain=localhost; Max-Age=1; HttpOnly; Secure", c.Writer.Header().Get("Set-Cookie"))
+	c.SetCookie("user", "gin", 1, "/", "localhost", true, true, true)
+	assert.Equal(t, "user=gin; Path=/; Domain=localhost; Max-Age=1; HttpOnly; Secure; SameSite=Strict", c.Writer.Header().Get("Set-Cookie"))
 }
 
 func TestContextSetCookiePathEmpty(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
-	c.SetCookie("user", "gin", 1, "", "localhost", true, true)
-	assert.Equal(t, "user=gin; Path=/; Domain=localhost; Max-Age=1; HttpOnly; Secure", c.Writer.Header().Get("Set-Cookie"))
+	c.SetCookie("user", "gin", 1, "", "localhost", true, true, true)
+	assert.Equal(t, "user=gin; Path=/; Domain=localhost; Max-Age=1; HttpOnly; Secure; SameSite=Strict", c.Writer.Header().Get("Set-Cookie"))
 }
 
 func TestContextGetCookie(t *testing.T) {


### PR DESCRIPTION
- Support for SameSite cookie via bool because Lax or Strict has same result
Source: https://www.netsparker.com/blog/web-security/same-site-cookie-attribute-prevent-cross-site-request-forgery/
