### PR TITLE
Support DisallowUnknownFields in JSON

### DIFF
--- a/binding/json.go
+++ b/binding/json.go
@@ -17,6 +17,10 @@ import (
 // interface{} as a Number instead of as a float64.
 var EnableDecoderUseNumber = false
 
+// EnableDecoderKnownFieldsOnly is used to toggle DisallowUnknownFields
+// which is disabled by default
+var EnableDecoderKnownFieldsOnly = false
+
 type jsonBinding struct{}
 
 func (jsonBinding) Name() string {
@@ -35,6 +39,9 @@ func decodeJSON(r io.Reader, obj interface{}) error {
 	decoder := json.NewDecoder(r)
 	if EnableDecoderUseNumber {
 		decoder.UseNumber()
+	}
+	if EnableDecoderKnownFieldsOnly {
+		decoder.DisallowUnknownFields()
 	}
 	if err := decoder.Decode(obj); err != nil {
 		return err


### PR DESCRIPTION
Currently it is not possible to tell the default JSON binder to use DisallowUnknownFields (supported by jsoniter and default Go json decoder). Use package variable EnableDecoderKnownFieldsOnly as a switch.