### PR TITLE
fix errcheck warnings

### DIFF
--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -516,28 +516,28 @@ func createFormPostRequestFail() *http.Request {
 	return req
 }
 
-func createFormMultipartRequest() *http.Request {
+func createFormMultipartRequest(t *testing.T) *http.Request {
 	boundary := "--testboundary"
 	body := new(bytes.Buffer)
 	mw := multipart.NewWriter(body)
 	defer mw.Close()
 
-	mw.SetBoundary(boundary)
-	mw.WriteField("foo", "bar")
-	mw.WriteField("bar", "foo")
+	assert.NoError(t, mw.SetBoundary(boundary))
+	assert.NoError(t, mw.WriteField("foo", "bar"))
+	assert.NoError(t, mw.WriteField("bar", "foo"))
 	req, _ := http.NewRequest("POST", "/?foo=getfoo&bar=getbar", body)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+boundary)
 	return req
 }
 
-func createFormMultipartRequestFail() *http.Request {
+func createFormMultipartRequestFail(t *testing.T) *http.Request {
 	boundary := "--testboundary"
 	body := new(bytes.Buffer)
 	mw := multipart.NewWriter(body)
 	defer mw.Close()
 
-	mw.SetBoundary(boundary)
-	mw.WriteField("map_foo", "bar")
+	assert.NoError(t, mw.SetBoundary(boundary))
+	assert.NoError(t, mw.WriteField("map_foo", "bar"))
 	req, _ := http.NewRequest("POST", "/?map_foo=getfoo", body)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+boundary)
 	return req
@@ -546,7 +546,7 @@ func createFormMultipartRequestFail() *http.Request {
 func TestBindingFormPost(t *testing.T) {
 	req := createFormPostRequest()
 	var obj FooBarStruct
-	FormPost.Bind(req, &obj)
+	assert.NoError(t, FormPost.Bind(req, &obj))
 
 	assert.Equal(t, "form-urlencoded", FormPost.Name())
 	assert.Equal(t, "bar", obj.Foo)
@@ -556,7 +556,7 @@ func TestBindingFormPost(t *testing.T) {
 func TestBindingDefaultValueFormPost(t *testing.T) {
 	req := createDefaultFormPostRequest()
 	var obj FooDefaultBarStruct
-	FormPost.Bind(req, &obj)
+	assert.NoError(t, FormPost.Bind(req, &obj))
 
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, "hello", obj.Bar)
@@ -570,9 +570,9 @@ func TestBindingFormPostFail(t *testing.T) {
 }
 
 func TestBindingFormMultipart(t *testing.T) {
-	req := createFormMultipartRequest()
+	req := createFormMultipartRequest(t)
 	var obj FooBarStruct
-	FormMultipart.Bind(req, &obj)
+	assert.NoError(t, FormMultipart.Bind(req, &obj))
 
 	assert.Equal(t, "multipart/form-data", FormMultipart.Name())
 	assert.Equal(t, "bar", obj.Foo)
@@ -580,7 +580,7 @@ func TestBindingFormMultipart(t *testing.T) {
 }
 
 func TestBindingFormMultipartFail(t *testing.T) {
-	req := createFormMultipartRequestFail()
+	req := createFormMultipartRequestFail(t)
 	var obj FooStructForMapType
 	err := FormMultipart.Bind(req, &obj)
 	assert.Error(t, err)

--- a/binding/form.go
+++ b/binding/form.go
@@ -20,7 +20,11 @@ func (formBinding) Bind(req *http.Request, obj interface{}) error {
 	if err := req.ParseForm(); err != nil {
 		return err
 	}
-	req.ParseMultipartForm(defaultMemory)
+	if err := req.ParseMultipartForm(defaultMemory); err != nil {
+		if err != http.ErrNotMultipart {
+			return err
+		}
+	}
 	if err := mapForm(obj, req.Form); err != nil {
 		return err
 	}

--- a/context.go
+++ b/context.go
@@ -415,7 +415,11 @@ func (c *Context) PostFormArray(key string) []string {
 // a boolean value whether at least one value exists for the given key.
 func (c *Context) GetPostFormArray(key string) ([]string, bool) {
 	req := c.Request
-	req.ParseMultipartForm(c.engine.MaxMultipartMemory)
+	if err := req.ParseMultipartForm(c.engine.MaxMultipartMemory); err != nil {
+		if err != http.ErrNotMultipart {
+			debugPrint("error on parse multipart form array: %v", err)
+		}
+	}
 	if values := req.PostForm[key]; len(values) > 0 {
 		return values, true
 	}
@@ -437,7 +441,11 @@ func (c *Context) PostFormMap(key string) map[string]string {
 // whether at least one value exists for the given key.
 func (c *Context) GetPostFormMap(key string) (map[string]string, bool) {
 	req := c.Request
-	req.ParseMultipartForm(c.engine.MaxMultipartMemory)
+	if err := req.ParseMultipartForm(c.engine.MaxMultipartMemory); err != nil {
+		if err != http.ErrNotMultipart {
+			debugPrint("error on parse multipart form map: %v", err)
+		}
+	}
 	dicts, exist := c.get(req.PostForm, key)
 
 	if !exist && req.MultipartForm != nil && req.MultipartForm.File != nil {
@@ -493,8 +501,8 @@ func (c *Context) SaveUploadedFile(file *multipart.FileHeader, dst string) error
 	}
 	defer out.Close()
 
-	io.Copy(out, src)
-	return nil
+	_, err = io.Copy(out, src)
+	return err
 }
 
 // Bind checks the Content-Type to select a binding engine automatically,
@@ -534,7 +542,7 @@ func (c *Context) BindYAML(obj interface{}) error {
 // It will abort the request with HTTP 400 if any error occurs.
 func (c *Context) BindUri(obj interface{}) error {
 	if err := c.ShouldBindUri(obj); err != nil {
-		c.AbortWithError(http.StatusBadRequest, err).SetType(ErrorTypeBind)
+		c.AbortWithError(http.StatusBadRequest, err).SetType(ErrorTypeBind) // nolint: errcheck
 		return err
 	}
 	return nil
@@ -545,7 +553,7 @@ func (c *Context) BindUri(obj interface{}) error {
 // See the binding package.
 func (c *Context) MustBindWith(obj interface{}, b binding.Binding) error {
 	if err := c.ShouldBindWith(obj, b); err != nil {
-		c.AbortWithError(http.StatusBadRequest, err).SetType(ErrorTypeBind)
+		c.AbortWithError(http.StatusBadRequest, err).SetType(ErrorTypeBind) // nolint: errcheck
 		return err
 	}
 	return nil
@@ -913,7 +921,7 @@ func (c *Context) Negotiate(code int, config Negotiate) {
 		c.XML(code, data)
 
 	default:
-		c.AbortWithError(http.StatusNotAcceptable, errors.New("the accepted formats are not offered by the server"))
+		c.AbortWithError(http.StatusNotAcceptable, errors.New("the accepted formats are not offered by the server")) // nolint: errcheck
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -70,7 +70,8 @@ func TestContextFormFile(t *testing.T) {
 	mw := multipart.NewWriter(buf)
 	w, err := mw.CreateFormFile("file", "test")
 	if assert.NoError(t, err) {
-		w.Write([]byte("test"))
+		_, err = w.Write([]byte("test"))
+		assert.NoError(t, err)
 	}
 	mw.Close()
 	c, _ := CreateTestContext(httptest.NewRecorder())
@@ -100,10 +101,11 @@ func TestContextFormFileFailed(t *testing.T) {
 func TestContextMultipartForm(t *testing.T) {
 	buf := new(bytes.Buffer)
 	mw := multipart.NewWriter(buf)
-	mw.WriteField("foo", "bar")
+	assert.NoError(t, mw.WriteField("foo", "bar"))
 	w, err := mw.CreateFormFile("file", "test")
 	if assert.NoError(t, err) {
-		w.Write([]byte("test"))
+		_, err = w.Write([]byte("test"))
+		assert.NoError(t, err)
 	}
 	mw.Close()
 	c, _ := CreateTestContext(httptest.NewRecorder())
@@ -137,7 +139,8 @@ func TestSaveUploadedCreateFailed(t *testing.T) {
 	mw := multipart.NewWriter(buf)
 	w, err := mw.CreateFormFile("file", "test")
 	if assert.NoError(t, err) {
-		w.Write([]byte("test"))
+		_, err = w.Write([]byte("test"))
+		assert.NoError(t, err)
 	}
 	mw.Close()
 	c, _ := CreateTestContext(httptest.NewRecorder())
@@ -159,7 +162,7 @@ func TestContextReset(t *testing.T) {
 	c.index = 2
 	c.Writer = &responseWriter{ResponseWriter: httptest.NewRecorder()}
 	c.Params = Params{Param{}}
-	c.Error(errors.New("test"))
+	c.Error(errors.New("test")) // nolint: errcheck
 	c.Set("foo", "bar")
 	c.reset()
 
@@ -798,7 +801,7 @@ func TestContextRenderHTML2(t *testing.T) {
 	assert.Len(t, router.trees, 1)
 
 	templ := template.Must(template.New("t").Parse(`Hello {{.name}}`))
-	re := captureOutput(func() {
+	re := captureOutput(t, func() {
 		SetMode(DebugMode)
 		router.SetHTMLTemplate(templ)
 		SetMode(TestMode)
@@ -1211,7 +1214,8 @@ func TestContextAbortWithStatusJSON(t *testing.T) {
 	assert.Equal(t, "application/json; charset=utf-8", contentType)
 
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(w.Body)
+	_, err := buf.ReadFrom(w.Body)
+	assert.NoError(t, err)
 	jsonStringBody := buf.String()
 	assert.Equal(t, fmt.Sprint(`{"foo":"fooValue","bar":"barValue"}`), jsonStringBody)
 }
@@ -1220,11 +1224,11 @@ func TestContextError(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	assert.Empty(t, c.Errors)
 
-	c.Error(errors.New("first error"))
+	c.Error(errors.New("first error")) // nolint: errcheck
 	assert.Len(t, c.Errors, 1)
 	assert.Equal(t, "Error #01: first error\n", c.Errors.String())
 
-	c.Error(&Error{
+	c.Error(&Error{ // nolint: errcheck
 		Err:  errors.New("second error"),
 		Meta: "some data 2",
 		Type: ErrorTypePublic,
@@ -1246,13 +1250,13 @@ func TestContextError(t *testing.T) {
 			t.Error("didn't panic")
 		}
 	}()
-	c.Error(nil)
+	c.Error(nil) // nolint: errcheck
 }
 
 func TestContextTypedError(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
-	c.Error(errors.New("externo 0")).SetType(ErrorTypePublic)
-	c.Error(errors.New("interno 0")).SetType(ErrorTypePrivate)
+	c.Error(errors.New("externo 0")).SetType(ErrorTypePublic)  // nolint: errcheck
+	c.Error(errors.New("interno 0")).SetType(ErrorTypePrivate) // nolint: errcheck
 
 	for _, err := range c.Errors.ByType(ErrorTypePublic) {
 		assert.Equal(t, ErrorTypePublic, err.Type)
@@ -1267,7 +1271,7 @@ func TestContextAbortWithError(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := CreateTestContext(w)
 
-	c.AbortWithError(http.StatusUnauthorized, errors.New("bad input")).SetMeta("some input")
+	c.AbortWithError(http.StatusUnauthorized, errors.New("bad input")).SetMeta("some input") // nolint: errcheck
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	assert.Equal(t, abortIndex, c.index)
@@ -1713,7 +1717,8 @@ func TestContextStream(t *testing.T) {
 			stopStream = false
 		}()
 
-		w.Write([]byte("test"))
+		_, err := w.Write([]byte("test"))
+		assert.NoError(t, err)
 
 		return stopStream
 	})
@@ -1730,7 +1735,8 @@ func TestContextStreamWithClientGone(t *testing.T) {
 			w.closeClient()
 		}()
 
-		writer.Write([]byte("test"))
+		_, err := writer.Write([]byte("test"))
+		assert.NoError(t, err)
 
 		return true
 	})

--- a/debug_test.go
+++ b/debug_test.go
@@ -32,7 +32,7 @@ func TestIsDebugging(t *testing.T) {
 }
 
 func TestDebugPrint(t *testing.T) {
-	re := captureOutput(func() {
+	re := captureOutput(t, func() {
 		SetMode(DebugMode)
 		SetMode(ReleaseMode)
 		debugPrint("DEBUG this!")
@@ -46,7 +46,7 @@ func TestDebugPrint(t *testing.T) {
 }
 
 func TestDebugPrintError(t *testing.T) {
-	re := captureOutput(func() {
+	re := captureOutput(t, func() {
 		SetMode(DebugMode)
 		debugPrintError(nil)
 		debugPrintError(errors.New("this is an error"))
@@ -56,7 +56,7 @@ func TestDebugPrintError(t *testing.T) {
 }
 
 func TestDebugPrintRoutes(t *testing.T) {
-	re := captureOutput(func() {
+	re := captureOutput(t, func() {
 		SetMode(DebugMode)
 		debugPrintRoute("GET", "/path/to/route/:param", HandlersChain{func(c *Context) {}, handlerNameTest})
 		SetMode(TestMode)
@@ -65,7 +65,7 @@ func TestDebugPrintRoutes(t *testing.T) {
 }
 
 func TestDebugPrintLoadTemplate(t *testing.T) {
-	re := captureOutput(func() {
+	re := captureOutput(t, func() {
 		SetMode(DebugMode)
 		templ := template.Must(template.New("").Delims("{[{", "}]}").ParseGlob("./testdata/template/hello.tmpl"))
 		debugPrintLoadTemplate(templ)
@@ -75,7 +75,7 @@ func TestDebugPrintLoadTemplate(t *testing.T) {
 }
 
 func TestDebugPrintWARNINGSetHTMLTemplate(t *testing.T) {
-	re := captureOutput(func() {
+	re := captureOutput(t, func() {
 		SetMode(DebugMode)
 		debugPrintWARNINGSetHTMLTemplate()
 		SetMode(TestMode)
@@ -84,7 +84,7 @@ func TestDebugPrintWARNINGSetHTMLTemplate(t *testing.T) {
 }
 
 func TestDebugPrintWARNINGDefault(t *testing.T) {
-	re := captureOutput(func() {
+	re := captureOutput(t, func() {
 		SetMode(DebugMode)
 		debugPrintWARNINGDefault()
 		SetMode(TestMode)
@@ -98,7 +98,7 @@ func TestDebugPrintWARNINGDefault(t *testing.T) {
 }
 
 func TestDebugPrintWARNINGNew(t *testing.T) {
-	re := captureOutput(func() {
+	re := captureOutput(t, func() {
 		SetMode(DebugMode)
 		debugPrintWARNINGNew()
 		SetMode(TestMode)
@@ -106,7 +106,7 @@ func TestDebugPrintWARNINGNew(t *testing.T) {
 	assert.Equal(t, "[GIN-debug] [WARNING] Running in \"debug\" mode. Switch to \"release\" mode in production.\n - using env:\texport GIN_MODE=release\n - using code:\tgin.SetMode(gin.ReleaseMode)\n\n", re)
 }
 
-func captureOutput(f func()) string {
+func captureOutput(t *testing.T, f func()) string {
 	reader, writer, err := os.Pipe()
 	if err != nil {
 		panic(err)
@@ -127,7 +127,8 @@ func captureOutput(f func()) string {
 	go func() {
 		var buf bytes.Buffer
 		wg.Done()
-		io.Copy(&buf, reader)
+		_, err := io.Copy(&buf, reader)
+		assert.NoError(t, err)
 		out <- buf.String()
 	}()
 	wg.Wait()

--- a/errors_test.go
+++ b/errors_test.go
@@ -34,7 +34,7 @@ func TestError(t *testing.T) {
 	jsonBytes, _ := json.Marshal(err)
 	assert.Equal(t, "{\"error\":\"test error\",\"meta\":\"some data\"}", string(jsonBytes))
 
-	err.SetMeta(H{
+	err.SetMeta(H{ // nolint: errcheck
 		"status": "200",
 		"data":   "some data",
 	})
@@ -44,7 +44,7 @@ func TestError(t *testing.T) {
 		"data":   "some data",
 	}, err.JSON())
 
-	err.SetMeta(H{
+	err.SetMeta(H{ // nolint: errcheck
 		"error":  "custom error",
 		"status": "200",
 		"data":   "some data",
@@ -59,7 +59,7 @@ func TestError(t *testing.T) {
 		status string
 		data   string
 	}
-	err.SetMeta(customError{status: "200", data: "other data"})
+	err.SetMeta(customError{status: "200", data: "other data"}) // nolint: errcheck
 	assert.Equal(t, customError{status: "200", data: "other data"}, err.JSON())
 }
 

--- a/gin.go
+++ b/gin.go
@@ -422,7 +422,10 @@ func serveError(c *Context, code int, defaultMessage []byte) {
 	}
 	if c.writermem.Status() == code {
 		c.writermem.Header()["Content-Type"] = mimePlain
-		c.Writer.Write(defaultMessage)
+		_, err := c.Writer.Write(defaultMessage)
+		if err != nil {
+			debugPrint("cannot write message to writer during serve error: %v", err)
+		}
 		return
 	}
 	c.writermem.WriteHeaderNow()

--- a/gin_integration_test.go
+++ b/gin_integration_test.go
@@ -87,7 +87,7 @@ func TestRunEmptyWithEnv(t *testing.T) {
 func TestRunTooMuchParams(t *testing.T) {
 	router := New()
 	assert.Panics(t, func() {
-		router.Run("2", "2")
+		assert.NoError(t, router.Run("2", "2"))
 	})
 }
 

--- a/githubapi_test.go
+++ b/githubapi_test.go
@@ -338,7 +338,7 @@ func TestBindUriError(t *testing.T) {
 	}
 	router.Handle("GET", "/new/rest/:num", func(c *Context) {
 		var m Member
-		c.BindUri(&m)
+		assert.Error(t, c.BindUri(&m))
 	})
 
 	path1, _ := exampleFromPath("/new/rest/:num")

--- a/logger_test.go
+++ b/logger_test.go
@@ -278,13 +278,13 @@ func TestErrorLogger(t *testing.T) {
 	router := New()
 	router.Use(ErrorLogger())
 	router.GET("/error", func(c *Context) {
-		c.Error(errors.New("this is an error"))
+		c.Error(errors.New("this is an error")) // nolint: errcheck
 	})
 	router.GET("/abort", func(c *Context) {
-		c.AbortWithError(http.StatusUnauthorized, errors.New("no authorized"))
+		c.AbortWithError(http.StatusUnauthorized, errors.New("no authorized")) // nolint: errcheck
 	})
 	router.GET("/print", func(c *Context) {
-		c.Error(errors.New("this is an error"))
+		c.Error(errors.New("this is an error")) // nolint: errcheck
 		c.String(http.StatusInternalServerError, "hola!")
 	})
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -208,7 +208,7 @@ func TestMiddlewareFailHandlersChain(t *testing.T) {
 	router := New()
 	router.Use(func(context *Context) {
 		signature += "A"
-		context.AbortWithError(http.StatusInternalServerError, errors.New("foo"))
+		context.AbortWithError(http.StatusInternalServerError, errors.New("foo")) // nolint: errcheck
 	})
 	router.Use(func(context *Context) {
 		signature += "B"

--- a/recovery.go
+++ b/recovery.go
@@ -66,7 +66,7 @@ func RecoveryWithWriter(out io.Writer) HandlerFunc {
 
 				// If the connection is dead, we can't write a status to it.
 				if brokenPipe {
-					c.Error(err.(error))
+					c.Error(err.(error)) // nolint: errcheck
 					c.Abort()
 				} else {
 					c.AbortWithStatus(http.StatusInternalServerError)

--- a/render/json.go
+++ b/render/json.go
@@ -67,8 +67,8 @@ func WriteJSON(w http.ResponseWriter, obj interface{}) error {
 	if err != nil {
 		return err
 	}
-	w.Write(jsonBytes)
-	return nil
+	_, err = w.Write(jsonBytes)
+	return err
 }
 
 // Render (IndentedJSON) marshals the given interface object and writes it with custom ContentType.
@@ -78,8 +78,8 @@ func (r IndentedJSON) Render(w http.ResponseWriter) error {
 	if err != nil {
 		return err
 	}
-	w.Write(jsonBytes)
-	return nil
+	_, err = w.Write(jsonBytes)
+	return err
 }
 
 // WriteContentType (IndentedJSON) writes JSON ContentType.
@@ -96,10 +96,13 @@ func (r SecureJSON) Render(w http.ResponseWriter) error {
 	}
 	// if the jsonBytes is array values
 	if bytes.HasPrefix(jsonBytes, []byte("[")) && bytes.HasSuffix(jsonBytes, []byte("]")) {
-		w.Write([]byte(r.Prefix))
+		_, err = w.Write([]byte(r.Prefix))
+		if err != nil {
+			return err
+		}
 	}
-	w.Write(jsonBytes)
-	return nil
+	_, err = w.Write(jsonBytes)
+	return err
 }
 
 // WriteContentType (SecureJSON) writes JSON ContentType.
@@ -116,15 +119,27 @@ func (r JsonpJSON) Render(w http.ResponseWriter) (err error) {
 	}
 
 	if r.Callback == "" {
-		w.Write(ret)
-		return nil
+		_, err = w.Write(ret)
+		return err
 	}
 
 	callback := template.JSEscapeString(r.Callback)
-	w.Write([]byte(callback))
-	w.Write([]byte("("))
-	w.Write(ret)
-	w.Write([]byte(")"))
+	_, err = w.Write([]byte(callback))
+	if err != nil {
+		return err
+	}
+	_, err = w.Write([]byte("("))
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(ret)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write([]byte(")"))
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -151,8 +166,8 @@ func (r AsciiJSON) Render(w http.ResponseWriter) (err error) {
 		buffer.WriteString(cvt)
 	}
 
-	w.Write(buffer.Bytes())
-	return nil
+	_, err = w.Write(buffer.Bytes())
+	return err
 }
 
 // WriteContentType (AsciiJSON) writes JSON ContentType.

--- a/render/protobuf.go
+++ b/render/protobuf.go
@@ -26,8 +26,8 @@ func (r ProtoBuf) Render(w http.ResponseWriter) error {
 		return err
 	}
 
-	w.Write(bytes)
-	return nil
+	_, err = w.Write(bytes)
+	return err
 }
 
 // WriteContentType (ProtoBuf) writes ProtoBuf ContentType.

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -71,7 +71,7 @@ func TestRenderJSONPanics(t *testing.T) {
 	data := make(chan int)
 
 	// json: unsupported type: chan int
-	assert.Panics(t, func() { (JSON{data}).Render(w) })
+	assert.Panics(t, func() { assert.NoError(t, (JSON{data}).Render(w)) })
 }
 
 func TestRenderIndentedJSON(t *testing.T) {
@@ -335,7 +335,7 @@ func TestRenderRedirect(t *testing.T) {
 	}
 
 	w = httptest.NewRecorder()
-	assert.Panics(t, func() { data2.Render(w) })
+	assert.Panics(t, func() { assert.NoError(t, data2.Render(w)) })
 
 	// only improve coverage
 	data2.WriteContentType(w)

--- a/render/text.go
+++ b/render/text.go
@@ -20,8 +20,7 @@ var plainContentType = []string{"text/plain; charset=utf-8"}
 
 // Render (String) writes data with custom ContentType.
 func (r String) Render(w http.ResponseWriter) error {
-	WriteString(w, r.Format, r.Data)
-	return nil
+	return WriteString(w, r.Format, r.Data)
 }
 
 // WriteContentType (String) writes Plain ContentType.
@@ -30,11 +29,12 @@ func (r String) WriteContentType(w http.ResponseWriter) {
 }
 
 // WriteString writes data according to its format and write custom ContentType.
-func WriteString(w http.ResponseWriter, format string, data []interface{}) {
+func WriteString(w http.ResponseWriter, format string, data []interface{}) (err error) {
 	writeContentType(w, plainContentType)
 	if len(data) > 0 {
-		fmt.Fprintf(w, format, data...)
+		_, err = fmt.Fprintf(w, format, data...)
 		return
 	}
-	io.WriteString(w, format)
+	_, err = io.WriteString(w, format)
+	return
 }

--- a/render/yaml.go
+++ b/render/yaml.go
@@ -26,8 +26,8 @@ func (r YAML) Render(w http.ResponseWriter) error {
 		return err
 	}
 
-	w.Write(bytes)
-	return nil
+	_, err = w.Write(bytes)
+	return err
 }
 
 // WriteContentType (YAML) writes YAML ContentType for response.

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -103,7 +103,8 @@ func TestResponseWriterHijack(t *testing.T) {
 	w := ResponseWriter(writer)
 
 	assert.Panics(t, func() {
-		w.Hijack()
+		_, _, err := w.Hijack()
+		assert.NoError(t, err)
 	})
 	assert.True(t, w.Written())
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -251,7 +251,8 @@ func TestRouteStaticFile(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.Remove(f.Name())
-	f.WriteString("Gin Web Framework")
+	_, err = f.WriteString("Gin Web Framework")
+	assert.NoError(t, err)
 	f.Close()
 
 	dir, filename := filepath.Split(f.Name())


### PR DESCRIPTION
Fix all warnings after run `golangci-lint run --disable-all -E errcheck`
Fix #1738 #1247