### PR TITLE
Unix Socket Handling

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -320,13 +320,13 @@ func (engine *Engine) RunUnix(file string) (err error) {
 	debugPrint("Listening and serving HTTP on unix:/%s", file)
 	defer func() { debugPrintError(err) }()
 
-	os.Remove(file)
 	listener, err := net.Listen("unix", file)
 	if err != nil {
 		return
 	}
 	defer listener.Close()
-	err = os.Chmod(file, 0777)
+	defer os.Remove(file)
+
 	if err != nil {
 		return
 	}

--- a/gin.go
+++ b/gin.go
@@ -327,9 +327,6 @@ func (engine *Engine) RunUnix(file string) (err error) {
 	defer listener.Close()
 	defer os.Remove(file)
 
-	if err != nil {
-		return
-	}
 	err = http.Serve(listener, engine)
 	return
 }


### PR DESCRIPTION
The current handling of Unix sockets is not correct.

1) The service should not delete the socket before binding to it. If the socket exists, that implies another service is already listening on the socket.
2) The socket should instead be cleaned up at shutdown.
3) The permissions should NOT be world writable by default.

One of the main reasons to use sockets is for security. Using sockets allows you to lock access down to a specific unix group/user.However, due to the various use cases for unix sockets, it may be a good idea to accept a `net.Listener` interface, so that the socket can be configured before the server is started.