### PR TITLE
chore: fix Make script when failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@ test:
 		if grep -q "^--- FAIL" tmp.out; then \
 			rm tmp.out; \
 			exit 1; \
-		elif grep -q "build failed" tmp.out; then \
+		elif grep -q "[build failed]" tmp.out; then \
+			rm tmp.out; \
+			exit 1; \
+		fi; \
+		elif grep -q "[setup failed]" tmp.out; then \
 			rm tmp.out; \
 			exit 1; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ test:
 		elif grep -q "[build failed]" tmp.out; then \
 			rm tmp.out; \
 			exit 1; \
-		fi; \
 		elif grep -q "[setup failed]" tmp.out; then \
 			rm tmp.out; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test:
 			exit 1; \
 		elif grep -q "build failed" tmp.out; then \
 			rm tmp.out; \
-			exit; \
+			exit 1; \
 		fi; \
 		if [ -f profile.out ]; then \
 			cat profile.out | grep -v "mode:" >> coverage.out; \

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ test:
 		if grep -q "^--- FAIL" tmp.out; then \
 			rm tmp.out; \
 			exit 1; \
-		elif grep -q "[build failed]" tmp.out; then \
+		elif grep -q "build failed" tmp.out; then \
 			rm tmp.out; \
 			exit 1; \
-		elif grep -q "[setup failed]" tmp.out; then \
+		elif grep -q "setup failed" tmp.out; then \
 			rm tmp.out; \
 			exit 1; \
 		fi; \


### PR DESCRIPTION
before:
```
# github.com/gin-gonic/gin
/tmp/go-build038919107/github.com/gin-gonic/gin/_test/_obj_test/context.go:719:11: unknown field 'SameSite' in struct literal of type http.Cookie
FAIL	github.com/gin-gonic/gin [build failed]
The command "make test" exited with 0.
```

And
```
# github.com/gin-gonic/gin/render
package github.com/gin-gonic/gin/render (test)
	imports github.com/stretchr/testify/assert
	imports github.com/pmezard/go-difflib/difflib: cannot find package "github.com/pmezard/go-difflib/difflib" in any of:
	/home/travis/gopath/src/github.com/gin-gonic/gin/vendor/github.com/pmezard/go-difflib/difflib (vendor tree)
	/home/travis/.gimme/versions/go1.8.7.linux.amd64/src/github.com/pmezard/go-difflib/difflib (from $GOROOT)
	/home/travis/gopath/src/github.com/pmezard/go-difflib/difflib (from $GOPATH)
FAIL	github.com/gin-gonic/gin/render [setup failed]
```
when test case failed, it should return `1` not `0`.

For example #1615 

