### PR TITLE
Remove contents of the Authorization header while dumping requests

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -53,11 +53,18 @@ func RecoveryWithWriter(out io.Writer) HandlerFunc {
 				if logger != nil {
 					stack := stack(3)
 					httpRequest, _ := httputil.DumpRequest(c.Request, false)
+					headers := strings.Split(string(httpRequest), "\r\n")
+					for idx, header := range headers {
+						current := strings.Split(header, ":")
+						if current[0] == "Authorization" {
+							headers[idx] = current[0] + ": *"
+						}
+					}
 					if brokenPipe {
 						logger.Printf("%s\n%s%s", err, string(httpRequest), reset)
 					} else if IsDebugging() {
 						logger.Printf("[Recovery] %s panic recovered:\n%s\n%s\n%s%s",
-							timeFormat(time.Now()), string(httpRequest), err, stack, reset)
+							timeFormat(time.Now()), strings.Join(headers, "\r\n"), err, stack, reset)
 					} else {
 						logger.Printf("[Recovery] %s panic recovered:\n%s\n%s%s",
 							timeFormat(time.Now()), err, stack, reset)

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -8,6 +8,7 @@ package gin
 
 import (
 	"bytes"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -17,6 +18,37 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestPanicClean(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	router := New()
+	password := "my-super-secret-password"
+	router.Use(RecoveryWithWriter(buffer))
+	router.GET("/recovery", func(c *Context) {
+		c.AbortWithStatus(http.StatusBadRequest)
+		panic("Oupps, Houston, we have a problem")
+	})
+	// RUN
+	w := performRequest(router, "GET", "/recovery",
+		header{
+			Key:   "Host",
+			Value: "www.google.com",
+		},
+		header{
+			Key:   "Authorization",
+			Value: fmt.Sprintf("Bearer %s", password),
+		},
+		header{
+			Key:   "Content-Type",
+			Value: "application/json",
+		},
+	)
+	// TEST
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Check the buffer does not have the secret key
+	assert.NotContains(t, buffer.String(), password)
+}
 
 // TestPanicInHandler assert that panic has been recovered.
 func TestPanicInHandler(t *testing.T) {


### PR DESCRIPTION
This PR replaces the contents of that header with a *. This prevents
credential leak in logs.

