### PR TITLE
add sync.Pool to manager JSON,XML,YAML,ProtoBuf... Render object.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ count.out
 test
 profile.out
 tmp.out
+.idea/
+*.iml

--- a/context_17.go
+++ b/context_17.go
@@ -15,7 +15,7 @@ import (
 // PureJSON serializes the given struct as JSON into the response body.
 // PureJSON, unlike JSON, does not replace special html characters with their unicode entities.
 func (c *Context) PureJSON(code int, obj interface{}) {
-	c.Render(code, render.PureJSON{Data: obj})
+	c.RenderWith(render.PureJSONRenderType, code, obj)
 }
 
 /************************************/

--- a/render/empty.go
+++ b/render/empty.go
@@ -1,0 +1,40 @@
+package render
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type EmptyRenderFactory struct{}
+
+type EmptyRender struct{}
+
+func init() {
+	Register(EmptyRenderType, EmptyRenderFactory{})
+}
+
+// Instance apply opts to build a new EmptyRender instance
+func (EmptyRenderFactory) Instance() RenderRecycler {
+	return &EmptyRender{}
+}
+
+// Render writes data with custom ContentType.
+func (r *EmptyRender) Render(w http.ResponseWriter) error {
+	r.WriteContentType(w)
+	return fmt.Errorf("empty render,you need register one first")
+}
+
+// WriteContentType writes custom ContentType.
+func (r *EmptyRender) WriteContentType(w http.ResponseWriter) {
+	// Empty
+}
+
+// Setup set data and opts
+func (r *EmptyRender) Setup(data interface{}, opts ...interface{}) {
+	// Empty
+}
+
+// Reset clean data and opts
+func (r *EmptyRender) Reset() {
+	// Empty
+}

--- a/render/json.go
+++ b/render/json.go
@@ -13,6 +13,14 @@ import (
 	"github.com/gin-gonic/gin/internal/json"
 )
 
+func init() {
+	Register(JSONRenderType, JSONFactory{})
+	Register(IntendedJSONRenderType, IndentedJSONFactory{})
+	Register(JsonpJSONRenderType, JsonpJSONFactory{})
+	Register(SecureJSONRenderType, SecureJSONFactory{})
+	Register(AsciiJSONRenderType, AsciiJSONFactory{})
+}
+
 // JSON contains the given interface object.
 type JSON struct {
 	Data interface{}
@@ -40,6 +48,21 @@ type AsciiJSON struct {
 	Data interface{}
 }
 
+// JSONFactory instance the JSON object.
+type JSONFactory struct{}
+
+// IndentedJSONFactory instance the IndentedJSON object.
+type IndentedJSONFactory struct{}
+
+// SecureJSONFactory instance the SecureJSON object.
+type SecureJSONFactory struct{}
+
+// JsonpJSONFactory instance the JsonpJSON object.
+type JsonpJSONFactory struct{}
+
+// AsciiJSONFactory instance the AsciiJSON object.
+type AsciiJSONFactory struct{}
+
 // SecureJSONPrefix is a string which represents SecureJSON prefix.
 type SecureJSONPrefix string
 
@@ -47,8 +70,18 @@ var jsonContentType = []string{"application/json; charset=utf-8"}
 var jsonpContentType = []string{"application/javascript; charset=utf-8"}
 var jsonAsciiContentType = []string{"application/json"}
 
+// Setup set data and opts
+func (r *JSON) Setup(data interface{}, opts ...interface{}) {
+	r.Data = data
+}
+
+// Reset clean data and opts
+func (r *JSON) Reset() {
+	r.Data = nil
+}
+
 // Render (JSON) writes data with custom ContentType.
-func (r JSON) Render(w http.ResponseWriter) (err error) {
+func (r *JSON) Render(w http.ResponseWriter) (err error) {
 	if err = WriteJSON(w, r.Data); err != nil {
 		panic(err)
 	}
@@ -56,7 +89,7 @@ func (r JSON) Render(w http.ResponseWriter) (err error) {
 }
 
 // WriteContentType (JSON) writes JSON ContentType.
-func (r JSON) WriteContentType(w http.ResponseWriter) {
+func (r *JSON) WriteContentType(w http.ResponseWriter) {
 	writeContentType(w, jsonContentType)
 }
 
@@ -71,8 +104,18 @@ func WriteJSON(w http.ResponseWriter, obj interface{}) error {
 	return nil
 }
 
+// Setup set data and opts
+func (r *IndentedJSON) Setup(data interface{}, opts ...interface{}) {
+	r.Data = data
+}
+
+// Reset clean data and opts
+func (r *IndentedJSON) Reset() {
+	r.Data = nil
+}
+
 // Render (IndentedJSON) marshals the given interface object and writes it with custom ContentType.
-func (r IndentedJSON) Render(w http.ResponseWriter) error {
+func (r *IndentedJSON) Render(w http.ResponseWriter) error {
 	r.WriteContentType(w)
 	jsonBytes, err := json.MarshalIndent(r.Data, "", "    ")
 	if err != nil {
@@ -83,12 +126,26 @@ func (r IndentedJSON) Render(w http.ResponseWriter) error {
 }
 
 // WriteContentType (IndentedJSON) writes JSON ContentType.
-func (r IndentedJSON) WriteContentType(w http.ResponseWriter) {
+func (r *IndentedJSON) WriteContentType(w http.ResponseWriter) {
 	writeContentType(w, jsonContentType)
 }
 
+// Setup set data and opts
+func (r *SecureJSON) Setup(data interface{}, opts ...interface{}) {
+	r.Data = data
+	if len(opts) == 1 {
+		r.Prefix, _ = opts[0].(string)
+	}
+}
+
+// Reset clean data and opts
+func (r *SecureJSON) Reset() {
+	r.Data = nil
+	r.Prefix = ""
+}
+
 // Render (SecureJSON) marshals the given interface object and writes it with custom ContentType.
-func (r SecureJSON) Render(w http.ResponseWriter) error {
+func (r *SecureJSON) Render(w http.ResponseWriter) error {
 	r.WriteContentType(w)
 	jsonBytes, err := json.Marshal(r.Data)
 	if err != nil {
@@ -103,12 +160,26 @@ func (r SecureJSON) Render(w http.ResponseWriter) error {
 }
 
 // WriteContentType (SecureJSON) writes JSON ContentType.
-func (r SecureJSON) WriteContentType(w http.ResponseWriter) {
+func (r *SecureJSON) WriteContentType(w http.ResponseWriter) {
 	writeContentType(w, jsonContentType)
 }
 
+// Setup set data and opts
+func (r *JsonpJSON) Setup(data interface{}, opts ...interface{}) {
+	r.Data = data
+	if len(opts) == 1 {
+		r.Callback, _ = opts[0].(string)
+	}
+}
+
+// Reset clean data and opts
+func (r *JsonpJSON) Reset() {
+	r.Data = nil
+	r.Callback = ""
+}
+
 // Render (JsonpJSON) marshals the given interface object and writes it and its callback with custom ContentType.
-func (r JsonpJSON) Render(w http.ResponseWriter) (err error) {
+func (r *JsonpJSON) Render(w http.ResponseWriter) (err error) {
 	r.WriteContentType(w)
 	ret, err := json.Marshal(r.Data)
 	if err != nil {
@@ -130,12 +201,22 @@ func (r JsonpJSON) Render(w http.ResponseWriter) (err error) {
 }
 
 // WriteContentType (JsonpJSON) writes Javascript ContentType.
-func (r JsonpJSON) WriteContentType(w http.ResponseWriter) {
+func (r *JsonpJSON) WriteContentType(w http.ResponseWriter) {
 	writeContentType(w, jsonpContentType)
 }
 
+// Setup set data and opts
+func (r *AsciiJSON) Setup(data interface{}, opts ...interface{}) {
+	r.Data = data
+}
+
+// Reset clean data and opts
+func (r *AsciiJSON) Reset() {
+	r.Data = nil
+}
+
 // Render (AsciiJSON) marshals the given interface object and writes it with custom ContentType.
-func (r AsciiJSON) Render(w http.ResponseWriter) (err error) {
+func (r *AsciiJSON) Render(w http.ResponseWriter) (err error) {
 	r.WriteContentType(w)
 	ret, err := json.Marshal(r.Data)
 	if err != nil {
@@ -156,6 +237,31 @@ func (r AsciiJSON) Render(w http.ResponseWriter) (err error) {
 }
 
 // WriteContentType (AsciiJSON) writes JSON ContentType.
-func (r AsciiJSON) WriteContentType(w http.ResponseWriter) {
+func (r *AsciiJSON) WriteContentType(w http.ResponseWriter) {
 	writeContentType(w, jsonAsciiContentType)
+}
+
+// Instance a new JSON object.
+func (JSONFactory) Instance() RenderRecycler {
+	return &JSON{}
+}
+
+// Instance a new IndentedJSON object.
+func (IndentedJSONFactory) Instance() RenderRecycler {
+	return &IndentedJSON{}
+}
+
+// Instance a new SecureJSON object.
+func (SecureJSONFactory) Instance() RenderRecycler {
+	return &SecureJSON{}
+}
+
+// Instance a new JsonpJSON object.
+func (JsonpJSONFactory) Instance() RenderRecycler {
+	return &JsonpJSON{}
+}
+
+// Instance a new AsciiJSON object.
+func (AsciiJSONFactory) Instance() RenderRecycler {
+	return &AsciiJSON{}
 }

--- a/render/json_17.go
+++ b/render/json_17.go
@@ -12,10 +12,27 @@ import (
 	"github.com/gin-gonic/gin/internal/json"
 )
 
+func init() {
+	Register(PureJSONRenderType, &PureJsonFactory{})
+}
+
 // PureJSON contains the given interface object.
 type PureJSON struct {
 	Data interface{}
 }
+
+// Setup set data and opts
+func (r *PureJSON) Setup(data interface{}, opts ...interface{}) {
+	r.Data = data
+}
+
+// Reset clean data and opts
+func (r *PureJSON) Reset() {
+	r.Data = nil
+}
+
+// JSONFactory instance the PureJson object.
+type PureJsonFactory struct{}
 
 // Render (PureJSON) writes custom ContentType and encodes the given interface object.
 func (r PureJSON) Render(w http.ResponseWriter) error {
@@ -28,4 +45,9 @@ func (r PureJSON) Render(w http.ResponseWriter) error {
 // WriteContentType (PureJSON) writes custom ContentType.
 func (r PureJSON) WriteContentType(w http.ResponseWriter) {
 	writeContentType(w, jsonContentType)
+}
+
+// Instance a new Render instance
+func (PureJsonFactory) Instance() RenderRecycler {
+	return &PureJSON{}
 }

--- a/render/msgpack.go
+++ b/render/msgpack.go
@@ -10,21 +10,38 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
+func init() {
+	Register(MsgPackRenderType, MsgPackFactory{})
+}
+
 // MsgPack contains the given interface object.
 type MsgPack struct {
 	Data interface{}
 }
 
+// MsgPackFactory instance the MsgPack object.
+type MsgPackFactory struct{}
+
 var msgpackContentType = []string{"application/msgpack; charset=utf-8"}
 
-// WriteContentType (MsgPack) writes MsgPack ContentType.
-func (r MsgPack) WriteContentType(w http.ResponseWriter) {
-	writeContentType(w, msgpackContentType)
+// Setup set data and opts
+func (r *MsgPack) Setup(data interface{}, opts ...interface{}) {
+	r.Data = data
+}
+
+// Reset clean data and opts
+func (r *MsgPack) Reset() {
+	r.Data = nil
 }
 
 // Render (MsgPack) encodes the given interface object and writes data with custom ContentType.
-func (r MsgPack) Render(w http.ResponseWriter) error {
+func (r *MsgPack) Render(w http.ResponseWriter) error {
 	return WriteMsgPack(w, r.Data)
+}
+
+// WriteContentType (MsgPack) writes MsgPack ContentType.
+func (r *MsgPack) WriteContentType(w http.ResponseWriter) {
+	writeContentType(w, msgpackContentType)
 }
 
 // WriteMsgPack writes MsgPack ContentType and encodes the given interface object.
@@ -32,4 +49,9 @@ func WriteMsgPack(w http.ResponseWriter, obj interface{}) error {
 	writeContentType(w, msgpackContentType)
 	var mh codec.MsgpackHandle
 	return codec.NewEncoder(w, &mh).Encode(obj)
+}
+
+// Instance a new MsgPack object.
+func (MsgPackFactory) Instance() RenderRecycler {
+	return &MsgPack{}
 }

--- a/render/protobuf.go
+++ b/render/protobuf.go
@@ -10,15 +10,32 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
+func init() {
+	Register(ProtoBufRenderType, ProtoBufFactory{})
+}
+
 // ProtoBuf contains the given interface object.
 type ProtoBuf struct {
 	Data interface{}
 }
 
+// ProtoBufFactory instance the ProtoBuf object.
+type ProtoBufFactory struct{}
+
 var protobufContentType = []string{"application/x-protobuf"}
 
+// Setup set data and opts
+func (r *ProtoBuf) Setup(data interface{}, opts ...interface{}) {
+	r.Data = data
+}
+
+// Reset clean data and opts
+func (r *ProtoBuf) Reset() {
+	r.Data = nil
+}
+
 // Render (ProtoBuf) marshals the given interface object and writes data with custom ContentType.
-func (r ProtoBuf) Render(w http.ResponseWriter) error {
+func (r *ProtoBuf) Render(w http.ResponseWriter) error {
 	r.WriteContentType(w)
 
 	bytes, err := proto.Marshal(r.Data.(proto.Message))
@@ -31,6 +48,11 @@ func (r ProtoBuf) Render(w http.ResponseWriter) error {
 }
 
 // WriteContentType (ProtoBuf) writes ProtoBuf ContentType.
-func (r ProtoBuf) WriteContentType(w http.ResponseWriter) {
+func (r *ProtoBuf) WriteContentType(w http.ResponseWriter) {
 	writeContentType(w, protobufContentType)
+}
+
+// Instance a new ProtoBuf object.
+func (ProtoBufFactory) Instance() RenderRecycler {
+	return &ProtoBuf{}
 }

--- a/render/render.go
+++ b/render/render.go
@@ -4,7 +4,30 @@
 
 package render
 
-import "net/http"
+import (
+	"net/http"
+	"sync"
+)
+
+// RenderType Names
+const (
+	JSONRenderType         = iota // JSON Render Type
+	IntendedJSONRenderType        // IntendedJSON Render Type
+	PureJSONRenderType            // PureJSON Render Type
+	AsciiJSONRenderType           // AsciiJSON Render Type
+	JsonpJSONRenderType           // JsonpJSON Render Type
+	SecureJSONRenderType          // SecureJSON Type
+	XMLRenderType                 // XML Render Type
+	YAMLRenderType                // YAML Render Type
+	MsgPackRenderType             // MsgPack Render Type
+	ProtoBufRenderType            // ProtoBuf Render Type
+	EmptyRenderType               // Empty Render Type
+	unknownRenderType             // Unknown Render Type,just used for test
+)
+
+var (
+	renderPool = &RenderPool{renderPools: make(map[int]sync.Pool)}
+)
 
 // Render interface is to be implemented by JSON, XML, HTML, YAML and so on.
 type Render interface {
@@ -14,23 +37,103 @@ type Render interface {
 	WriteContentType(w http.ResponseWriter)
 }
 
+// RenderRecycler interface is to be implemented by JSON, XML, HTML, YAML and so on.
+type RenderRecycler interface {
+	Render
+	// Setup set data and opts
+	Setup(data interface{}, opts ...interface{})
+	// Reset clean data and opts
+	Reset()
+}
+
+// RenderFactory interface is to be implemented by other Render.
+type RenderFactory interface {
+	// Instance a new RenderRecycler instance
+	Instance() RenderRecycler
+}
+
+// RenderPool contains Render instance
+type RenderPool struct {
+	mu          sync.RWMutex
+	renderPools map[int]sync.Pool
+}
+
+func (p *RenderPool) get(name int) RenderRecycler {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	var render RenderRecycler
+	if pool, ok := p.renderPools[name]; ok {
+		render, _ = pool.Get().(RenderRecycler)
+	} else {
+		pool, _ = p.renderPools[EmptyRenderType]
+		render, _ = pool.Get().(RenderRecycler)
+	}
+	return render
+}
+
+func (p *RenderPool) put(name int, render RenderRecycler) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if pool, ok := p.renderPools[name]; ok {
+		render.Reset()
+		pool.Put(render)
+	}
+}
+
+func (p *RenderPool) register(name int, factory RenderFactory) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if factory == nil {
+		panic("gin: Register RenderFactory is nil")
+	}
+	if _, dup := p.renderPools[name]; dup {
+		panic("gin: Register called twice for RenderFactory")
+	}
+
+	p.renderPools[name] = sync.Pool{
+		New: func() interface{} {
+			return factory.Instance()
+		},
+	}
+}
+
+// Register makes a binding available by the provided name.
+// If Register is called twice with the same name or if binding is nil,
+// it panics.
+func Register(name int, factory RenderFactory) {
+	renderPool.register(name, factory)
+}
+
+// Default returns the appropriate Render instance based on the render type.
+func Default(name int) RenderRecycler {
+	return renderPool.get(name)
+}
+
+// Recycle put render to sync.Pool
+func Recycle(name int, render RenderRecycler) {
+	renderPool.put(name, render)
+}
+
 var (
-	_ Render     = JSON{}
-	_ Render     = IndentedJSON{}
-	_ Render     = SecureJSON{}
-	_ Render     = JsonpJSON{}
-	_ Render     = XML{}
-	_ Render     = String{}
-	_ Render     = Redirect{}
-	_ Render     = Data{}
-	_ Render     = HTML{}
-	_ HTMLRender = HTMLDebug{}
-	_ HTMLRender = HTMLProduction{}
-	_ Render     = YAML{}
-	_ Render     = MsgPack{}
-	_ Render     = Reader{}
-	_ Render     = AsciiJSON{}
-	_ Render     = ProtoBuf{}
+	_ RenderRecycler = &JSON{}
+	_ RenderRecycler = &IndentedJSON{}
+	_ RenderRecycler = &SecureJSON{}
+	_ RenderRecycler = &JsonpJSON{}
+	_ RenderRecycler = &XML{}
+	_ Render         = String{}
+	_ Render         = Redirect{}
+	_ Render         = Data{}
+	_ Render         = HTML{}
+	_ HTMLRender     = HTMLDebug{}
+	_ HTMLRender     = HTMLProduction{}
+	_ RenderRecycler = &YAML{}
+	_ RenderRecycler = &MsgPack{}
+	_ Render         = Reader{}
+	_ RenderRecycler = &AsciiJSON{}
+	_ RenderRecycler = &ProtoBuf{}
 )
 
 func writeContentType(w http.ResponseWriter, value []string) {

--- a/render/render_17_test.go
+++ b/render/render_17_test.go
@@ -19,7 +19,10 @@ func TestRenderPureJSON(t *testing.T) {
 		"foo":  "bar",
 		"html": "<b>",
 	}
-	err := (PureJSON{data}).Render(w)
+	r := Default(PureJSONRenderType)
+	r.Setup(data)
+	err := r.Render(w)
+	Recycle(PureJSONRenderType, r)
 	assert.NoError(t, err)
 	assert.Equal(t, "{\"foo\":\"bar\",\"html\":\"<b>\"}\n", w.Body.String())
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))

--- a/render/xml.go
+++ b/render/xml.go
@@ -9,20 +9,42 @@ import (
 	"net/http"
 )
 
+func init() {
+	Register(XMLRenderType, XMLFactory{})
+}
+
 // XML contains the given interface object.
 type XML struct {
 	Data interface{}
 }
 
+// XMLFactory instance the XML object.
+type XMLFactory struct{}
+
 var xmlContentType = []string{"application/xml; charset=utf-8"}
 
+// Setup set data and opts
+func (r *XML) Setup(data interface{}, opts ...interface{}) {
+	r.Data = data
+}
+
+// Reset clean data and opts
+func (r *XML) Reset() {
+	r.Data = nil
+}
+
 // Render (XML) encodes the given interface object and writes data with custom ContentType.
-func (r XML) Render(w http.ResponseWriter) error {
+func (r *XML) Render(w http.ResponseWriter) error {
 	r.WriteContentType(w)
 	return xml.NewEncoder(w).Encode(r.Data)
 }
 
 // WriteContentType (XML) writes XML ContentType for response.
-func (r XML) WriteContentType(w http.ResponseWriter) {
+func (r *XML) WriteContentType(w http.ResponseWriter) {
 	writeContentType(w, xmlContentType)
+}
+
+// Instance a new XML object.
+func (XMLFactory) Instance() RenderRecycler {
+	return &XML{}
 }

--- a/render/yaml.go
+++ b/render/yaml.go
@@ -10,15 +10,32 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+func init() {
+	Register(YAMLRenderType, YAMLFactory{})
+}
+
 // YAML contains the given interface object.
 type YAML struct {
 	Data interface{}
 }
 
+// YAMLFactory instance the YAML object.
+type YAMLFactory struct{}
+
 var yamlContentType = []string{"application/x-yaml; charset=utf-8"}
 
+// Setup set data and opts
+func (r *YAML) Setup(data interface{}, opts ...interface{}) {
+	r.Data = data
+}
+
+// Reset clean data and opts
+func (r *YAML) Reset() {
+	r.Data = nil
+}
+
 // Render (YAML) marshals the given interface object and writes data with custom ContentType.
-func (r YAML) Render(w http.ResponseWriter) error {
+func (r *YAML) Render(w http.ResponseWriter) error {
 	r.WriteContentType(w)
 
 	bytes, err := yaml.Marshal(r.Data)
@@ -31,6 +48,11 @@ func (r YAML) Render(w http.ResponseWriter) error {
 }
 
 // WriteContentType (YAML) writes YAML ContentType for response.
-func (r YAML) WriteContentType(w http.ResponseWriter) {
+func (r *YAML) WriteContentType(w http.ResponseWriter) {
 	writeContentType(w, yamlContentType)
+}
+
+// Instance a new Render instance
+func (YAMLFactory) Instance() RenderRecycler {
+	return &YAML{}
 }


### PR DESCRIPTION
* add sync.Pool to manager JSON,XML,YAML,ProtoBuf,MsgPack Render object.
* we can move JSON,XML,YAML,ProtoBuf,MsgPack Render implement to sub-module in Gin (such like [github.com/alimy/gin/tree/master/module](https://github.com/alimy/gin/tree/master/module))  or other module repository based on this change.

