### PR TITLE
Updated Readme.md: file.Close() for template read

### DIFF
--- a/README.md
+++ b/README.md
@@ -1799,6 +1799,7 @@ func main() {
 func loadTemplate() (*template.Template, error) {
 	t := template.New("")
 	for name, file := range Assets.Files {
+		defer file.Close()
 		if file.IsDir() || !strings.HasSuffix(name, ".tmpl") {
 			continue
 		}


### PR DESCRIPTION
If you try to use `loadTemplate()` several times, every time except first will fail.


