### PR TITLE
support bind http header param #1956

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Gin is a web framework written in Go (Golang). It features a martini-like API wi
     - [Only Bind Query String](#only-bind-query-string)
     - [Bind Query String or Post Data](#bind-query-string-or-post-data)
     - [Bind Uri](#bind-uri)
+    - [Bind Header](#bind-header)
     - [Bind HTML checkboxes](#bind-html-checkboxes)
     - [Multipart/Urlencoded binding](#multiparturlencoded-binding)
     - [XML, JSON, YAML and ProtoBuf rendering](#xml-json-yaml-and-protobuf-rendering)
@@ -908,6 +909,43 @@ Test it with:
 ```sh
 $ curl -v localhost:8088/thinkerou/987fbc97-4bed-5078-9f07-9141ba07c9f3
 $ curl -v localhost:8088/thinkerou/not-uuid
+```
+
+### Bind Header
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+)
+
+type testHeader struct {
+	Rate   int    `header:"Rate"`
+	Domain string `header:"Domain"`
+}
+
+func main() {
+	r := gin.Default()
+	r.GET("/", func(c *gin.Context) {
+		h := testHeader{}
+
+		if err := c.ShouldBindHeader(&h); err != nil {
+			c.JSON(200, err)
+		}
+
+		fmt.Printf("%#v\n", h)
+		c.JSON(200, gin.H{"Rate": h.Rate, "Domain": h.Domain})
+	})
+
+	r.Run()
+
+// client
+// curl -H "rate:300" -H "domain:music" 127.0.0.1:8080/
+// output
+// {"Domain":"music","Rate":300}
+}
 ```
 
 ### Bind HTML checkboxes

--- a/binding/binding.go
+++ b/binding/binding.go
@@ -78,6 +78,7 @@ var (
 	MsgPack       = msgpackBinding{}
 	YAML          = yamlBinding{}
 	Uri           = uriBinding{}
+	Header        = headerBinding{}
 )
 
 // Default returns the appropriate Binding instance based on the HTTP method

--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -667,6 +667,22 @@ func TestExistsFails(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestHeaderBinding(t *testing.T) {
+	h := Header
+	assert.Equal(t, "header", h.Name())
+
+	type tHeader struct {
+		Limit int `header:"limit"`
+	}
+
+	var theader tHeader
+	req := requestWithBody("GET", "/", "")
+	req.Header.Add("limit", "1000")
+	assert.NoError(t, h.Bind(req, &theader))
+	assert.Equal(t, 1000, theader.Limit)
+
+}
+
 func TestUriBinding(t *testing.T) {
 	b := Uri
 	assert.Equal(t, "uri", b.Name())

--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -681,6 +681,15 @@ func TestHeaderBinding(t *testing.T) {
 	assert.NoError(t, h.Bind(req, &theader))
 	assert.Equal(t, 1000, theader.Limit)
 
+	req = requestWithBody("GET", "/", "")
+	req.Header.Add("fail", `{fail:fail}`)
+
+	type failStruct struct {
+		Fail map[string]interface{} `header:"fail"`
+	}
+
+	err := h.Bind(req, &failStruct{})
+	assert.Error(t, err)
 }
 
 func TestUriBinding(t *testing.T) {

--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -38,6 +38,8 @@ type setter interface {
 
 type formSource map[string][]string
 
+var _ setter = formSource(nil)
+
 // TrySet tries to set a value by request's form source (like map[string][]string)
 func (form formSource) TrySet(value reflect.Value, field reflect.StructField, tagValue string, opt setOptions) (isSetted bool, err error) {
 	return setByForm(value, field, form, tagValue, opt)

--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -38,8 +38,6 @@ type setter interface {
 
 type formSource map[string][]string
 
-var _ setter = formSource(nil)
-
 // TrySet tries to set a value by request's form source (like map[string][]string)
 func (form formSource) TrySet(value reflect.Value, field reflect.StructField, tagValue string, opt setOptions) (isSetted bool, err error) {
 	return setByForm(value, field, form, tagValue, opt)

--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -7,7 +7,6 @@ package binding
 import (
 	"errors"
 	"fmt"
-	"net/textproto"
 	"reflect"
 	"strconv"
 	"strings"
@@ -20,10 +19,6 @@ var errUnknownType = errors.New("Unknown type")
 
 func mapUri(ptr interface{}, m map[string][]string) error {
 	return mapFormByTag(ptr, m, "uri")
-}
-
-func mapHeader(ptr interface{}, m map[string][]string) error {
-	return mapFormByTag(ptr, m, "header")
 }
 
 func mapForm(ptr interface{}, form map[string][]string) error {
@@ -107,7 +102,6 @@ func mapping(value reflect.Value, field reflect.StructField, setter setter, tag 
 
 type setOptions struct {
 	isDefaultExists bool
-	isHeader        bool
 	defaultValue    string
 }
 
@@ -129,7 +123,6 @@ func tryToSetValue(value reflect.Value, field reflect.StructField, setter setter
 	}
 
 	var opt string
-	setOpt.isHeader = tag == "header"
 	for len(opts) > 0 {
 		opt, opts = head(opts, ",")
 
@@ -143,17 +136,7 @@ func tryToSetValue(value reflect.Value, field reflect.StructField, setter setter
 }
 
 func setByForm(value reflect.Value, field reflect.StructField, form map[string][]string, tagValue string, opt setOptions) (isSetted bool, err error) {
-	var (
-		vs []string
-		ok bool
-	)
-
-	if opt.isHeader {
-		vs, ok = form[textproto.CanonicalMIMEHeaderKey(tagValue)]
-	} else {
-		vs, ok = form[tagValue]
-	}
-
+	vs, ok := form[tagValue]
 	if !ok && !opt.isDefaultExists {
 		return false, nil
 	}

--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -21,6 +21,10 @@ func mapUri(ptr interface{}, m map[string][]string) error {
 	return mapFormByTag(ptr, m, "uri")
 }
 
+func mapHeader(ptr interface{}, m map[string][]string) error {
+	return mapFormByTag(ptr, m, "header")
+}
+
 func mapForm(ptr interface{}, form map[string][]string) error {
 	return mapFormByTag(ptr, form, "form")
 }

--- a/binding/header.go
+++ b/binding/header.go
@@ -1,6 +1,10 @@
 package binding
 
-import "net/http"
+import (
+	"net/http"
+	"net/textproto"
+	"reflect"
+)
 
 type headerBinding struct{}
 
@@ -15,4 +19,16 @@ func (headerBinding) Bind(req *http.Request, obj interface{}) error {
 	}
 
 	return validate(obj)
+}
+
+func mapHeader(ptr interface{}, h map[string][]string) error {
+	return mappingByPtr(ptr, headerSource(h), "header")
+}
+
+type headerSource map[string][]string
+
+//var _ setter = headerSource(nil)
+
+func (hs headerSource) TrySet(value reflect.Value, field reflect.StructField, tagValue string, opt setOptions) (isSetted bool, err error) {
+	return setByForm(value, field, hs, textproto.CanonicalMIMEHeaderKey(tagValue), opt)
 }

--- a/binding/header.go
+++ b/binding/header.go
@@ -27,6 +27,8 @@ func mapHeader(ptr interface{}, h map[string][]string) error {
 
 type headerSource map[string][]string
 
+var _ setter = headerSource(nil)
+
 func (hs headerSource) TrySet(value reflect.Value, field reflect.StructField, tagValue string, opt setOptions) (isSetted bool, err error) {
 	return setByForm(value, field, hs, textproto.CanonicalMIMEHeaderKey(tagValue), opt)
 }

--- a/binding/header.go
+++ b/binding/header.go
@@ -27,8 +27,6 @@ func mapHeader(ptr interface{}, h map[string][]string) error {
 
 type headerSource map[string][]string
 
-//var _ setter = headerSource(nil)
-
 func (hs headerSource) TrySet(value reflect.Value, field reflect.StructField, tagValue string, opt setOptions) (isSetted bool, err error) {
 	return setByForm(value, field, hs, textproto.CanonicalMIMEHeaderKey(tagValue), opt)
 }

--- a/binding/header.go
+++ b/binding/header.go
@@ -1,0 +1,18 @@
+package binding
+
+import "net/http"
+
+type headerBinding struct{}
+
+func (headerBinding) Name() string {
+	return "header"
+}
+
+func (headerBinding) Bind(req *http.Request, obj interface{}) error {
+
+	if err := mapHeader(obj, req.Header); err != nil {
+		return err
+	}
+
+	return validate(obj)
+}

--- a/context.go
+++ b/context.go
@@ -583,6 +583,11 @@ func (c *Context) BindYAML(obj interface{}) error {
 	return c.MustBindWith(obj, binding.YAML)
 }
 
+// BindHeader is a shortcut for c.MustBindWith(obj, binding.Header).
+func (c *Context) BindHeader(obj interface{}) error {
+	return c.MustBindWith(obj, binding.Header)
+}
+
 // BindUri binds the passed struct pointer using binding.Uri.
 // It will abort the request with HTTP 400 if any error occurs.
 func (c *Context) BindUri(obj interface{}) error {
@@ -635,6 +640,11 @@ func (c *Context) ShouldBindQuery(obj interface{}) error {
 // ShouldBindYAML is a shortcut for c.ShouldBindWith(obj, binding.YAML).
 func (c *Context) ShouldBindYAML(obj interface{}) error {
 	return c.ShouldBindWith(obj, binding.YAML)
+}
+
+// ShouldBindHeader is a shortcut for c.ShouldBindWith(obj, binding.Header).
+func (c *Context) ShouldBindHeader(obj interface{}) error {
+	return c.ShouldBindWith(obj, binding.Header)
 }
 
 // ShouldBindUri binds the passed struct pointer using the specified binding engine.

--- a/context_test.go
+++ b/context_test.go
@@ -1436,6 +1436,25 @@ func TestContextBindWithXML(t *testing.T) {
 	assert.Equal(t, 0, w.Body.Len())
 }
 
+func TestContextBindHeader(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest("POST", "/", nil)
+	c.Request.Header.Add("rate", "8000")
+	c.Request.Header.Add("domain", "music")
+
+	var testHeader struct {
+		Rate   int    `header:"Rate"`
+		Domain string `header:"Domain"`
+	}
+
+	assert.NoError(t, c.BindHeader(&testHeader))
+	assert.Equal(t, 8000, testHeader.Rate)
+	assert.Equal(t, "music", testHeader.Domain)
+	assert.Equal(t, 0, w.Body.Len())
+}
+
 func TestContextBindWithQuery(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := CreateTestContext(w)
@@ -1540,6 +1559,25 @@ func TestContextShouldBindWithXML(t *testing.T) {
 	assert.NoError(t, c.ShouldBindXML(&obj))
 	assert.Equal(t, "FOO", obj.Foo)
 	assert.Equal(t, "BAR", obj.Bar)
+	assert.Equal(t, 0, w.Body.Len())
+}
+
+func TestContextShouldBindHeader(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest("POST", "/", nil)
+	c.Request.Header.Add("rate", "8000")
+	c.Request.Header.Add("domain", "music")
+
+	var testHeader struct {
+		Rate   int    `header:"Rate"`
+		Domain string `header:"Domain"`
+	}
+
+	assert.NoError(t, c.ShouldBindHeader(&testHeader))
+	assert.Equal(t, 8000, testHeader.Rate)
+	assert.Equal(t, "music", testHeader.Domain)
 	assert.Equal(t, 0, w.Body.Len())
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -1443,15 +1443,18 @@ func TestContextBindHeader(t *testing.T) {
 	c.Request, _ = http.NewRequest("POST", "/", nil)
 	c.Request.Header.Add("rate", "8000")
 	c.Request.Header.Add("domain", "music")
+	c.Request.Header.Add("limit", "1000")
 
 	var testHeader struct {
 		Rate   int    `header:"Rate"`
 		Domain string `header:"Domain"`
+		Limit  int    `header:"limit"`
 	}
 
 	assert.NoError(t, c.BindHeader(&testHeader))
 	assert.Equal(t, 8000, testHeader.Rate)
 	assert.Equal(t, "music", testHeader.Domain)
+	assert.Equal(t, 1000, testHeader.Limit)
 	assert.Equal(t, 0, w.Body.Len())
 }
 
@@ -1569,15 +1572,18 @@ func TestContextShouldBindHeader(t *testing.T) {
 	c.Request, _ = http.NewRequest("POST", "/", nil)
 	c.Request.Header.Add("rate", "8000")
 	c.Request.Header.Add("domain", "music")
+	c.Request.Header.Add("limit", "1000")
 
 	var testHeader struct {
 		Rate   int    `header:"Rate"`
 		Domain string `header:"Domain"`
+		Limit  int    `header:"limit"`
 	}
 
 	assert.NoError(t, c.ShouldBindHeader(&testHeader))
 	assert.Equal(t, 8000, testHeader.Rate)
 	assert.Equal(t, "music", testHeader.Domain)
+	assert.Equal(t, 1000, testHeader.Limit)
 	assert.Equal(t, 0, w.Body.Len())
 }
 


### PR DESCRIPTION
update #1956
```go
package main

import (
	"fmt"
	"github.com/gin-gonic/gin"
)

type testHeader struct {
	Rate   int    `header:"Rate"`
	Domain string `header:"Domain"`
}

func main() {
	r := gin.Default()
	r.GET("/", func(c *gin.Context) {
		h := testHeader{}

		if err := c.ShouldBindHeader(&h); err != nil {
			c.JSON(200, err)
		}

		fmt.Printf("%#v\n", h)
		c.JSON(200, gin.H{"Rate": h.Rate, "Domain": h.Domain})
	})

	r.Run()

// client
// curl -H "rate:300" -H "domain:music" 127.0.0.1:8080/
// output
// {"Domain":"music","Rate":300}
}
```

