### PR TITLE
Request and Writer Getters in Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -70,11 +70,11 @@ type Context struct {
 }
 
 func (c Context) GetRequest() *http.Request {
-    return c.Request
+	return c.Request
 }
 
 func (c Context) GetWriter() ResponseWriter {
-    return c.Writer
+	return c.Writer
 }
 
 /************************************/

--- a/context.go
+++ b/context.go
@@ -69,6 +69,14 @@ type Context struct {
 	formCache url.Values
 }
 
+func (c Context) GetRequest() *http.Request {
+    return c.Request
+}
+
+func (c Context) GetWriter() ResponseWriter {
+    return c.Writer
+}
+
 /************************************/
 /********** CONTEXT CREATION ********/
 /************************************/

--- a/context_test.go
+++ b/context_test.go
@@ -1918,3 +1918,16 @@ func TestRaceParamsContextCopy(t *testing.T) {
 	performRequest(router, "GET", "/name2/api")
 	wg.Wait()
 }
+
+func TestGetRequest(t *testing.T) {
+	c, _ := CreateTestContext(CreateTestResponseRecorder())
+	c.Request, _ = http.NewRequest("POST", "/", new(bytes.Buffer))
+
+	assert.Equal(t, c.Request, c.GetRequest())
+}
+
+func TestGetResponseWriter(t *testing.T) {
+	c, _ := CreateTestContext(CreateTestResponseRecorder())
+
+	assert.Equal(t, c.Writer, c.GetWriter())
+}


### PR DESCRIPTION
I added getter functions for the `Request` and `Writer` field in `Context`.
With these changes, it will be easier to create an interface for `Context` in a project using gin and because of this, easier to mock.
