### PR TITLE
Update readme on custom validation fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
-	"gopkg.in/go-playground/validator.v10"
+	"github.com/go-playground/validator/v10"
 )
 
 // Booking contains binded and validated data.


### PR DESCRIPTION
V10 now uses a different package path. More at https://github.com/go-playground/validator/releases/tag/v10.0.0
