### PR TITLE
handle nil body for JSON binding

### DIFF
--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -195,6 +195,13 @@ func TestBindingDefault(t *testing.T) {
 	assert.Equal(t, YAML, Default("PUT", MIMEYAML))
 }
 
+func TestBindingJSONNilBody(t *testing.T) {
+	var obj FooStruct
+	req, _ := http.NewRequest(http.MethodPost, "/", nil)
+	err := JSON.Bind(req, &obj)
+	assert.Error(t, err)
+}
+
 func TestBindingJSON(t *testing.T) {
 	testBodyBinding(t,
 		JSON, "json",

--- a/binding/json.go
+++ b/binding/json.go
@@ -6,6 +6,7 @@ package binding
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -24,6 +25,9 @@ func (jsonBinding) Name() string {
 }
 
 func (jsonBinding) Bind(req *http.Request, obj interface{}) error {
+	if req == nil || req.Body == nil {
+		return fmt.Errorf("invalid request")
+	}
 	return decodeJSON(req.Body, obj)
 }
 


### PR DESCRIPTION
- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integrations systems such as TravisCI.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

In the real world, it probably shouldn't matter. It just happened when I forgot to pass body to `http.NewRequest` and the function `Bind` panicked under that situation.

If we always assume body will not be nil, please let me know, I will close this PR. Thank you.
