### PR TITLE
fix bug that tag `form:",default=1"` are not effective in some cases

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -163,8 +163,10 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 			val = opt.defaultValue
 		}
 
-		if len(vs) > 0 {
+		if len(vs) > 0 && vs[0] != "" {
 			val = vs[0]
+		} else {
+			val = opt.defaultValue
 		}
 		return true, setWithProperType(val, value, field)
 	}

--- a/binding/form_mapping_test.go
+++ b/binding/form_mapping_test.go
@@ -62,14 +62,22 @@ func TestMappingBaseTypes(t *testing.T) {
 
 func TestMappingDefault(t *testing.T) {
 	var s struct {
-		Int   int    `form:",default=9"`
-		Slice []int  `form:",default=9"`
-		Array [1]int `form:",default=9"`
+		Int    int    `form:",default=9"`
+		PageNo int    `form:"page_no,default=9"`
+		String string `form:"string,default=9"`
+		Slice  []int  `form:",default=9"`
+		Array  [1]int `form:",default=9"`
 	}
-	err := mappingByPtr(&s, formSource{}, "form")
+	form := map[string][]string{
+		"page_no": []string{""},
+		"string":  []string{""},
+	}
+	err := mappingByPtr(&s, formSource(form), "form")
 	assert.NoError(t, err)
 
 	assert.Equal(t, 9, s.Int)
+	assert.Equal(t, 9, s.PageNo)
+	assert.Equal(t, "9", s.String)
 	assert.Equal(t, []int{9}, s.Slice)
 	assert.Equal(t, [1]int{9}, s.Array)
 }

--- a/gin_integration_test.go
+++ b/gin_integration_test.go
@@ -146,15 +146,19 @@ func TestRunWithPort(t *testing.T) {
 func TestUnixSocket(t *testing.T) {
 	router := New()
 
+	unixTestSocket := "/tmp/unix_unit_test"
+
+	defer os.Remove(unixTestSocket)
+
 	go func() {
 		router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
-		assert.NoError(t, router.RunUnix("/tmp/unix_unit_test"))
+		assert.NoError(t, router.RunUnix(unixTestSocket))
 	}()
 	// have to wait for the goroutine to start and run the server
 	// otherwise the main thread will complete
 	time.Sleep(5 * time.Millisecond)
 
-	c, err := net.Dial("unix", "/tmp/unix_unit_test")
+	c, err := net.Dial("unix", unixTestSocket)
 	assert.NoError(t, err)
 
 	fmt.Fprint(c, "GET /example HTTP/1.0\r\n\r\n")


### PR DESCRIPTION
fix bug that tag `form:",default=1"` are not effective in some cases, e.g: http://host/list?page_no=&page_size=

- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as TravisCI.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

