### PR TITLE
chore: fix test fail

### DIFF
--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -687,7 +687,7 @@ func TestUriBinding(t *testing.T) {
 	}
 	var not NotSupportStruct
 	assert.Error(t, b.BindUri(m, &not))
-	assert.Equal(t, "", not.Name)
+	assert.Equal(t, map[string]interface{}(nil), not.Name)
 }
 
 func testFormBinding(t *testing.T, method, path, badPath, body, badBody string) {

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -84,7 +85,7 @@ func TestPanicWithBrokenPipe(t *testing.T) {
 	const expectCode = 204
 
 	expectMsgs := map[syscall.Errno]string{
-		syscall.EPIPE:      "Broken pipe",
+		syscall.EPIPE:      "broken pipe",
 		syscall.ECONNRESET: "connection reset by peer",
 	}
 
@@ -108,7 +109,7 @@ func TestPanicWithBrokenPipe(t *testing.T) {
 			w := performRequest(router, "GET", "/recovery")
 			// TEST
 			assert.Equal(t, expectCode, w.Code)
-			assert.Contains(t, buf.String(), expectMsg)
+			assert.Contains(t, strings.ToLower(buf.String()), expectMsg)
 		})
 	}
 }


### PR DESCRIPTION
now ci have the following output:

```
[GIN-debug] GET    /recovery                 --> github.com/gin-gonic/gin.TestPanicWithBrokenPipe.func1.1 (2 handlers)
--- FAIL: TestPanicWithBrokenPipe (0.00s)
    --- FAIL: TestPanicWithBrokenPipe/Broken_pipe (0.00s)
        recovery_test.go:111: 
            	Error Trace:	recovery_test.go:111
            	Error:      	"
            	            	
            	            	2018/11/26 03:31:54 : : broken pipe
            	            	GET /recovery HTTP/1.1
            	            	
            	            	
            	            	" does not contain "Broken pipe"
            	Test:       	TestPanicWithBrokenPipe/Broken_pipe
    --- PASS: TestPanicWithBrokenPipe/connection_reset_by_peer (0.00s)
=== RUN   TestResponseWriterReset
```

update after output:

```
=== RUN   TestPanicWithBrokenPipe
=== RUN   TestPanicWithBrokenPipe/broken_pipe
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:	export GIN_MODE=release
 - using code:	gin.SetMode(gin.ReleaseMode)
[GIN-debug] GET    /recovery                 --> github.com/gin-gonic/gin.TestPanicWithBrokenPipe.func1.1 (2 handlers)
=== RUN   TestPanicWithBrokenPipe/connection_reset_by_peer
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:	export GIN_MODE=release
 - using code:	gin.SetMode(gin.ReleaseMode)
[GIN-debug] GET    /recovery                 --> github.com/gin-gonic/gin.TestPanicWithBrokenPipe.func1.1 (2 handlers)
--- PASS: TestPanicWithBrokenPipe (0.00s)
    --- PASS: TestPanicWithBrokenPipe/broken_pipe (0.00s)
    --- PASS: TestPanicWithBrokenPipe/connection_reset_by_peer (0.00s)
```
