### PR TITLE
chore(performance): Change *sync.RWMutex to sync.RWMutex

### DIFF
--- a/context.go
+++ b/context.go
@@ -53,8 +53,6 @@ type Context struct {
 
 	engine *Engine
 
-	EnableMutexLock bool
-
 	// This mutex protect Keys map
 	mu sync.RWMutex
 
@@ -235,27 +233,21 @@ func (c *Context) Error(err error) *Error {
 // Set is used to store a new key/value pair exclusively for this context.
 // It also lazy initializes  c.Keys if it was not used previously.
 func (c *Context) Set(key string, value interface{}) {
-	if c.EnableMutexLock {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-	}
-
+	c.mu.Lock()
 	if c.Keys == nil {
 		c.Keys = make(map[string]interface{})
 	}
 
 	c.Keys[key] = value
+	c.mu.Unlock()
 }
 
 // Get returns the value for the given key, ie: (value, true).
 // If the value does not exists it returns (nil, false)
 func (c *Context) Get(key string) (value interface{}, exists bool) {
-	if c.EnableMutexLock {
-		c.mu.RLock()
-		defer c.mu.RUnlock()
-	}
-
+	c.mu.RLock()
 	value, exists = c.Keys[key]
+	c.mu.RUnlock()
 	return
 }
 

--- a/gin.go
+++ b/gin.go
@@ -162,7 +162,7 @@ func Default() *Engine {
 }
 
 func (engine *Engine) allocateContext() *Context {
-	return &Context{engine: engine, KeysMutex: &sync.RWMutex{}}
+	return &Context{engine: engine}
 }
 
 // Delims sets template left and right delims and returns a Engine instance.


### PR DESCRIPTION
fix #2350 

See the report: https://github.com/gin-gonic/gin/issues/2350

Change `*sync.RWMutex` to `sync.RWMutex`. See [the commet](https://github.com/gin-gonic/gin/pull/2305#discussion_r399993737)

## step and result

Testing in my Macbook Pro

```
$ go get github.com/gin-gonic/gin@d5a42fc8ac93cebe42cde9c9b91a138358e4f99a
go: github.com/gin-gonic/gin d5a42fc8ac93cebe42cde9c9b91a138358e4f99a => v1.6.3-0.20200503042414-d5a42fc8ac93
go: downloading github.com/gin-gonic/gin v1.6.3-0.20200503042414-d5a42fc8ac93
$ go get github.com/julienschmidt/httprouter@master
go: github.com/julienschmidt/httprouter master => v1.3.1-0.20200114094804-8c9f31f047a3
go: downloading github.com/julienschmidt/httprouter v1.3.1-0.20200114094804-8c9f31f047a3
```

Benchmark Result:

```
BenchmarkEcho_Param              	12894638	        88.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_Param               	16120810	        75.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_Param        	20860491	        59.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_Param5             	 5107472	       236 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_Param5              	 8665498	       139 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_Param5       	10716376	       111 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_Param20            	 1649486	       736 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_Param20             	 3693909	       317 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_Param20      	 4302121	       291 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_ParamWrite         	 6067071	       206 ns/op	       8 B/op	       1 allocs/op
BenchmarkGin_ParamWrite          	 7927640	       153 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_ParamWrite   	12336866	        97.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_GithubStatic       	 9660526	       123 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_GithubStatic        	12108596	        99.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_GithubStatic 	22733364	        53.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_GithubParam        	 4760176	       241 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_GithubParam         	 6903195	       175 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_GithubParam  	 8757140	       139 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_GithubAll          	   25303	     47044 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_GithubAll           	   35906	     32017 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_GithubAll    	   48505	     24723 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_GPlusStatic        	13986368	        88.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_GPlusStatic         	15715994	        76.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_GPlusStatic  	40313703	        30.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_GPlusParam         	 8838810	       132 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_GPlusParam          	11063152	       110 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_GPlusParam   	14874406	        83.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_GPlus2Params       	 5957268	       197 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_GPlus2Params        	 8538530	       138 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_GPlus2Params 	11009853	       109 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_GPlusAll           	  610393	      2072 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_GPlusAll            	  845540	      1452 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_GPlusAll     	 1000000	      1022 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_ParseStatic        	13372183	        89.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_ParseStatic         	15553862	        76.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_ParseStatic  	36294546	        32.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_ParseParam         	10718779	       108 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_ParseParam          	14966005	        82.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_ParseParam   	18341719	        65.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_Parse2Params       	 8146166	       149 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_Parse2Params        	11563095	       105 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_Parse2Params 	14198692	        83.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_ParseAll           	  343478	      3427 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_ParseAll            	  467335	      2817 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_ParseAll     	  739195	      1768 ns/op	       0 B/op	       0 allocs/op
BenchmarkEcho_StaticAll          	   39229	     29002 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_StaticAll           	   50160	     25493 ns/op	       0 B/op	       0 allocs/op
BenchmarkHttpRouter_StaticAll    	   90253	     12674 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/julienschmidt/go-http-routing-benchmark	67.399s
```

Or you can see the benchmark result from Travis: https://travis-ci.org/github/gin-gonic/go-http-routing-benchmark/jobs/682559844