### PR TITLE
fix bug that tag `form:",default=1"` are not effective in some cases

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -158,12 +158,8 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 		}
 		return true, setArray(vs, value, field)
 	default:
-		var val string
-		if !ok {
-			val = opt.defaultValue
-		}
-
-		if len(vs) > 0 {
+		val := opt.defaultValue
+		if len(vs) > 0 && vs[0] != "" {
 			val = vs[0]
 		}
 		return true, setWithProperType(val, value, field)

--- a/binding/form_mapping_test.go
+++ b/binding/form_mapping_test.go
@@ -62,14 +62,25 @@ func TestMappingBaseTypes(t *testing.T) {
 
 func TestMappingDefault(t *testing.T) {
 	var s struct {
-		Int   int    `form:",default=9"`
-		Slice []int  `form:",default=9"`
-		Array [1]int `form:",default=9"`
+		Int      int    `form:",default=9"`
+		PageNo   int    `form:"page_no,default=1"`
+		PageSize int    `form:"page_size,default=60"`
+		String   string `form:"string,default=9"`
+		Slice    []int  `form:",default=9"`
+		Array    [1]int `form:",default=9"`
 	}
-	err := mappingByPtr(&s, formSource{}, "form")
+	form := map[string][]string{
+		"page_no":   {""},
+		"page_size": {""},
+		"string":    {"test"},
+	}
+	err := mappingByPtr(&s, formSource(form), "form")
 	assert.NoError(t, err)
 
 	assert.Equal(t, 9, s.Int)
+	assert.Equal(t, 1, s.PageNo)
+	assert.Equal(t, 60, s.PageSize)
+	assert.Equal(t, "test", s.String)
 	assert.Equal(t, []int{9}, s.Slice)
 	assert.Equal(t, [1]int{9}, s.Array)
 }


### PR DESCRIPTION
fix bug that tag form:"page_no,default=1" are not effective in some cases, e.g: http://host/list?page_no=&page_size=

- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as TravisCI.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

