### PR TITLE
fix(tree): reassign fullpath when register new node which the same current node

### DIFF
--- a/routes_test.go
+++ b/routes_test.go
@@ -585,7 +585,6 @@ func TestRouteContextHoldsFullPath(t *testing.T) {
 	// Test routes
 	routes := []string{
 		"/simple",
-		"/project/:name/bui",
 		"/project/:name",
 		"/",
 		"/news/home",
@@ -593,6 +592,10 @@ func TestRouteContextHoldsFullPath(t *testing.T) {
 		"/simple-two/one",
 		"/simple-two/one-two",
 		"/project/:name/build/*params",
+		"/project/:name/bui",
+		"/user/:id/status",
+		"/user/:id",
+		"/user/:id/profile",
 	}
 
 	for _, route := range routes {

--- a/routes_test.go
+++ b/routes_test.go
@@ -585,6 +585,7 @@ func TestRouteContextHoldsFullPath(t *testing.T) {
 	// Test routes
 	routes := []string{
 		"/simple",
+		"/project/:name/bui",
 		"/project/:name",
 		"/",
 		"/news/home",
@@ -592,7 +593,6 @@ func TestRouteContextHoldsFullPath(t *testing.T) {
 		"/simple-two/one",
 		"/simple-two/one-two",
 		"/project/:name/build/*params",
-		"/project/:name/bui",
 	}
 
 	for _, route := range routes {

--- a/tree.go
+++ b/tree.go
@@ -260,6 +260,7 @@ walk:
 			panic("handlers are already registered for path '" + fullPath + "'")
 		}
 		n.handlers = handlers
+		n.fullPath = fullPath
 		return
 	}
 }


### PR DESCRIPTION
## Proposed changes

While using func `context.FullPath()`, I encountered an issue that it always returns previous registered parent path. It's fine when I change the registration order.

Example: 

```go
func (s *testSuite) registerTest() {
	s.router.GET("/user/:id/status", s.processWithStatus())
	s.router.GET("/user/:id", s.processWithID())
}

func (s *testSuite) processWithStatus() gin.HandlerFunc {
	return func(c *gin.Context) {
		logger.Infof("XXX - FullPath /user/:id/status ---> %s", c.FullPath())
		return
	}
}

func (s *testSuite) processWithID() gin.HandlerFunc {
	return func(c *gin.Context) {
		logger.Infof("XXX - FullPath /user/:id ---> %s", c.FullPath())
		return
	}
}
```

Result: 
```
XXX - FullPath /user/:id/status ---> /service/api/v1/user/:id/status
XXX - FullPath /user/:id ---> /service/api/v1/user/:id/status
```

But, when I register with different the order of router, such as: 

```go
func (s *testSuite) registerTest() {
	s.router.GET("/user/:id", s.processWithID())
	s.router.GET("/user/:id/status", s.processWithStatus())
}
```

It's every thing so ok. 

I have fix this bug and updated the test case. 
Hope you spend your time review and accept my pull request with this issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
