### PR TITLE
chore: improve render string performance

### DIFF
--- a/render/text.go
+++ b/render/text.go
@@ -6,7 +6,6 @@ package render
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -35,6 +34,6 @@ func WriteString(w http.ResponseWriter, format string, data []interface{}) (err 
 		_, err = fmt.Fprintf(w, format, data...)
 		return
 	}
-	_, err = io.WriteString(w, format)
+	_, err = w.Write([]byte(format))
 	return
 }


### PR DESCRIPTION
testing repo: https://github.com/appleboy/web-framework-benchmark

## before

script:

```sh
$ go get github.com/gin-gonic/gin@v1.6.3
$ go test -bench=. -benchtime=10s
```

result: 

```
BenchmarkGinStatic-8               23306             50344 ns/op            8283 B/op        157 allocs/op
BenchmarkGinGitHubAPI-8            16506             71542 ns/op           10801 B/op        203 allocs/op
BenchmarkGinGplusAPI-8            284379              4061 ns/op             685 B/op         13 allocs/op
BenchmarkGinParseAPI-8            153843              7657 ns/op            1361 B/op         26 allocs/op
```

## after

script:

```sh
$ go get github.com/gin-gonic/gin@1bd5a8f
$ go test -bench=. -benchtime=10s
```

result: 

```
BenchmarkGinStatic-8              246488             46740 ns/op            9915 B/op        314 allocs/op
BenchmarkGinGitHubAPI-8           176192             65348 ns/op           12940 B/op        406 allocs/op
BenchmarkGinGplusAPI-8           3298646              3747 ns/op             811 B/op         26 allocs/op
BenchmarkGinParseAPI-8           1683153              7003 ns/op            1620 B/op         52 allocs/op
```