### PR TITLE
chore: remove wercker yml file

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,1 +1,0 @@
-box: wercker/default


### PR DESCRIPTION
Now the `wercker.yml` have no longer used.