### PR TITLE
context: inherits context cancelation and deadline from http.Request context for Go>=1.7

### DIFF
--- a/context.go
+++ b/context.go
@@ -932,34 +932,6 @@ func (c *Context) SetAccepted(formats ...string) {
 	c.Accepted = formats
 }
 
-/************************************/
-/***** GOLANG.ORG/X/NET/CONTEXT *****/
-/************************************/
-
-// Deadline returns the time when work done on behalf of this context
-// should be canceled. Deadline returns ok==false when no deadline is
-// set. Successive calls to Deadline return the same results.
-func (c *Context) Deadline() (deadline time.Time, ok bool) {
-	return
-}
-
-// Done returns a channel that's closed when work done on behalf of this
-// context should be canceled. Done may return nil if this context can
-// never be canceled. Successive calls to Done return the same value.
-func (c *Context) Done() <-chan struct{} {
-	return nil
-}
-
-// Err returns a non-nil error value after Done is closed,
-// successive calls to Err return the same error.
-// If Done is not yet closed, Err returns nil.
-// If Done is closed, Err returns a non-nil error explaining why:
-// Canceled if the context was canceled
-// or DeadlineExceeded if the context's deadline passed.
-func (c *Context) Err() error {
-	return nil
-}
-
 // Value returns the value associated with this context for key, or nil
 // if no value is associated with key. Successive calls to Value with
 // the same key returns the same result.

--- a/context_17_test.go
+++ b/context_17_test.go
@@ -7,9 +7,12 @@
 package gin
 
 import (
+	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -24,4 +27,50 @@ func TestContextRenderPureJSON(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, w.Code)
 	assert.Equal(t, "{\"foo\":\"bar\",\"html\":\"<b>\"}\n", w.Body.String())
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+}
+
+func TestContextHTTPContext(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	req, _ := http.NewRequest("POST", "/", bytes.NewBufferString("{\"foo\":\"bar\", \"bar\":\"foo\"}"))
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	c.Request = req.WithContext(ctx)
+
+	assert.NoError(t, c.Err())
+	assert.NotNil(t, c.Done())
+	select {
+	case <-c.Done():
+		assert.Fail(t, "context should not be canceled")
+	default:
+	}
+
+	ti, ok := c.Deadline()
+	assert.Equal(t, ti, time.Time{})
+	assert.False(t, ok)
+	assert.Equal(t, c.Value(0), c.Request)
+
+	cancelFunc()
+	assert.NotNil(t, c.Done())
+	select {
+	case <-c.Done():
+	default:
+		assert.Fail(t, "context should be canceled")
+	}
+}
+
+func TestContextHTTPContextWithDeadline(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	req, _ := http.NewRequest("POST", "/", bytes.NewBufferString("{\"foo\":\"bar\", \"bar\":\"foo\"}"))
+	location, _ := time.LoadLocation("Europe/Paris")
+	assert.NotNil(t, location)
+	date := time.Date(2031, 12, 27, 16, 00, 00, 00, location)
+	ctx, cancelFunc := context.WithDeadline(context.Background(), date)
+	defer cancelFunc()
+	c.Request = req.WithContext(ctx)
+
+	assert.NoError(t, c.Err())
+
+	ti, ok := c.Deadline()
+	assert.Equal(t, ti, date)
+	assert.True(t, ok)
 }

--- a/context_pre17.go
+++ b/context_pre17.go
@@ -2,21 +2,13 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-// +build go1.7
+// +build !go1.7
 
 package gin
 
 import (
 	"time"
-
-	"github.com/gin-gonic/gin/render"
 )
-
-// PureJSON serializes the given struct as JSON into the response body.
-// PureJSON, unlike JSON, does not replace special html characters with their unicode entities.
-func (c *Context) PureJSON(code int, obj interface{}) {
-	c.Render(code, render.PureJSON{Data: obj})
-}
 
 /************************************/
 /***** GOLANG.ORG/X/NET/CONTEXT *****/
@@ -25,15 +17,15 @@ func (c *Context) PureJSON(code int, obj interface{}) {
 // Deadline returns the time when work done on behalf of this context
 // should be canceled. Deadline returns ok==false when no deadline is
 // set. Successive calls to Deadline return the same results.
-func (c *Context) Deadline() (time.Time, bool) {
-	return c.Request.Context().Deadline()
+func (c *Context) Deadline() (deadline time.Time, ok bool) {
+	return
 }
 
 // Done returns a channel that's closed when work done on behalf of this
 // context should be canceled. Done may return nil if this context can
 // never be canceled. Successive calls to Done return the same value.
 func (c *Context) Done() <-chan struct{} {
-	return c.Request.Context().Done()
+	return nil
 }
 
 // Err returns a non-nil error value after Done is closed,
@@ -43,5 +35,5 @@ func (c *Context) Done() <-chan struct{} {
 // Canceled if the context was canceled
 // or DeadlineExceeded if the context's deadline passed.
 func (c *Context) Err() error {
-	return c.Request.Context().Err()
+	return nil
 }


### PR DESCRIPTION
*gin.Context implements standard context.Context methods, but always
returns data as context is still valid. Since Go 1.7, http.Request now
contains a context.Context object, which can be controlled by the
http.Server to indicates that the context is now closed, and persue of
request should be canceled.

This implements the propagation of http.Request context methods inside
gin.Context to have HTTP context cancelation information at gin.Context
level.

This is retro-compatible for Golang 1.6, and have no effect if http.Request have no context (as http.Request always provide context.Background is ctx is nil)