### PR TITLE
Add build tag nomsgpack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
   - go: 1.12.x
     env: GO111MODULE=on
   - go: 1.13.x
+  - go: 1.13.x
+    env: 
+      - TESTTAGS=nomsgpack
   - go: master
 
 git:

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,13 @@ PACKAGES ?= $(shell $(GO) list ./...)
 VETPACKAGES ?= $(shell $(GO) list ./... | grep -v /examples/)
 GOFILES := $(shell find . -name "*.go")
 TESTFOLDER := $(shell $(GO) list ./... | grep -E 'gin$$|binding$$|render$$' | grep -v examples)
+TESTTAGS ?= ""
 
 .PHONY: test
 test:
 	echo "mode: count" > coverage.out
 	for d in $(TESTFOLDER); do \
-		$(GO) test -v -covermode=count -coverprofile=profile.out $$d > tmp.out; \
+		$(GO) test -tags $(TESTTAGS) -v -covermode=count -coverprofile=profile.out $$d > tmp.out; \
 		cat tmp.out; \
 		if grep -q "^--- FAIL" tmp.out; then \
 			rm tmp.out; \

--- a/binding/binding_msgpack_test.go
+++ b/binding/binding_msgpack_test.go
@@ -1,0 +1,57 @@
+// Copyright 2014 Manu Martinez-Almeida.  All rights reserved.
+// Use of this source code is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+// +build !nomsgpack
+
+package binding
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/ugorji/go/codec"
+)
+
+func TestBindingMsgPack(t *testing.T) {
+	test := FooStruct{
+		Foo: "bar",
+	}
+
+	h := new(codec.MsgpackHandle)
+	assert.NotNil(t, h)
+	buf := bytes.NewBuffer([]byte{})
+	assert.NotNil(t, buf)
+	err := codec.NewEncoder(buf, h).Encode(test)
+	assert.NoError(t, err)
+
+	data := buf.Bytes()
+
+	testMsgPackBodyBinding(t,
+		MsgPack, "msgpack",
+		"/", "/",
+		string(data), string(data[1:]))
+}
+
+func testMsgPackBodyBinding(t *testing.T, b Binding, name, path, badPath, body, badBody string) {
+	assert.Equal(t, name, b.Name())
+
+	obj := FooStruct{}
+	req := requestWithBody("POST", path, body)
+	req.Header.Add("Content-Type", MIMEMSGPACK)
+	err := b.Bind(req, &obj)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", obj.Foo)
+
+	obj = FooStruct{}
+	req = requestWithBody("POST", badPath, badBody)
+	req.Header.Add("Content-Type", MIMEMSGPACK)
+	err = MsgPack.Bind(req, &obj)
+	assert.Error(t, err)
+}
+
+func TestBindingDefaultMsgPack(t *testing.T) {
+	assert.Equal(t, MsgPack, Default("POST", MIMEMSGPACK))
+	assert.Equal(t, MsgPack, Default("PUT", MIMEMSGPACK2))
+}

--- a/binding/binding_msgpack_test.go
+++ b/binding/binding_msgpack_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Manu Martinez-Almeida.  All rights reserved.
+// Copyright 2020 Gin Core Team. All rights reserved.
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 

--- a/binding/binding_nomsgpack.go
+++ b/binding/binding_nomsgpack.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-// +build !nomsgpack
+// +build nomsgpack
 
 package binding
 
@@ -18,8 +18,6 @@ const (
 	MIMEPOSTForm          = "application/x-www-form-urlencoded"
 	MIMEMultipartPOSTForm = "multipart/form-data"
 	MIMEPROTOBUF          = "application/x-protobuf"
-	MIMEMSGPACK           = "application/x-msgpack"
-	MIMEMSGPACK2          = "application/msgpack"
 	MIMEYAML              = "application/x-yaml"
 )
 
