### PR TITLE
case insensitivity

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -395,7 +395,8 @@ func (n *node) getValue(path string, po Params, unescape bool) (value nodeValue)
 walk: // Outer loop for walking the tree
 	for {
 		if len(path) > len(n.path) {
-			if path[:len(n.path)] == n.path {
+			if strings.ToLower(path[:len(n.path)]) == strings.ToLower(n.path) {
+				//if path[:len(n.path)] == n.path {
 				path = path[len(n.path):]
 				// If this node does not have a wildcard (param or catchAll)
 				// child,  we can just look up the next child node and continue
@@ -494,7 +495,8 @@ walk: // Outer loop for walking the tree
 					panic("invalid node type")
 				}
 			}
-		} else if path == n.path {
+		} else if strings.ToLower(path) == strings.ToLower(n.path) {
+			//} else if path == n.path {
 			// We should have reached the node containing the handle.
 			// Check if this node has a handle registered.
 			if value.handlers = n.handlers; value.handlers != nil {


### PR DESCRIPTION
The Gin framework is case sensitive for URLs, but the URL is not case sensitive in the browser. For a better user experience, it is recommended to optimize the URL case sensitivity, and use the lowercase path uniformly when registering the handler. Considering the case of URI parameters, you can't directly convert the URL to lowercase or uppercase in the program. You can convert it to lowercase in the node.getValue() method and compare it to achieve case insensitivity.

For example, the more complex URI below:

Router := gin.Default()

router.GET("/user/:firstname/:lastname/go42", func(c *gin.Context) {
Fname := c.Param("firstname")
Lname := c.Param("lastname")

c.String(http.StatusOK, "Hello %s %s ", fname, lname)
})

router.Run(":8080")

When this feature is implemented. Although the user and go42 in the above program are lowercase when registering, when accessing the following two URLs, they can be accessed normally and the page is rendered.

Localhost:8080/user/Rob/Pike/Go42
Localhost:8080/uSer/Rob/Pike/Go42

