### PR TITLE
Updated Readme.md for serving multiple services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1678,11 +1678,19 @@ func main() {
 	}
 
 	g.Go(func() error {
-		return server01.ListenAndServe()
+		err := server01.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+		return err
 	})
 
 	g.Go(func() error {
-		return server02.ListenAndServe()
+		err := server02.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+		return err
 	})
 
 	if err := g.Wait(); err != nil {


### PR DESCRIPTION
Previous version of Readme's multiple services case had issues: if one service did not start for any reason, you would never know about it.


