### PR TITLE
Drone switch from gin to go-chi in 1.0 version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2082,7 +2082,6 @@ func TestPingRoute(t *testing.T) {
 
 Awesome project lists using [Gin](https://github.com/gin-gonic/gin) web framework.
 
-* [drone](https://github.com/drone/drone): Drone is a Continuous Delivery platform built on Docker, written in Go.
 * [gorush](https://github.com/appleboy/gorush): A push notification server written in Go.
 * [fnproject](https://github.com/fnproject/fn): The container native, cloud agnostic serverless platform.
 * [photoprism](https://github.com/photoprism/photoprism): Personal photo management powered by Go and Google TensorFlow.


### PR DESCRIPTION
Remove the link that doesn't use gin anymore. See the https://github.com/drone/drone/blob/20c19bc522abacc6072c566b6a4bd7cc3d19c2a6/go.mod#L29-L30