### PR TITLE
fix travis freeze on concurrent test

### DIFF
--- a/gin_integration_test.go
+++ b/gin_integration_test.go
@@ -188,15 +188,12 @@ func TestConcurrentHandleContext(t *testing.T) {
 	})
 	router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
 
-	ts := httptest.NewServer(router)
-	defer ts.Close()
-
 	var wg sync.WaitGroup
 	iterations := 200
 	wg.Add(iterations)
 	for i := 0; i < iterations; i++ {
 		go func() {
-			testRequest(t, ts.URL+"/")
+			testGetRequestHandler(t, router, "/")
 			wg.Done()
 		}()
 	}
@@ -217,3 +214,14 @@ func TestConcurrentHandleContext(t *testing.T) {
 
 // 	testRequest(t, "http://localhost:8033/example")
 // }
+
+func testGetRequestHandler(t *testing.T, h http.Handler, url string) {
+	req, err := http.NewRequest("GET", url, nil)
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, "it worked", w.Body.String(), "resp body should match")
+	assert.Equal(t, 200, w.Code, "should get a 200")
+}


### PR DESCRIPTION
Sometimes travis-ci tests fails like this https://travis-ci.org/gin-gonic/gin/jobs/488105097
It happens when `TestConcurrentHandleContext` freezes - client don't have timeout and request waiting unlimited.
If test it without net layout (without start server), just by testing of handler - we can avoid this problem.