### PR TITLE
add a method to set the indentJsonIndentString used in Context.Indent…

### DIFF
--- a/context.go
+++ b/context.go
@@ -859,7 +859,7 @@ func (c *Context) HTML(code int, name string, obj interface{}) {
 // WARNING: we recommend to use this only for development purposes since printing pretty JSON is
 // more CPU and bandwidth consuming. Use Context.JSON() instead.
 func (c *Context) IndentedJSON(code int, obj interface{}) {
-	c.Render(code, render.IndentedJSON{Data: obj})
+	c.Render(code, render.IndentedJSON{IndentString: c.engine.indentJsonIndentString, Data: obj})
 }
 
 // SecureJSON serializes the given struct as Secure JSON into the response body.

--- a/gin.go
+++ b/gin.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"sync"
 
 	"github.com/gin-gonic/gin/internal/bytesconv"
@@ -18,6 +19,9 @@ import (
 )
 
 const defaultMultipartMemory = 32 << 20 // 32 MB
+
+// A space string
+var spaceString = string(32)
 
 var (
 	default404Body   = []byte("404 page not found")
@@ -102,16 +106,17 @@ type Engine struct {
 	// See the PR #1817 and issue #1644
 	RemoveExtraSlash bool
 
-	delims           render.Delims
-	secureJsonPrefix string
-	HTMLRender       render.HTMLRender
-	FuncMap          template.FuncMap
-	allNoRoute       HandlersChain
-	allNoMethod      HandlersChain
-	noRoute          HandlersChain
-	noMethod         HandlersChain
-	pool             sync.Pool
-	trees            methodTrees
+	delims                 render.Delims
+	secureJsonPrefix       string
+	HTMLRender             render.HTMLRender
+	FuncMap                template.FuncMap
+	allNoRoute             HandlersChain
+	allNoMethod            HandlersChain
+	noRoute                HandlersChain
+	noMethod               HandlersChain
+	pool                   sync.Pool
+	trees                  methodTrees
+	indentJsonIndentString string
 }
 
 var _ IRouter = &Engine{}
@@ -145,6 +150,7 @@ func New() *Engine {
 		trees:                  make(methodTrees, 0, 9),
 		delims:                 render.Delims{Left: "{{", Right: "}}"},
 		secureJsonPrefix:       "while(1);",
+		indentJsonIndentString: strings.Repeat(spaceString, 4),
 	}
 	engine.RouterGroup.engine = engine
 	engine.pool.New = func() interface{} {
@@ -174,6 +180,13 @@ func (engine *Engine) Delims(left, right string) *Engine {
 // SecureJsonPrefix sets the secureJsonPrefix used in Context.SecureJSON.
 func (engine *Engine) SecureJsonPrefix(prefix string) *Engine {
 	engine.secureJsonPrefix = prefix
+	return engine
+}
+
+// IndentJsonIndentSpaceNum sets the indentJsonIndentString used in Context.IndentedJSON.
+// When we use Context.IndentedJSON, we can use custom indentation to render the response.
+func (engine *Engine) IndentJsonIndentSpaceNum(spaceNum int) *Engine {
+	engine.indentJsonIndentString = strings.Repeat(spaceString, spaceNum)
 	return engine
 }
 

--- a/render/json.go
+++ b/render/json.go
@@ -21,7 +21,8 @@ type JSON struct {
 
 // IndentedJSON contains the given interface object.
 type IndentedJSON struct {
-	Data interface{}
+	IndentString string
+	Data         interface{}
 }
 
 // SecureJSON contains the given interface object and its prefix.
@@ -80,7 +81,7 @@ func WriteJSON(w http.ResponseWriter, obj interface{}) error {
 // Render (IndentedJSON) marshals the given interface object and writes it with custom ContentType.
 func (r IndentedJSON) Render(w http.ResponseWriter) error {
 	r.WriteContentType(w)
-	jsonBytes, err := json.MarshalIndent(r.Data, "", "    ")
+	jsonBytes, err := json.MarshalIndent(r.Data, "", r.IndentString)
 	if err != nil {
 		return err
 	}

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -55,7 +55,7 @@ func TestRenderIndentedJSON(t *testing.T) {
 		"bar": "foo",
 	}
 
-	err := (IndentedJSON{data}).Render(w)
+	err := (IndentedJSON{Data: data}).Render(w)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "{\n    \"bar\": \"foo\",\n    \"foo\": \"bar\"\n}", w.Body.String())
@@ -67,7 +67,7 @@ func TestRenderIndentedJSONPanics(t *testing.T) {
 	data := make(chan int)
 
 	// json: unsupported type: chan int
-	err := (IndentedJSON{data}).Render(w)
+	err := (IndentedJSON{Data: data}).Render(w)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
Hi, I have add a method named `IndentJsonIndentSpaceNum` for `Engine` to set number of indented blanks when you use `Context.IndentedJSON`.We can use it like this:

```
router := gin.Default()
router.IndentJsonIndentSpaceNum(2)
```

The serialized string of `gin.H {" name ":" test "," age ": 2}` is like:

```
{
  "name":  "test",
  "age": 2
}
```

There are only 2 spaces in front of the `name` field.
