### PR TITLE
Remove unused Name() method from Binding interface

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -25,7 +25,6 @@ const (
 // data present in the request such as JSON request body, query parameters or
 // the form POST.
 type Binding interface {
-	Name() string
 	Bind(*http.Request, interface{}) error
 }
 


### PR DESCRIPTION
The method Name() is not used in gin.