### PR TITLE
Make silent debug info on tests

### DIFF
--- a/debug_test.go
+++ b/debug_test.go
@@ -39,7 +39,7 @@ func TestDebugPrint(t *testing.T) {
 		SetMode(TestMode)
 		debugPrint("DEBUG this!")
 		SetMode(DebugMode)
-		debugPrint("these are %d %s\n", 2, "error messages")
+		debugPrint("these are %d %s", 2, "error messages")
 		SetMode(TestMode)
 	})
 	assert.Equal(t, "[GIN-debug] these are 2 error messages\n", re)

--- a/deprecated_test.go
+++ b/deprecated_test.go
@@ -24,7 +24,9 @@ func TestBindWith(t *testing.T) {
 		Foo string `form:"foo"`
 		Bar string `form:"bar"`
 	}
-	assert.NoError(t, c.BindWith(&obj, binding.Form))
+	captureOutput(t, func() {
+		assert.NoError(t, c.BindWith(&obj, binding.Form))
+	})
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, 0, w.Body.Len())

--- a/gin_test.go
+++ b/gin_test.go
@@ -25,18 +25,23 @@ func formatAsDate(t time.Time) string {
 
 func setupHTMLFiles(t *testing.T, mode string, tls bool, loadMethod func(*Engine)) *httptest.Server {
 	SetMode(mode)
-	router := New()
-	router.Delims("{[{", "}]}")
-	router.SetFuncMap(template.FuncMap{
-		"formatAsDate": formatAsDate,
-	})
-	loadMethod(router)
-	router.GET("/test", func(c *Context) {
-		c.HTML(http.StatusOK, "hello.tmpl", map[string]string{"name": "world"})
-	})
-	router.GET("/raw", func(c *Context) {
-		c.HTML(http.StatusOK, "raw.tmpl", map[string]interface{}{
-			"now": time.Date(2017, 07, 01, 0, 0, 0, 0, time.UTC),
+	defer SetMode(TestMode)
+
+	var router *Engine
+	captureOutput(t, func() {
+		router = New()
+		router.Delims("{[{", "}]}")
+		router.SetFuncMap(template.FuncMap{
+			"formatAsDate": formatAsDate,
+		})
+		loadMethod(router)
+		router.GET("/test", func(c *Context) {
+			c.HTML(http.StatusOK, "hello.tmpl", map[string]string{"name": "world"})
+		})
+		router.GET("/raw", func(c *Context) {
+			c.HTML(http.StatusOK, "raw.tmpl", map[string]interface{}{
+				"now": time.Date(2017, 07, 01, 0, 0, 0, 0, time.UTC),
+			})
 		})
 	})
 

--- a/githubapi_test.go
+++ b/githubapi_test.go
@@ -287,7 +287,7 @@ var githubAPI = []route{
 
 func TestShouldBindUri(t *testing.T) {
 	DefaultWriter = os.Stdout
-	router := Default()
+	router := New()
 
 	type Person struct {
 		Name string `uri:"name" binding:"required"`
@@ -309,7 +309,7 @@ func TestShouldBindUri(t *testing.T) {
 
 func TestBindUri(t *testing.T) {
 	DefaultWriter = os.Stdout
-	router := Default()
+	router := New()
 
 	type Person struct {
 		Name string `uri:"name" binding:"required"`
@@ -331,7 +331,7 @@ func TestBindUri(t *testing.T) {
 
 func TestBindUriError(t *testing.T) {
 	DefaultWriter = os.Stdout
-	router := Default()
+	router := New()
 
 	type Member struct {
 		Number string `uri:"num" binding:"required,uuid"`
@@ -361,7 +361,7 @@ func githubConfigRouter(router *Engine) {
 
 func TestGithubAPI(t *testing.T) {
 	DefaultWriter = os.Stdout
-	router := Default()
+	router := New()
 	githubConfigRouter(router)
 
 	for _, route := range githubAPI {
@@ -436,7 +436,7 @@ func BenchmarkParallelGithub(b *testing.B) {
 
 func BenchmarkParallelGithubDefault(b *testing.B) {
 	DefaultWriter = os.Stdout
-	router := Default()
+	router := New()
 	githubConfigRouter(router)
 
 	req, _ := http.NewRequest("POST", "/repos/manucorporat/sse/git/blobs", nil)

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -43,6 +43,7 @@ func TestPanicInHandler(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, buffer.String(), "GET /recovery")
 
+	SetMode(TestMode)
 }
 
 // TestPanicWithAbort assert that panic has been recovered even if context.Abort was used.


### PR DESCRIPTION
There are many tests write debug info to `os.Stderr`. And after that is hard to inspect failed tests.
Now I see only logs of failed tests.