### PR TITLE
Support http.Server customization

### DIFF
--- a/gin_test.go
+++ b/gin_test.go
@@ -176,6 +176,14 @@ func TestCreateEngine(t *testing.T) {
 	assert.Empty(t, router.Handlers)
 }
 
+func TestSetServer(t *testing.T) {
+	router := New()
+	router.SetServer(&http.Server{IdleTimeout: 5 * time.Second})
+	assert.Equal(t, "/", router.basePath)
+	assert.Equal(t, router.engine, router)
+	assert.Empty(t, router.Handlers)
+}
+
 func TestLoadHTMLFilesTestMode(t *testing.T) {
 	ts := setupHTMLFiles(
 		t,


### PR DESCRIPTION
add `SetServer` to `Engine`to customize `http.Server` under the hood, which makes gin much more extensible and powerful, for example, support the idle timeout:
``` go
r := gin.Default()
s := &http.Server{IdleTimeout: 5*time.Second}
r.SetServer(s)
```