### PR TITLE
add `isValidPORTEnvVar` function to judge the  PORT  whether is valid

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -138,14 +139,23 @@ func resolveAddress(addr []string) string {
 	switch len(addr) {
 	case 0:
 		if port := os.Getenv("PORT"); port != "" {
-			debugPrint("Environment variable PORT=\"%s\"", port)
-			return ":" + port
+			if isValidPORTEnvVar(port) {
+				debugPrint("Environment variable PORT=\"%s\"", port)
+				return ":" + port
+			}
 		}
-		debugPrint("Environment variable PORT is undefined. Using port :8080 by default")
+		debugPrint("Environment variable PORT is undefined or invalid. Using port :8080 by default")
 		return ":8080"
 	case 1:
 		return addr[0]
 	default:
 		panic("too many parameters")
 	}
+}
+
+// Determine the PORT environment variable whether is valid。
+// If the PORT can be parsed to uint(0-65535)，return true。
+func isValidPORTEnvVar(portString string) bool {
+	_, err := strconv.ParseUint(portString, 10, 16)
+	return err == nil
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -137,3 +137,18 @@ func TestMarshalXMLforH(t *testing.T) {
 	e := h.MarshalXML(enc, x)
 	assert.Error(t, e)
 }
+
+func TestIsValidPPORTEnvVar(t *testing.T) {
+	assert.Equal(t, false, isValidPORTEnvVar("abc"))
+	assert.Equal(t, false, isValidPORTEnvVar("-1"))
+	assert.Equal(t, false, isValidPORTEnvVar("-100"))
+	assert.Equal(t, true, isValidPORTEnvVar("1"))
+	assert.Equal(t, true, isValidPORTEnvVar("1000"))
+	assert.Equal(t, true, isValidPORTEnvVar("10000"))
+	assert.Equal(t, false, isValidPORTEnvVar(" 10000"))
+	assert.Equal(t, false, isValidPORTEnvVar("10000 "))
+	assert.Equal(t, false, isValidPORTEnvVar("10000."))
+	assert.Equal(t, true, isValidPORTEnvVar("65535"))
+	assert.Equal(t, false, isValidPORTEnvVar("65536"))
+	assert.Equal(t, false, isValidPORTEnvVar("655360"))
+}


### PR DESCRIPTION
If an addr parameter is not passed in `Run`, it will get `PORT` env variable. If there is not a PORT variable，it will use default port - `8080`. But sometimes, there is a PORT env variable, but it is not a valid value(0-65535),the app will panic. So I add a function to judge the PORT whether is valid. For example:

my code:
```
func main() {
    r := gin.Default()
    ...
    if  err := r.Run(); err != nil {
       ...
   }
}
```

run:
```
➜  gin $ echo $PORT
abc
➜  gin $ go run main.go
[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.

[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:	export GIN_MODE=release
 - using code:	gin.SetMode(gin.ReleaseMode)

[GIN-debug] GET    /get                      --> main.main.func1 (3 handlers)
[GIN-debug] Environment variable PORT="abcd"
[GIN-debug] Listening and serving HTTP on :abcd
[GIN-debug] [ERROR] listen tcp: lookup tcp/abcd: nodename nor servname provided, or not known
2020/04/16 23:33:36 listen tcp: lookup tcp/abcd: nodename nor servname provided, or not known
exit status 1
```