### PR TITLE
feat: add ability to override the debugPrint statement

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -23,6 +23,9 @@ func IsDebugging() bool {
 // DebugPrintRouteFunc indicates debug log output format.
 var DebugPrintRouteFunc func(httpMethod, absolutePath, handlerName string, nuHandlers int)
 
+// DebugPrintFunc indicates debug log output format.
+var DebugPrintFunc func(format string, values ...interface{})
+
 func debugPrintRoute(httpMethod, absolutePath string, handlers HandlersChain) {
 	if IsDebugging() {
 		nuHandlers := len(handlers)
@@ -49,10 +52,14 @@ func debugPrintLoadTemplate(tmpl *template.Template) {
 
 func debugPrint(format string, values ...interface{}) {
 	if IsDebugging() {
-		if !strings.HasSuffix(format, "\n") {
-			format += "\n"
+		if DebugPrintFunc == nil {
+			if !strings.HasSuffix(format, "\n") {
+				format += "\n"
+			}
+			fmt.Fprintf(DefaultWriter, "[GIN-debug] "+format, values...)
+		} else {
+			DebugPrintFunc(format, values...)
 		}
-		fmt.Fprintf(DefaultWriter, "[GIN-debug] "+format, values...)
 	}
 }
 


### PR DESCRIPTION
This allows users to use a single logger within their application for all printing, regardless of level.

- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as TravisCI.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

