### PR TITLE
Handle invalid Accept header values properly

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -1228,6 +1228,32 @@ func TestContextNegotiationFormatWithWildcardAccept(t *testing.T) {
 	assert.Equal(t, c.NegotiateFormat(MIMEHTML), MIMEHTML)
 }
 
+func TestContextNegotiationFormatWithInvalidAccept(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest("POST", "/", nil)
+	c.Request.Header.Add("Accept", "text*,*/html")
+
+	assert.Equal(t, c.NegotiateFormat("*/*"), "")
+	assert.Equal(t, c.NegotiateFormat("text/*"), "")
+	assert.Equal(t, c.NegotiateFormat("text/html"), "")
+	assert.Equal(t, c.NegotiateFormat(MIMEJSON), "")
+	assert.Equal(t, c.NegotiateFormat(MIMEXML), "")
+	assert.Equal(t, c.NegotiateFormat(MIMEHTML), "")
+
+	c, _ = CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest("POST", "/", nil)
+	c.Request.Header.Add("Accept", "text*/*,application/j*,application/jso,application/json2")
+
+	assert.Equal(t, c.NegotiateFormat("*/*"), "*/*")
+	assert.Equal(t, c.NegotiateFormat("text/*"), "")
+	assert.Equal(t, c.NegotiateFormat("text/html"), "")
+	assert.Equal(t, c.NegotiateFormat("application/*"), "application/*")
+	assert.Equal(t, c.NegotiateFormat("application/json"), "")
+	assert.Equal(t, c.NegotiateFormat(MIMEJSON), "")
+	assert.Equal(t, c.NegotiateFormat(MIMEXML), "")
+	assert.Equal(t, c.NegotiateFormat(MIMEHTML), "")
+}
+
 func TestContextNegotiationFormatCustom(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Request, _ = http.NewRequest("POST", "/", nil)


### PR DESCRIPTION
`NegotationFormat` raises out-of-range access to an offer string with some invalid HTTP Accept header values. It happens with the current master: 3315353c20ab224d9308db9df19d83383dba539a .

For example, the following header causes an internal server error.

```
Accept: application/json2
```

I also found `NegotationFormat` returns an inappropriate result with some invalid Accept values. Please refer to the `TestContextNegotiationFormatWithInvalidAccept`.

So I updated the implementation to handle those invalid values properly.

---

I found that the wildcard support for content negotiation was introduced in https://github.com/gin-gonic/gin/pull/1112.
But it seems there is no discussion about the old implementation.
I am sorry if I missed something.