### PR TITLE
judge the environment variable PORT  whether is valid

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -137,7 +138,7 @@ func joinPaths(absolutePath, relativePath string) string {
 func resolveAddress(addr []string) string {
 	switch len(addr) {
 	case 0:
-		if port := os.Getenv("PORT"); port != "" {
+		if port := os.Getenv("PORT"); port != "" && isValidPortEnvVar(port) {
 			debugPrint("Environment variable PORT=\"%s\"", port)
 			return ":" + port
 		}
@@ -148,4 +149,11 @@ func resolveAddress(addr []string) string {
 	default:
 		panic("too many parameters")
 	}
+}
+
+// Determine whether the PORT environment variable is valid。
+// If the PORT can be parsed to int(0-65535)，return true。
+func isValidPortEnvVar(portString string) bool {
+	_, err := strconv.ParseUint(portString, 10, 16)
+	return err == nil
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -137,3 +137,14 @@ func TestMarshalXMLforH(t *testing.T) {
 	e := h.MarshalXML(enc, x)
 	assert.Error(t, e)
 }
+
+func TestIsValidPortEnvVar(t *testing.T) {
+	assert.Equal(t, false, isValidPortEnvVar("abc"))
+	assert.Equal(t, false, isValidPortEnvVar("-1"))
+	assert.Equal(t, true, isValidPortEnvVar("1"))
+	assert.Equal(t, true, isValidPortEnvVar("1000"))
+	assert.Equal(t, true, isValidPortEnvVar("10000"))
+	assert.Equal(t, true, isValidPortEnvVar("65535"))
+	assert.Equal(t, false, isValidPortEnvVar("65536"))
+	assert.Equal(t, false, isValidPortEnvVar("655360"))
+}


### PR DESCRIPTION
If an addr parameter is not passed in `Run`, it will get `PORT` env variable。If there is not a `PORT` variable，it will use default port - `8080`。But sometimes, there is a `PORT` env variable, but it is not a valid value(0-63335),the app will panic。So I add a function to judge the `PORT` whether is valid。For example:
```
➜  gin $ echo $PORT
abc
➜  gin $ go run main.go
[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.

[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:	export GIN_MODE=release
 - using code:	gin.SetMode(gin.ReleaseMode)

[GIN-debug] GET    /get                      --> main.main.func1 (3 handlers)
[GIN-debug] Environment variable PORT="abcd"
[GIN-debug] Listening and serving HTTP on :abcd
[GIN-debug] [ERROR] listen tcp: lookup tcp/abcd: nodename nor servname provided, or not known
2020/04/16 23:33:36 listen tcp: lookup tcp/abcd: nodename nor servname provided, or not known
exit status 1
```