### PR TITLE
git ignore .idea for GoLand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ count.out
 test
 profile.out
 tmp.out
+.idea/


### PR DESCRIPTION
- Add `.idea` directory to `.gitignore`.
    - This helps those who use the GoLand IDE, which stores its temporary files in `.idea` folder.
