### PR TITLE
Fix not to pass formatted string to Fprintf's format specifier parameter

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -191,7 +191,7 @@ func LoggerWithConfig(conf LoggerConfig) HandlerFunc {
 
 			param.Path = path
 
-			fmt.Fprintf(out, formatter(param))
+			fmt.Fprint(out, formatter(param))
 		}
 	}
 }


### PR DESCRIPTION
Fix the bug of issue https://github.com/gin-gonic/gin/issues/1746.

PR https://github.com/gin-gonic/gin/pull/1677 caused it.