### PR TITLE
Now you can parse the inline lowercase start structure

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -70,12 +70,14 @@ func mapping(value reflect.Value, field reflect.StructField, setter setter, tag 
 		return isSetted, nil
 	}
 
-	ok, err := tryToSetValue(value, field, setter, tag)
-	if err != nil {
-		return false, err
-	}
-	if ok {
-		return true, nil
+	if !(vKind == reflect.Struct && field.Anonymous) {
+		ok, err := tryToSetValue(value, field, setter, tag)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
 	}
 
 	if vKind == reflect.Struct {
@@ -83,7 +85,8 @@ func mapping(value reflect.Value, field reflect.StructField, setter setter, tag 
 
 		var isSetted bool
 		for i := 0; i < value.NumField(); i++ {
-			if !value.Field(i).CanSet() {
+			sf := tValue.Field(i)
+			if sf.PkgPath != "" && !sf.Anonymous { // unexported
 				continue
 			}
 			ok, err := mapping(value.Field(i), tValue.Field(i), setter, tag)

--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -70,7 +70,7 @@ func mapping(value reflect.Value, field reflect.StructField, setter setter, tag 
 		return isSetted, nil
 	}
 
-	if !(vKind == reflect.Struct && field.Anonymous) {
+	if vKind != reflect.Struct || !field.Anonymous {
 		ok, err := tryToSetValue(value, field, setter, tag)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
``` golang
package main

import (
	"github.com/gin-gonic/gin"
)

type appkey struct {
	Appkey string `json:"appkey" form:"appkey"`
}

type Query struct {
	Page int `json:"page" form:"page"`
	Size int `json:"size" form:"size"`
	appkey
}

func main() {

	router := gin.Default()
	router.POST("/login", func(c *gin.Context) {

		var q2 Query

		if c.ShouldBindQuery(&q2) == nil {
			c.JSON(200, &q2)
		}
	})
	router.Run(":8088")
}
```
http client:

old:
``` bash
curl -X POST "127.0.0.1:8088/login?appkey=china&page=1&size=10"
{"page":1,"size":10,"appkey":""}
```
now:
``` bash
curl -X POST "127.0.0.1:8088/login?appkey=china&page=1&size=10"
{"page":1,"size":10,"appkey":"china"}
```



