### PR TITLE
fix bug

### DIFF
--- a/routergroup.go
+++ b/routergroup.go
@@ -187,8 +187,11 @@ func (group *RouterGroup) createStaticHandler(relativePath string, fs http.FileS
 	fileServer := http.StripPrefix(absolutePath, http.FileServer(fs))
 
 	return func(c *Context) {
-		file := c.Param("filepath")
+		if _, nolisting := fs.(*onlyfilesFS); nolisting {
+			c.Writer.WriteHeader(http.StatusNotFound)
+		}
 
+		file := c.Param("filepath")
 		// Check if file exists and/or if we have permission to access it
 		if _, err := fs.Open(file); err != nil {
 			c.Writer.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
fix: 
```
=== RUN   TestRouteStaticNoListing
--- FAIL: TestRouteStaticNoListing (0.00s)
	assertions.go:256: 
			Error Trace:	routes_test.go:298
			Error:      	Not equal: 
			            	expected: 404
			            	actual  : 200
			Test:       	TestRouteStaticNoListing
```