### PR TITLE
Add a function to force color in console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,6 @@ $ go build -tags=jsoniter .
 
 ```go
 func main() {
-	// Disable Console Color
-	// gin.DisableConsoleColor()
-
 	// Creates a gin router with default middleware:
 	// logger and recovery (crash-free) middleware
 	router := gin.Default()
@@ -568,6 +565,48 @@ func main() {
 **Sample Output**
 ```
 ::1 - [Fri, 07 Dec 2018 17:04:38 JST] "GET /ping HTTP/1.1 200 122.767µs "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.80 Safari/537.36" "
+```
+
+### Controlling Log output coloring 
+
+By default, logs output on console should be colorized depending on the detected TTY.
+
+Never colorize logs: 
+
+```go
+func main() {
+    // Disable log's color
+    gin.DisableConsoleColor()
+    
+    // Creates a gin router with default middleware:
+    // logger and recovery (crash-free) middleware
+    router := gin.Default()
+    
+    router.GET("/ping", func(c *gin.Context) {
+        c.String(200, "pong")
+    })
+    
+    router.Run(":8080")
+}
+```
+
+Always colorize logs: 
+
+```go
+func main() {
+    // Force log's color
+    gin.ForceConsoleColor()
+    
+    // Creates a gin router with default middleware:
+    // logger and recovery (crash-free) middleware
+    router := gin.Default()
+    
+    router.GET("/ping", func(c *gin.Context) {
+        c.String(200, "pong")
+    })
+    
+    router.Run(":8080")
+}
 ```
 
 ### Model binding and validation

--- a/logger.go
+++ b/logger.go
@@ -24,6 +24,7 @@ var (
 	cyan         = string([]byte{27, 91, 57, 55, 59, 52, 54, 109})
 	reset        = string([]byte{27, 91, 48, 109})
 	disableColor = false
+	forceColor   = false
 )
 
 // LoggerConfig defines the config for Logger middleware.
@@ -90,6 +91,11 @@ func DisableConsoleColor() {
 	disableColor = true
 }
 
+// ForceConsoleColor force color output in the console.
+func ForceConsoleColor() {
+	forceColor = true
+}
+
 // ErrorLogger returns a handlerfunc for any error type.
 func ErrorLogger() HandlerFunc {
 	return ErrorLoggerT(ErrorTypeAny)
@@ -144,9 +150,9 @@ func LoggerWithConfig(conf LoggerConfig) HandlerFunc {
 
 	isTerm := true
 
-	if w, ok := out.(*os.File); !ok ||
+	if w, ok := out.(*os.File); (!ok ||
 		(os.Getenv("TERM") == "dumb" || (!isatty.IsTerminal(w.Fd()) && !isatty.IsCygwinTerminal(w.Fd()))) ||
-		disableColor {
+		disableColor) && !forceColor {
 		isTerm = false
 	}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -340,3 +340,10 @@ func TestDisableConsoleColor(t *testing.T) {
 	DisableConsoleColor()
 	assert.True(t, disableColor)
 }
+
+func TestForceConsoleColor(t *testing.T) {
+	New()
+	assert.False(t, forceColor)
+	ForceConsoleColor()
+	assert.True(t, forceColor)
+}


### PR DESCRIPTION
Add a function `ForceConsoleColor`, like `DisableConsoleColor` but to force coloring the output.

It usefull when some IDE's integrated console (like IntelliJ or Goland) are not detected as TTY, but can display colors.

Also helps if one want to output color in log file (#1590) and as a workaround for #1547.
