### PR TITLE
Update gin_integration_test.go

### DIFF
--- a/gin_integration_test.go
+++ b/gin_integration_test.go
@@ -144,31 +144,31 @@ func TestRunWithPort(t *testing.T) {
 }
 
 func TestUnixSocket(t *testing.T) {
-        router := New()
+	router := New()
 
-        unixTestSocket := "/tmp/unix_unit_test"
+	unixTestSocket := "/tmp/unix_unit_test"
 
-        defer os.Remove(unixTestSocket)
+	defer os.Remove(unixTestSocket)
 
-        go func() {
-                router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
-                assert.NoError(t, router.RunUnix(unixTestSocket))
-        }()
-        // have to wait for the goroutine to start and run the server
-        // otherwise the main thread will complete
-        time.Sleep(5 * time.Millisecond)
+	go func() {
+	        router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
+	        assert.NoError(t, router.RunUnix(unixTestSocket))
+	}()
+	// have to wait for the goroutine to start and run the server
+	// otherwise the main thread will complete
+	time.Sleep(5 * time.Millisecond)
 
-        c, err := net.Dial("unix", unixTestSocket)
-        assert.NoError(t, err)
+	c, err := net.Dial("unix", unixTestSocket)
+	assert.NoError(t, err)
 
-        fmt.Fprint(c, "GET /example HTTP/1.0\r\n\r\n")
-        scanner := bufio.NewScanner(c)
-        var response string
-        for scanner.Scan() {
-                response += scanner.Text()
-        }
-        assert.Contains(t, response, "HTTP/1.0 200", "should get a 200")
-        assert.Contains(t, response, "it worked", "resp body should match")
+	fmt.Fprint(c, "GET /example HTTP/1.0\r\n\r\n")
+	scanner := bufio.NewScanner(c)
+	var response string
+	for scanner.Scan() {
+	        response += scanner.Text()
+	}
+	assert.Contains(t, response, "HTTP/1.0 200", "should get a 200")
+	assert.Contains(t, response, "it worked", "resp body should match")
 }
 
 func TestBadUnixSocket(t *testing.T) {

--- a/gin_integration_test.go
+++ b/gin_integration_test.go
@@ -151,8 +151,8 @@ func TestUnixSocket(t *testing.T) {
 	defer os.Remove(unixTestSocket)
 
 	go func() {
-	        router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
-	        assert.NoError(t, router.RunUnix(unixTestSocket))
+		router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
+		assert.NoError(t, router.RunUnix(unixTestSocket))
 	}()
 	// have to wait for the goroutine to start and run the server
 	// otherwise the main thread will complete
@@ -165,7 +165,7 @@ func TestUnixSocket(t *testing.T) {
 	scanner := bufio.NewScanner(c)
 	var response string
 	for scanner.Scan() {
-	        response += scanner.Text()
+		response += scanner.Text()
 	}
 	assert.Contains(t, response, "HTTP/1.0 200", "should get a 200")
 	assert.Contains(t, response, "it worked", "resp body should match")


### PR DESCRIPTION
TestUnixSocket fails if you run it twice in a row.  This is due to the unix socket file persisting.  Added defer to clean up.

Whats unclear is the following test TestBadUnixSocket I suspect is just looking for cruft maybe from a prior test or defaults not working, I have not enough background to say.

- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as TravisCI.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

