### PR TITLE
Simplify code

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -437,7 +437,6 @@ func serveError(c *Context, code int, defaultMessage []byte) {
 		return
 	}
 	c.writermem.WriteHeaderNow()
-	return
 }
 
 func redirectTrailingSlash(c *Context) {

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -45,7 +45,7 @@ func TestRenderMsgPack(t *testing.T) {
 	err = codec.NewEncoder(buf, h).Encode(data)
 
 	assert.NoError(t, err)
-	assert.Equal(t, w.Body.String(), string(buf.Bytes()))
+	assert.Equal(t, w.Body.String(), buf.String())
 	assert.Equal(t, "application/msgpack; charset=utf-8", w.Header().Get("Content-Type"))
 }
 


### PR DESCRIPTION
- Use buf.String instead of converison
- Remove redundant return