@@ -77,7 +75,6 @@ var (
 	FormPost      = formPostBinding{}
 	FormMultipart = formMultipartBinding{}
 	ProtoBuf      = protobufBinding{}
-	MsgPack       = msgpackBinding{}
 	YAML          = yamlBinding{}
 	Uri           = uriBinding{}
 	Header        = headerBinding{}
@@ -86,7 +83,7 @@ var (
 // Default returns the appropriate Binding instance based on the HTTP method
 // and the content type.
 func Default(method, contentType string) Binding {
-	if method == http.MethodGet {
+	if method == "GET" {
 		return Form
 	}
 
@@ -97,8 +94,6 @@ func Default(method, contentType string) Binding {
 		return XML
 	case MIMEPROTOBUF:
 		return ProtoBuf
-	case MIMEMSGPACK, MIMEMSGPACK2:
-		return MsgPack
 	case MIMEYAML:
 		return YAML
 	case MIMEMultipartPOSTForm:

--- a/binding/binding_nomsgpack.go
+++ b/binding/binding_nomsgpack.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Manu Martinez-Almeida.  All rights reserved.
+// Copyright 2020 Gin Core Team. All rights reserved.
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 

--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gin-gonic/gin/testdata/protoexample"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
-	"github.com/ugorji/go/codec"
 )
 
 type appkey struct {
@@ -162,9 +161,6 @@ func TestBindingDefault(t *testing.T) {
 
 	assert.Equal(t, ProtoBuf, Default("POST", MIMEPROTOBUF))
 	assert.Equal(t, ProtoBuf, Default("PUT", MIMEPROTOBUF))
-
-	assert.Equal(t, MsgPack, Default("POST", MIMEMSGPACK))
-	assert.Equal(t, MsgPack, Default("PUT", MIMEMSGPACK2))
 
 	assert.Equal(t, YAML, Default("POST", MIMEYAML))
 	assert.Equal(t, YAML, Default("PUT", MIMEYAML))
@@ -629,26 +625,6 @@ func TestBindingProtoBufFail(t *testing.T) {
 
 	testProtoBodyBindingFail(t,
 		ProtoBuf, "protobuf",
-		"/", "/",
-		string(data), string(data[1:]))
-}
-
-func TestBindingMsgPack(t *testing.T) {
-	test := FooStruct{
-		Foo: "bar",
-	}
-
-	h := new(codec.MsgpackHandle)
-	assert.NotNil(t, h)
-	buf := bytes.NewBuffer([]byte{})
-	assert.NotNil(t, buf)
-	err := codec.NewEncoder(buf, h).Encode(test)
-	assert.NoError(t, err)
-
-	data := buf.Bytes()
-
-	testMsgPackBodyBinding(t,
-		MsgPack, "msgpack",
 		"/", "/",
 		string(data), string(data[1:]))
 }
@@ -1247,23 +1223,6 @@ func testProtoBodyBindingFail(t *testing.T, b Binding, name, path, badPath, body
 	req = requestWithBody("POST", badPath, badBody)
 	req.Header.Add("Content-Type", MIMEPROTOBUF)
 	err = ProtoBuf.Bind(req, &obj)
-	assert.Error(t, err)
-}
-
-func testMsgPackBodyBinding(t *testing.T, b Binding, name, path, badPath, body, badBody string) {
-	assert.Equal(t, name, b.Name())
-
-	obj := FooStruct{}
-	req := requestWithBody("POST", path, body)
-	req.Header.Add("Content-Type", MIMEMSGPACK)
-	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
-	assert.Equal(t, "bar", obj.Foo)
-
-	obj = FooStruct{}
-	req = requestWithBody("POST", badPath, badBody)
-	req.Header.Add("Content-Type", MIMEMSGPACK)
-	err = MsgPack.Bind(req, &obj)
 	assert.Error(t, err)
 }
 

--- a/binding/msgpack.go
+++ b/binding/msgpack.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
+// +build !nomsgpack
+
 package binding
 
 import (

--- a/binding/msgpack_test.go
+++ b/binding/msgpack_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
+// +build !nomsgpack
+
 package binding
 
 import (

--- a/render/msgpack.go
+++ b/render/msgpack.go
@@ -2,12 +2,18 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
+// +build !nomsgpack
+
 package render
 
 import (
 	"net/http"
 
 	"github.com/ugorji/go/codec"
+)
+
+var (
+	_ Render = MsgPack{}
 )
 
 // MsgPack contains the given interface object.

--- a/render/render.go
+++ b/render/render.go
@@ -27,7 +27,6 @@ var (
 	_ HTMLRender = HTMLDebug{}
 	_ HTMLRender = HTMLProduction{}
 	_ Render     = YAML{}
-	_ Render     = MsgPack{}
 	_ Render     = Reader{}
 	_ Render     = AsciiJSON{}
 	_ Render     = ProtoBuf{}

--- a/render/render_msgpack_test.go
+++ b/render/render_msgpack_test.go
@@ -1,0 +1,43 @@
+// Copyright 2014 Manu Martinez-Almeida.  All rights reserved.
+// Use of this source code is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+// +build !nomsgpack
+
+package render
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/ugorji/go/codec"
+)
+
+// TODO unit tests
+// test errors
+
+func TestRenderMsgPack(t *testing.T) {
+	w := httptest.NewRecorder()
+	data := map[string]interface{}{
+		"foo": "bar",
+	}
+
+	(MsgPack{data}).WriteContentType(w)
+	assert.Equal(t, "application/msgpack; charset=utf-8", w.Header().Get("Content-Type"))
+
+	err := (MsgPack{data}).Render(w)
+
+	assert.NoError(t, err)
+
+	h := new(codec.MsgpackHandle)
+	assert.NotNil(t, h)
+	buf := bytes.NewBuffer([]byte{})
+	assert.NotNil(t, buf)
+	err = codec.NewEncoder(buf, h).Encode(data)
+
+	assert.NoError(t, err)
+	assert.Equal(t, w.Body.String(), string(buf.Bytes()))
+	assert.Equal(t, "application/msgpack; charset=utf-8", w.Header().Get("Content-Type"))
+}

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -5,7 +5,6 @@
 package render
 
 import (
-	"bytes"
 	"encoding/xml"
 	"errors"
 	"html/template"
@@ -17,37 +16,12 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
-	"github.com/ugorji/go/codec"
 
 	testdata "github.com/gin-gonic/gin/testdata/protoexample"
 )
 
 // TODO unit tests
 // test errors
-
-func TestRenderMsgPack(t *testing.T) {
-	w := httptest.NewRecorder()
-	data := map[string]interface{}{
-		"foo": "bar",
-	}
-
-	(MsgPack{data}).WriteContentType(w)
-	assert.Equal(t, "application/msgpack; charset=utf-8", w.Header().Get("Content-Type"))
-
-	err := (MsgPack{data}).Render(w)
-
-	assert.NoError(t, err)
-
-	h := new(codec.MsgpackHandle)
-	assert.NotNil(t, h)
-	buf := bytes.NewBuffer([]byte{})
-	assert.NotNil(t, buf)
-	err = codec.NewEncoder(buf, h).Encode(data)
-
-	assert.NoError(t, err)
-	assert.Equal(t, w.Body.String(), buf.String())
-	assert.Equal(t, "application/msgpack; charset=utf-8", w.Header().Get("Content-Type"))
-}
 
 func TestRenderJSON(t *testing.T) {
 	w := httptest.NewRecorder()


### PR DESCRIPTION
This PR add a build tag `nomsgpack` to exclude heavy deps `github.com/ugorji/go/codec` that may be not needed for most project. The goal is to reduce the resulting binary size. This could maybe improve some performances but that not the goal so I haven't bench it.

I go for the no impact by default by using a negate tag so that without change it will not impact project depending on this lib.

~~I will try to provide some results of binary size based on https://github.com/gin-gonic/examples.~~ -> see [comment](https://github.com/gin-gonic/gin/pull/1852#issuecomment-481043187)

Should fix (or at least a mitigation to) #1847 
 