### PR TITLE
Use DefaultWriter and DefaultErrorWriter for debug messages

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -54,7 +53,7 @@ func debugPrint(format string, values ...interface{}) {
 		if !strings.HasSuffix(format, "\n") {
 			format += "\n"
 		}
-		fmt.Fprintf(os.Stderr, "[GIN-debug] "+format, values...)
+		fmt.Fprintf(DefaultWriter, "[GIN-debug] "+format, values...)
 	}
 }
 
@@ -98,6 +97,8 @@ at initialization. ie. before any route is registered or the router is listening
 
 func debugPrintError(err error) {
 	if err != nil {
-		debugPrint("[ERROR] %v\n", err)
+		if IsDebugging() {
+			fmt.Fprintf(DefaultErrorWriter, "[GIN-debug] [ERROR] %v\n", err)
+		}
 	}
 }

--- a/debug_test.go
+++ b/debug_test.go
@@ -111,15 +111,15 @@ func captureOutput(t *testing.T, f func()) string {
 	if err != nil {
 		panic(err)
 	}
-	stdout := os.Stdout
-	stderr := os.Stderr
+	defaultWriter := DefaultWriter
+	defaultErrorWriter := DefaultErrorWriter
 	defer func() {
-		os.Stdout = stdout
-		os.Stderr = stderr
+		DefaultWriter = defaultWriter
+		DefaultErrorWriter = defaultErrorWriter
 		log.SetOutput(os.Stderr)
 	}()
-	os.Stdout = writer
-	os.Stderr = writer
+	DefaultWriter = writer
+	DefaultErrorWriter = writer
 	log.SetOutput(writer)
 	out := make(chan string)
 	wg := new(sync.WaitGroup)


### PR DESCRIPTION
Aligns behaviour according to documentation.

Closes #1890.