### PR TITLE
Adjust Render.Redirect test case

### DIFF
--- a/render/render_test.go
+++ b/render/render_test.go
@@ -347,7 +347,17 @@ func TestRenderRedirect(t *testing.T) {
 	}
 
 	w = httptest.NewRecorder()
-	assert.Panics(t, func() { assert.NoError(t, data2.Render(w)) })
+	assert.PanicsWithValue(t, "Cannot redirect with status code 200", func() { data2.Render(w) })
+
+	data3 := Redirect{
+		Code:     http.StatusCreated,
+		Request:  req,
+		Location: "/new/location",
+	}
+
+	w = httptest.NewRecorder()
+	err = data3.Render(w)
+	assert.NoError(t, err)
 
 	// only improve coverage
 	data2.WriteContentType(w)


### PR DESCRIPTION
- Fixed : Adjust the correct test case, the source code is to `pinic`,  but test case is not correctly captured
- Add : Add the test case of code 201

**[The original PR](#2014 )**