### PR TITLE
path: sync code with httprouter

### DIFF
--- a/path.go
+++ b/path.go
@@ -5,8 +5,6 @@
 
 package gin
 
-const stackBufSize = 128
-
 // cleanPath is the URL version of path.Clean, it returns a canonical URL path
 // for p, eliminating . and .. elements.
 //
@@ -21,6 +19,7 @@ const stackBufSize = 128
 //
 // If the result of this process is an empty string, "/" is returned.
 func cleanPath(p string) string {
+	const stackBufSize = 128
 	// Turn empty string into "/"
 	if p == "" {
 		return "/"


### PR DESCRIPTION
Make the constant `stackBufSize` local since the go compiler will replace any occurrence with the const value and it only applies to the `cleanPath` function. 

Also to correct the last wrong sync by me and sync code with httprouter again:
https://github.com/julienschmidt/httprouter/blob/master/path.go#L22