### PR TITLE
modify: nil instead of []string{}

### DIFF
--- a/context.go
+++ b/context.go
@@ -426,7 +426,7 @@ func (c *Context) GetQueryArray(key string) ([]string, bool) {
 	if values, ok := c.queryCache[key]; ok && len(values) > 0 {
 		return values, true
 	}
-	return []string{}, false
+	return nil, false
 }
 
 // QueryMap returns a map for a given query key.


### PR DESCRIPTION
I think it is better to replace `[] string {}` with `nil` when` key` does not exist, because the zero value of `[] string` type is` nil`.
