### PR TITLE
Gin1.5 bytes.Buffer to strings.Builder

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -7,13 +7,12 @@ package gin
 import (
 	"fmt"
 	"html/template"
-	"os"
 	"runtime"
 	"strconv"
 	"strings"
 )
 
-const ginSupportMinGoVer = 6
+const ginSupportMinGoVer = 8
 
 // IsDebugging returns true if the framework is running in debug mode.
 // Use SetMode(gin.ReleaseMode) to disable debug mode.
@@ -53,7 +52,7 @@ func debugPrint(format string, values ...interface{}) {
 		if !strings.HasSuffix(format, "\n") {
 			format += "\n"
 		}
-		fmt.Fprintf(os.Stderr, "[GIN-debug] "+format, values...)
+		fmt.Fprintf(DefaultWriter, "[GIN-debug] "+format, values...)
 	}
 }
 
@@ -68,7 +67,7 @@ func getMinVer(v string) (uint64, error) {
 
 func debugPrintWARNINGDefault() {
 	if v, e := getMinVer(runtime.Version()); e == nil && v <= ginSupportMinGoVer {
-		debugPrint(`[WARNING] Now Gin requires Go 1.6 or later and Go 1.7 will be required soon.
+		debugPrint(`[WARNING] Now Gin requires Go 1.8 or later and Go 1.9 will be required soon.
 
 `)
 	}
@@ -97,6 +96,8 @@ at initialization. ie. before any route is registered or the router is listening
 
 func debugPrintError(err error) {
 	if err != nil {
-		debugPrint("[ERROR] %v\n", err)
+		if IsDebugging() {
+			fmt.Fprintf(DefaultErrorWriter, "[GIN-debug] [ERROR] %v\n", err)
+		}
 	}
 }

--- a/debug.go
+++ b/debug.go
@@ -5,15 +5,15 @@
 package gin
 
 import (
-	"bytes"
 	"fmt"
 	"html/template"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
 )
 
-const ginSupportMinGoVer = 8
+const ginSupportMinGoVer = 6
 
 // IsDebugging returns true if the framework is running in debug mode.
 // Use SetMode(gin.ReleaseMode) to disable debug mode.
@@ -38,7 +38,7 @@ func debugPrintRoute(httpMethod, absolutePath string, handlers HandlersChain) {
 
 func debugPrintLoadTemplate(tmpl *template.Template) {
 	if IsDebugging() {
-		var buf bytes.Buffer
+		var buf strings.Builder
 		for _, tmpl := range tmpl.Templates() {
 			buf.WriteString("\t- ")
 			buf.WriteString(tmpl.Name())
@@ -53,7 +53,7 @@ func debugPrint(format string, values ...interface{}) {
 		if !strings.HasSuffix(format, "\n") {
 			format += "\n"
 		}
-		fmt.Fprintf(DefaultWriter, "[GIN-debug] "+format, values...)
+		fmt.Fprintf(os.Stderr, "[GIN-debug] "+format, values...)
 	}
 }
 
@@ -68,7 +68,7 @@ func getMinVer(v string) (uint64, error) {
 
 func debugPrintWARNINGDefault() {
 	if v, e := getMinVer(runtime.Version()); e == nil && v <= ginSupportMinGoVer {
-		debugPrint(`[WARNING] Now Gin requires Go 1.8 or later and Go 1.9 will be required soon.
+		debugPrint(`[WARNING] Now Gin requires Go 1.6 or later and Go 1.7 will be required soon.
 
 `)
 	}
@@ -97,8 +97,6 @@ at initialization. ie. before any route is registered or the router is listening
 
 func debugPrintError(err error) {
 	if err != nil {
-		if IsDebugging() {
-			fmt.Fprintf(DefaultErrorWriter, "[GIN-debug] [ERROR] %v\n", err)
-		}
+		debugPrint("[ERROR] %v\n", err)
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -6,9 +6,10 @@ package gin
 
 import (
 	"fmt"
-	"github.com/gin-gonic/gin/internal/json"
 	"reflect"
 	"strings"
+
+	"github.com/gin-gonic/gin/internal/json"
 )
 
 // ErrorType is an unsigned 64-bit error code as defined in the gin spec.

--- a/errors.go
+++ b/errors.go
@@ -5,11 +5,10 @@
 package gin
 
 import (
-	"bytes"
 	"fmt"
-	"reflect"
-
 	"github.com/gin-gonic/gin/internal/json"
+	"reflect"
+	"strings"
 )
 
 // ErrorType is an unsigned 64-bit error code as defined in the gin spec.
@@ -158,7 +157,7 @@ func (a errorMsgs) String() string {
 	if len(a) == 0 {
 		return ""
 	}
-	var buffer bytes.Buffer
+	var buffer strings.Builder
 	for i, msg := range a {
 		fmt.Fprintf(&buffer, "Error #%02d: %s\n", i+1, msg.Err)
 		if msg.Meta != nil {


### PR DESCRIPTION
Go1.10's strings.Builder structure saves memory
This is its implementation principle
```go
// String returns the accumulated string.
func (b *Builder) String() string {
    return *(*string)(unsafe.Pointer(&b.buf))
}

```