### PR TITLE
make Context.Value method concurrent safe

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -330,11 +330,31 @@ func TestContextCopy(t *testing.T) {
 	assert.Equal(t, &cp.writermem, cp.Writer.(*responseWriter))
 	assert.Equal(t, cp.Request, c.Request)
 	assert.Equal(t, cp.index, abortIndex)
-	assert.Equal(t, cp.Keys, c.Keys)
+	toMap := func(p *sync.Map) map[string]interface{} {
+		if p == nil {
+			return nil
+		}
+		m := map[string]interface{}{}
+		p.Range(func(key, value interface{}) bool {
+			if str, ok := key.(string); ok {
+				m[str] = value
+			}
+			return true
+		})
+		return m
+	}
+	assert.Equal(t, toMap(cp.Keys), toMap(c.Keys))
 	assert.Equal(t, cp.engine, c.engine)
 	assert.Equal(t, cp.Params, c.Params)
 	cp.Set("foo", "notBar")
-	assert.False(t, cp.Keys["foo"] == c.Keys["foo"])
+	var vc, vcp interface{}
+	if c.Keys != nil {
+		vc, _ = c.Keys.Load("foo")
+	}
+	if cp.Keys != nil {
+		vcp, _ = cp.Keys.Load("foo")
+	}
+	assert.False(t, vc == vcp)
 }
 
 func TestContextHandlerName(t *testing.T) {

--- a/logger.go
+++ b/logger.go
@@ -245,7 +245,17 @@ func LoggerWithConfig(conf LoggerConfig) HandlerFunc {
 			param := LogFormatterParams{
 				Request: c.Request,
 				isTerm:  isTerm,
-				Keys:    c.Keys,
+			}
+
+			keys := c.Keys
+			if keys != nil {
+				param.Keys = make(map[string]interface{})
+				keys.Range(func(key, value interface{}) bool {
+					if str, ok := key.(string); ok {
+						param.Keys[str] = value
+					}
+					return true
+				})
 			}
 
 			// Stop timer

--- a/logger_test.go
+++ b/logger_test.go
@@ -205,7 +205,16 @@ func TestLoggerWithConfigFormatting(t *testing.T) {
 	router.GET("/example", func(c *Context) {
 		// set dummy ClientIP
 		c.Request.Header.Set("X-Forwarded-For", "20.20.20.20")
-		gotKeys = c.Keys
+		keys := c.Keys
+		if keys != nil {
+			gotKeys = make(map[string]interface{})
+			keys.Range(func(key, value interface{}) bool {
+				if str, ok := key.(string); ok {
+					gotKeys[str] = value
+				}
+				return true
+			})
+		}
 	})
 	performRequest(router, "GET", "/example?a=100")
 


### PR DESCRIPTION
Make Context.Value, Context.Get, Context.Set methods concurrent safe, to be consistent with Go's context.Context.