### PR TITLE
[FIX] c.Request.FormFile maybe file, need close

### DIFF
--- a/context.go
+++ b/context.go
@@ -516,7 +516,11 @@ func (c *Context) FormFile(name string) (*multipart.FileHeader, error) {
 			return nil, err
 		}
 	}
-	_, fh, err := c.Request.FormFile(name)
+	f, fh, err := c.Request.FormFile(name)
+	if err != nil {
+		return nil, err
+	}
+	f.Close()
 	return fh, err
 }
 


### PR DESCRIPTION
https://github.com/gin-gonic/gin/issues/2104

func (r *Request) FormFile(key string) (multipart.File, *multipart.FileHeader, error)

File is an interface to access the file part of a multipart message. Its contents may be either stored in memory or on disk. If stored on disk, the File's underlying concrete type will be an *os.File. 