### PR TITLE
Add support for multimaps in query strings

### DIFF
--- a/context.go
+++ b/context.go
@@ -413,9 +413,22 @@ func (c *Context) QueryMap(key string) map[string]string {
 	return dicts
 }
 
+// QueryMultiMap returns a multimap for a given query key.
+func (c *Context) QueryMultiMap(key string) map[string][]string {
+	dicts, _ := c.GetQueryMultiMap(key)
+	return dicts
+}
+
 // GetQueryMap returns a map for a given query key, plus a boolean value
 // whether at least one value exists for the given key.
 func (c *Context) GetQueryMap(key string) (map[string]string, bool) {
+	dicts, exists := c.GetQueryMultiMap(key)
+	return filterAllValuesButTheFirstOne(dicts), exists
+}
+
+// GetQueryMultiMap returns a multimap for a given query key, plus a boolean value
+// whether at least one value exists for the given key.
+func (c *Context) GetQueryMultiMap(key string) (map[string][]string, bool) {
 	c.getQueryCache()
 	return c.get(c.queryCache, key)
 }
@@ -491,22 +504,35 @@ func (c *Context) PostFormMap(key string) map[string]string {
 // whether at least one value exists for the given key.
 func (c *Context) GetPostFormMap(key string) (map[string]string, bool) {
 	c.getFormCache()
-	return c.get(c.formCache, key)
+	dicts, exists := c.get(c.formCache, key)
+	return filterAllValuesButTheFirstOne(dicts), exists
 }
 
-// get is an internal method and returns a map which satisfy conditions.
-func (c *Context) get(m map[string][]string, key string) (map[string]string, bool) {
-	dicts := make(map[string]string)
+// get is an internal method and returns a multimap which satisfy conditions.
+func (c *Context) get(m map[string][]string, key string) (map[string][]string, bool) {
+	dicts := make(map[string][]string)
 	exist := false
 	for k, v := range m {
 		if i := strings.IndexByte(k, '['); i >= 1 && k[0:i] == key {
 			if j := strings.IndexByte(k[i+1:], ']'); j >= 1 {
 				exist = true
-				dicts[k[i+1:][:j]] = v[0]
+				dicts[k[i+1:][:j]] = v
 			}
 		}
 	}
 	return dicts, exist
+}
+
+// filterAllValuesButTheFirstOne returns a map where the values correspond
+// to the first value for each key in the multimap given as input.
+func filterAllValuesButTheFirstOne(m map[string][]string) map[string]string {
+	result := map[string]string{}
+
+	for k, v := range m {
+		result[k] = v[0]
+	}
+
+	return result
 }
 
 // FormFile returns the first file for the provided form key.

--- a/context_test.go
+++ b/context_test.go
@@ -414,7 +414,7 @@ func TestContextQueryAndPostForm(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	body := bytes.NewBufferString("foo=bar&page=11&both=&foo=second")
 	c.Request, _ = http.NewRequest("POST",
-		"/?both=GET&id=main&id=omit&array[]=first&array[]=second&ids[a]=hi&ids[b]=3.14", body)
+		"/?both=GET&id=main&id=omit&array[]=first&array[]=second&ids[a]=hi&ids[a]=bye&ids[b]=3.14", body)
 	c.Request.Header.Add("Content-Type", MIMEPOSTForm)
 
 	assert.Equal(t, "bar", c.DefaultPostForm("foo", "none"))
@@ -506,6 +506,30 @@ func TestContextQueryAndPostForm(t *testing.T) {
 
 	dicts = c.QueryMap("nokey")
 	assert.Equal(t, 0, len(dicts))
+
+	multiDicts, ok := c.GetQueryMultiMap("ids")
+	assert.True(t, ok)
+	assert.Equal(t, []string{"hi", "bye"}, multiDicts["a"])
+	assert.Equal(t, []string{"3.14"}, multiDicts["b"])
+
+	multiDicts, ok = c.GetQueryMultiMap("nokey")
+	assert.False(t, ok)
+	assert.Equal(t, 0, len(multiDicts))
+
+	multiDicts, ok = c.GetQueryMultiMap("both")
+	assert.False(t, ok)
+	assert.Equal(t, 0, len(multiDicts))
+
+	multiDicts, ok = c.GetQueryMultiMap("array")
+	assert.False(t, ok)
+	assert.Equal(t, 0, len(multiDicts))
+
+	multiDicts = c.QueryMultiMap("ids")
+	assert.Equal(t, []string{"hi", "bye"}, multiDicts["a"])
+	assert.Equal(t, []string{"3.14"}, multiDicts["b"])
+
+	multiDicts = c.QueryMultiMap("nokey")
+	assert.Equal(t, 0, len(multiDicts))
 }
 
 func TestContextPostFormMultipart(t *testing.T) {


### PR DESCRIPTION
Currently, Gin supports parsing maps in query strings using `GetQueryMap`. The current implementation, however, is limited to simple maps where values are strings. A simple change to the code enables parsing more complex maps where values are string arrays. For instance, the following URL contains such a map:

`/test?map[key1]=value11&map[key1]=value12&map[key2]=value2`

We have use-cases where we need to parse such URLs. Given the change is relatively minor, and it is backwards compatible, it would be nice to have this feature added.

I chose `multimap` to refer to a map containing string arrays (see https://en.wikipedia.org/wiki/Multimap). But, there might be a better name.

I will document the new methods in the README if you think it is a feature you want to add to Gin.