### PR TITLE
Proposal: fix call Stream() on copy of *Context (#1763)

### DIFF
--- a/context.go
+++ b/context.go
@@ -78,7 +78,6 @@ func (c *Context) reset() {
 // This has to be used when the context has to be passed to a goroutine.
 func (c *Context) Copy() *Context {
 	var cp = *c
-	cp.writermem.ResponseWriter = nil
 	cp.Writer = &cp.writermem
 	cp.index = abortIndex
 	cp.handlers = nil

--- a/context_test.go
+++ b/context_test.go
@@ -324,7 +324,6 @@ func TestContextCopy(t *testing.T) {
 
 	cp := c.Copy()
 	assert.Nil(t, cp.handlers)
-	assert.Nil(t, cp.writermem.ResponseWriter)
 	assert.Equal(t, &cp.writermem, cp.Writer.(*responseWriter))
 	assert.Equal(t, cp.Request, c.Request)
 	assert.Equal(t, cp.index, abortIndex)
@@ -1754,4 +1753,30 @@ func TestContextResetInHandler(t *testing.T) {
 	assert.NotPanics(t, func() {
 		c.Next()
 	})
+}
+
+func TestContextStreamToCopyOfContext(t *testing.T) {
+	w := CreateTestResponseRecorder()
+	c, _ := CreateTestContext(w)
+
+	h := func(c *Context) {
+		nc := c.Copy()
+		nc.Stream(func(w io.Writer) bool {
+			w.Write([]byte("1"))
+			return false
+		})
+		c.String(http.StatusOK, "%s", "2")
+		w.closeClient()
+
+		nc.Stream(func(w io.Writer) bool {
+			w.Write([]byte("3"))
+			return false
+		})
+	}
+
+	assert.NotPanics(t, func() {
+		h(c)
+	})
+
+	assert.Equal(t, "12", w.Body.String())
 }


### PR DESCRIPTION
Can someone explain - why on `Copy()` method we are set `null` value to `cp.writermem.ResponseWriter`?

https://github.com/gin-gonic/gin/blob/5acf6601170bb49a1958c055d66d54ba152dc34b/context.go#L79-L86

Without that we can call `Stream()` method on copy of Context.
Fix #1763 