### PR TITLE
Add IContext

### DIFF
--- a/context.go
+++ b/context.go
@@ -5,6 +5,7 @@
 package gin
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -41,8 +42,113 @@ const BodyBytesKey = "_gin-gonic/gin/bodybyteskey"
 
 const abortIndex int8 = math.MaxInt8 / 2
 
-// Context is the most important part of gin. It allows us to pass variables between middleware,
+// IContext is the most important part of gin. It allows us to pass variables between middleware,
 // manage the flow, validate the JSON of a request and render a JSON response for example.
+type IContext interface {
+	reset()
+	Copy() *Context
+	HandlerName() string
+	HandlerNames() []string
+	Handler() HandlerFunc
+	FullPath() string
+	Next()
+	IsAborted() bool
+	Abort()
+	AbortWithStatus(code int)
+	AbortWithStatusJSON(code int, jsonObj interface{})
+	AbortWithError(code int, err error) *Error
+	Error(err error) *Error
+	Set(key string, value interface{})
+	Get(key string) (value interface{}, exists bool)
+	MustGet(key string) interface{}
+	GetString(key string) (s string)
+	GetBool(key string) (b bool)
+	GetInt(key string) (i int)
+	GetInt64(key string) (i64 int64)
+	GetFloat64(key string) (f64 float64)
+	GetTime(key string) (t time.Time)
+	GetDuration(key string) (d time.Duration)
+	GetStringSlice(key string) (ss []string)
+	GetStringMap(key string) (sm map[string]interface{})
+	GetStringMapString(key string) (sms map[string]string)
+	GetStringMapStringSlice(key string) (smss map[string][]string)
+	Param(key string) string
+	Query(key string) string
+	DefaultQuery(key, defaultValue string) string
+	GetQuery(key string) (string, bool)
+	QueryArray(key string) []string
+	initQueryCache()
+	GetQueryArray(key string) ([]string, bool)
+	QueryMap(key string) map[string]string
+	GetQueryMap(key string) (map[string]string, bool)
+	PostForm(key string) string
+	DefaultPostForm(key, defaultValue string) string
+	GetPostForm(key string) (string, bool)
+	PostFormArray(key string) []string
+	initFormCache()
+	GetPostFormArray(key string) ([]string, bool)
+	PostFormMap(key string) map[string]string
+	GetPostFormMap(key string) (map[string]string, bool)
+	get(m map[string][]string, key string) (map[string]string, bool)
+	FormFile(name string) (*multipart.FileHeader, error)
+	MultipartForm() (*multipart.Form, error)
+	SaveUploadedFile(file *multipart.FileHeader, dst string) error
+	Bind(obj interface{}) error
+	BindJSON(obj interface{}) error
+	BindXML(obj interface{}) error
+	BindQuery(obj interface{}) error
+	BindYAML(obj interface{}) error
+	BindHeader(obj interface{}) error
+	BindUri(obj interface{}) error
+	MustBindWith(obj interface{}, b binding.Binding) error
+	ShouldBind(obj interface{}) error
+	ShouldBindJSON(obj interface{}) error
+	ShouldBindXML(obj interface{}) error
+	ShouldBindQuery(obj interface{}) error
+	ShouldBindYAML(obj interface{}) error
+	ShouldBindHeader(obj interface{}) error
+	ShouldBindUri(obj interface{}) error
+	ShouldBindWith(obj interface{}, b binding.Binding) error
+	ShouldBindBodyWith(obj interface{}, bb binding.BindingBody) (err error)
+	ClientIP() string
+	ContentType() string
+	IsWebsocket() bool
+	requestHeader(key string) string
+	Status(code int)
+	Header(key, value string)
+	GetHeader(key string) string
+	GetRawData() ([]byte, error)
+	SetSameSite(samesite http.SameSite)
+	SetCookie(name, value string, maxAge int, path, domain string, secure, httpOnly bool)
+	Cookie(name string) (string, error)
+	Render(code int, r render.Render)
+	HTML(code int, name string, obj interface{})
+	IndentedJSON(code int, obj interface{})
+	SecureJSON(code int, obj interface{})
+	JSONP(code int, obj interface{})
+	JSON(code int, obj interface{})
+	AsciiJSON(code int, obj interface{})
+	PureJSON(code int, obj interface{})
+	XML(code int, obj interface{})
+	YAML(code int, obj interface{})
+	ProtoBuf(code int, obj interface{})
+	String(code int, format string, values ...interface{})
+	Redirect(code int, location string)
+	Data(code int, contentType string, data []byte)
+	DataFromReader(code int, contentLength int64, contentType string, reader io.Reader, extraHeaders map[string]string)
+	File(filepath string)
+	FileFromFS(filepath string, fs http.FileSystem)
+	FileAttachment(filepath, filename string)
+	SSEvent(name string, message interface{})
+	Stream(step func(w io.Writer) bool) bool
+	Negotiate(code int, config Negotiate)
+	NegotiateFormat(offered ...string) string
+	SetAccepted(formats ...string)
+	context.Context
+}
+
+
+// Context is an IContext implementation.
 type Context struct {
 	writermem responseWriter
 	Request   *http.Request


### PR DESCRIPTION
Hey there.
I've created this PR in order to add the **IContext** interface. The reason behind doing this is to expose the methods that Context has using an interface.

Use case:
```golang
type Input IContext

func NewInput(c *Context) Input {
	return c
}

func example(i Input) {
	i.Get() // Works out of the box.
}
```

I didn't add any tests because it doesn't need to change gin's internal behavior. I also didn't add any documentation for the same reason.