### PR TITLE
fix Context.Next() - recheck len of handlers every iteration

### DIFF
--- a/context.go
+++ b/context.go
@@ -105,7 +105,7 @@ func (c *Context) Handler() HandlerFunc {
 // See example in GitHub.
 func (c *Context) Next() {
 	c.index++
-	for s := int8(len(c.handlers)); c.index < s; c.index++ {
+	for ; c.index < int8(len(c.handlers)); c.index++ {
 		c.handlers[c.index](c)
 	}
 }

--- a/context.go
+++ b/context.go
@@ -105,8 +105,9 @@ func (c *Context) Handler() HandlerFunc {
 // See example in GitHub.
 func (c *Context) Next() {
 	c.index++
-	for ; c.index < int8(len(c.handlers)); c.index++ {
+	for c.index < int8(len(c.handlers)) {
 		c.handlers[c.index](c)
+		c.index++
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -1737,3 +1737,15 @@ func TestContextStreamWithClientGone(t *testing.T) {
 
 	assert.Equal(t, "test", w.Body.String())
 }
+
+func TestContextResetInHandler(t *testing.T) {
+	w := CreateTestResponseRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.handlers = []HandlerFunc{
+		func(c *Context) { c.reset() },
+	}
+	assert.NotPanics(t, func() {
+		c.Next()
+	})
+}

--- a/gin_test.go
+++ b/gin_test.go
@@ -471,6 +471,23 @@ func TestListOfRoutes(t *testing.T) {
 	})
 }
 
+func TestEngineHandleContext(t *testing.T) {
+	r := New()
+	r.GET("/", func(c *Context) {
+		c.Request.URL.Path = "/v2"
+		r.HandleContext(c)
+	})
+	v2 := r.Group("/v2")
+	{
+		v2.GET("/", func(c *Context) {})
+	}
+
+	assert.NotPanics(t, func() {
+		w := performRequest(r, "GET", "/")
+		assert.Equal(t, 301, w.Code)
+	})
+}
+
 func assertRoutePresent(t *testing.T, gotRoutes RoutesInfo, wantRoute RouteInfo) {
 	for _, gotRoute := range gotRoutes {
 		if gotRoute.Path == wantRoute.Path && gotRoute.Method == wantRoute.Method {

--- a/routes_test.go
+++ b/routes_test.go
@@ -426,6 +426,16 @@ func TestRouterStaticFSNotFound(t *testing.T) {
 	assert.Equal(t, "non existent", w.Body.String())
 }
 
+func TestRouterStaticFSFileNotFound(t *testing.T) {
+	router := New()
+
+	router.StaticFS("/", http.FileSystem(http.Dir(".")))
+
+	assert.NotPanics(t, func() {
+		performRequest(router, "GET", "/nonexistent")
+	})
+}
+
 func TestRouteRawPath(t *testing.T) {
 	route := New()
 	route.UseRawPath = true


### PR DESCRIPTION
If gin sometimes reset `Context.index` and `.handlers` then needs to recheck len of handlers every iteration on func `Context.Next()`:
https://github.com/gin-gonic/gin/blob/29a145c85dc0fafc3dd0ada62d856c4d95240010/context.go#L103-L111

---
Fix #1678, because gin change `c.handlers` when error on open file.
https://github.com/gin-gonic/gin/blob/29a145c85dc0fafc3dd0ada62d856c4d95240010/routergroup.go#L195-L202

---
Fix #1744, because gin reset `c.handlers` slice on `HandleContext()` func.
https://github.com/gin-gonic/gin/blob/29a145c85dc0fafc3dd0ada62d856c4d95240010/gin.go#L354-L360
https://github.com/gin-gonic/gin/blob/29a145c85dc0fafc3dd0ada62d856c4d95240010/context.go#L67-L75