### PR TITLE
fix README.md code bug and Change map to gin.H

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,8 +1081,8 @@ Using JSONP to request data from a server  in a different domain. Add callback t
 func main() {
 	r := gin.Default()
 
-	r.GET("/JSONP?callback=x", func(c *gin.Context) {
-		data := map[string]interface{}{
+	r.GET("/JSONP", func(c *gin.Context) {
+		data := gin.H{
 			"foo": "bar",
 		}
 		
@@ -1093,6 +1093,9 @@ func main() {
 
 	// Listen and serve on 0.0.0.0:8080
 	r.Run(":8080")
+
+        // client
+        // curl http://127.0.0.1:8080/JSONP?callback=x
 }
 ```
 
@@ -1105,7 +1108,7 @@ func main() {
 	r := gin.Default()
 
 	r.GET("/someJSON", func(c *gin.Context) {
-		data := map[string]interface{}{
+		data := gin.H{
 			"lang": "GO语言",
 			"tag":  "<br>",
 		}
@@ -1314,7 +1317,7 @@ func main() {
     router.LoadHTMLFiles("./testdata/template/raw.tmpl")
 
     router.GET("/raw", func(c *gin.Context) {
-        c.HTML(http.StatusOK, "raw.tmpl", map[string]interface{}{
+        c.HTML(http.StatusOK, "raw.tmpl", gin.H{
             "now": time.Date(2017, 07, 01, 0, 0, 0, 0, time.UTC),
         })
     })


### PR DESCRIPTION
* fix README.md code bug
``` go
func main() {
        r := gin.Default()

        // r.GET("/JSONP?callback=x", func(c *gin.Context) { // old
        r.GET("/JSONP", func(c *gin.Context) {    // new
                data := gin.H{
                        "foo": "bar",
                }

                //callback is x
                // Will output  :   x({\"foo\":\"bar\"})
                c.JSONP(http.StatusOK, data)
        })

        // Listen and serve on 0.0.0.0:8080
        r.Run(":8080")
}

// client
// curl http://127.0.0.1:8080/JSONP?callback=x

// old output
// 404 page not found

// new output
// x({"foo":"bar"})

```
* change map[string]interface{} to gin.H
Most of the sample code in the documentation map[string]interface{} is represented by gin.H.
gin.H is a very important place for me to like gin, can write a lot less code


