### PR TITLE
binding: add ShouldBindQuery2 and BindQuery2

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -72,6 +72,7 @@ var (
 	XML           = xmlBinding{}
 	Form          = formBinding{}
 	Query         = queryBinding{}
+	Query2        = queryBinding2{}
 	FormPost      = formPostBinding{}
 	FormMultipart = formMultipartBinding{}
 	ProtoBuf      = protobufBinding{}

--- a/binding/query.go
+++ b/binding/query.go
@@ -19,3 +19,18 @@ func (queryBinding) Bind(req *http.Request, obj interface{}) error {
 	}
 	return validate(obj)
 }
+
+// Support for query tag binding data
+type queryBinding2 struct{}
+
+func (queryBinding2) Name() string {
+	return "query"
+}
+
+func (queryBinding2) Bind(req *http.Request, obj interface{}) error {
+	if err := mapFormByTag(obj, req.URL.Query(), "query"); err != nil {
+		return err
+	}
+
+	return validate(obj)
+}

--- a/context.go
+++ b/context.go
@@ -572,6 +572,11 @@ func (c *Context) BindQuery(obj interface{}) error {
 	return c.MustBindWith(obj, binding.Query)
 }
 
+// BindQuery2 is a shortcut for c.MustBindWith(obj, binding.Query2).
+func (c *Context) BindQuery2(obj interface{}) error {
+	return c.MustBindWith(obj, binding.Query2)
+}
+
 // BindYAML is a shortcut for c.MustBindWith(obj, binding.YAML).
 func (c *Context) BindYAML(obj interface{}) error {
 	return c.MustBindWith(obj, binding.YAML)
@@ -629,6 +634,11 @@ func (c *Context) ShouldBindXML(obj interface{}) error {
 // ShouldBindQuery is a shortcut for c.ShouldBindWith(obj, binding.Query).
 func (c *Context) ShouldBindQuery(obj interface{}) error {
 	return c.ShouldBindWith(obj, binding.Query)
+}
+
+// ShouldBindQuery2 is a shortcut for c.ShouldBindWith(obj, binding.Query2).
+func (c *Context) ShouldBindQuery2(obj interface{}) error {
+	return c.ShouldBindWith(obj, binding.Query2)
 }
 
 // ShouldBindYAML is a shortcut for c.ShouldBindWith(obj, binding.YAML).

--- a/context_test.go
+++ b/context_test.go
@@ -1474,6 +1474,22 @@ func TestContextBindWithQuery(t *testing.T) {
 	assert.Equal(t, 0, w.Body.Len())
 }
 
+func TestContextBindWithQuery2(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest("POST", "/?foo=bar&bar=foo", bytes.NewBufferString("foo=unused"))
+
+	var obj struct {
+		Foo string `query:"foo"`
+		Bar string `query:"bar"`
+	}
+
+	assert.NoError(t, c.BindQuery2(&obj))
+	assert.Equal(t, "foo", obj.Bar)
+	assert.Equal(t, "bar", obj.Foo)
+	assert.Equal(t, 0, w.Body.Len())
+}
 func TestContextBindWithYAML(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := CreateTestContext(w)
@@ -1600,6 +1616,26 @@ func TestContextShouldBindWithQuery(t *testing.T) {
 		Bar1 string `form:"Bar"`
 	}
 	assert.NoError(t, c.ShouldBindQuery(&obj))
+	assert.Equal(t, "foo", obj.Bar)
+	assert.Equal(t, "bar", obj.Foo)
+	assert.Equal(t, "foo1", obj.Bar1)
+	assert.Equal(t, "bar1", obj.Foo1)
+	assert.Equal(t, 0, w.Body.Len())
+}
+
+func TestContextShouldBindWithQuery2(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest("POST", "/?foo=bar&bar=foo&Foo=bar1&Bar=foo1", bytes.NewBufferString("foo=unused"))
+
+	var obj struct {
+		Foo  string `query:"foo"`
+		Bar  string `query:"bar"`
+		Foo1 string `query:"Foo"`
+		Bar1 string `query:"Bar"`
+	}
+	assert.NoError(t, c.ShouldBindQuery2(&obj))
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, "foo1", obj.Bar1)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=


### PR DESCRIPTION
### Why mention this pr
In data binding
http header uses the SoupdBindHeader function, the tag is the header
JSON uses the SoupdBindJSON function, the tag is json
uri uses the ShoulddBindUri function, the tag is uri
In design, keep a tag and a function one-to-one correspondence.
However, both ShouldBind and ShoulddBindQuery use form tags.

This pr just separates the query from the form, based on the considerations below.

* Behind the good aspects plus new features, do not worry about breaking the form data binding.
* Used in conjunction with github.com/guonaihong/gout http client, people can easily bind data with gin and then forward the data to the next service node with gout

### demo
```go
package main

import (
	"github.com/gin-gonic/gin"
        "github.com/guonaihong/gout"
)

type testQuery struct {
	Size int    `query:"size"`
	Page int    `query:"page"`
	Ak   string `query:"ak"`
}

func nextSever() {
        r := gin.Default()

	r.GET("/query", func(c *gin.Context) {
		q := testQuery{}
		err := c.ShouldBindQuery2(&q)
		if err != nil {
			return
		}
		c.JSON(200, q)
	})
        r.Run(":1234")
}

func main() {
        go nextSever()
	r := gin.Default()

	r.GET("/query", func(c *gin.Context) {
		q := testQuery{}
		err := c.ShouldBindQuery2(&q)
		if err != nil {
			return
		}
                // Send to the next service
                code := 0 // http code
                err := gout.GET("127.0.0.1:1234/query").SetQuery(q).Code(&code).Do()
                if err != nil || code != 200 { /* todo Need to handle errors here */}
		c.JSON(200, q)
	})

	r.Run()
}

// http client
// curl '127.0.0.1:8080/query?size=10&page=20&ak=test'
```



