### PR TITLE
chore(performance): improve countParams

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -80,10 +80,19 @@ func longestCommonPrefix(a, b string) int {
 	return i
 }
 
+// bytesToStr converts byte slice to a string without memory allocation.
+// See https://groups.google.com/forum/#!msg/Golang-Nuts/ENgbUzYvCuU/90yGx7GUAgAJ .
+//
+// Note it may break if string and/or slice header will change
+// in the future go versions.
 func bytesToStr(b []byte) string {
 	return *(*string)(unsafe.Pointer(&b))
 }
 
+// strToBytes converts string to a byte slice without memory allocation.
+//
+// Note it may break if string and/or slice header will change
+// in the future go versions.
 func strToBytes(s string) (b []byte) {
 	/* #nosec G103 */
 	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))

--- a/tree.go
+++ b/tree.go
@@ -41,12 +41,6 @@ func (ps Params) ByName(name string) (va string) {
 	return
 }
 
-func strToBytes(s string) []byte {
-	x := (*[2]uintptr)(unsafe.Pointer(&s))
-	h := [3]uintptr{x[0], x[1], x[1]}
-	return *(*[]byte)(unsafe.Pointer(&h))
-}
-
 func bytesToStr(b []byte) string {
 	return *(*string)(unsafe.Pointer(&b))
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -93,20 +93,6 @@ func TestCountParams(t *testing.T) {
 	}
 }
 
-var s = strings.Repeat("/:param", 5)
-
-func BenchmarkCountParamsOld(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		countParamsOld(s)
-	}
-}
-
-func BenchmarkCountParams(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		countParamsNew(s)
-	}
-}
-
 func TestTreeAddAndGet(t *testing.T) {
 	tree := &node{}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -93,6 +93,20 @@ func TestCountParams(t *testing.T) {
 	}
 }
 
+var s = strings.Repeat("/:param", 5)
+
+func BenchmarkCountParamsOld(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		countParamsOld(s)
+	}
+}
+
+func BenchmarkCountParams(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		countParamsNew(s)
+	}
+}
+
 func TestTreeAddAndGet(t *testing.T) {
 	tree := &node{}
 


### PR DESCRIPTION
```go
package convert

import (
	"bytes"
	"strings"
	"testing"
)

var (
	strColon = []byte(":")
	strStar  = []byte("*")
)

func countParamsOld(path string) uint16 {
	var n uint
	for i := range []byte(path) {
		switch path[i] {
		case ':', '*':
			n++
		}
	}
	return uint16(n)
}

func countParamsNew(path string) uint16 {
	var n uint
	s := strToBytes(path)
	n += uint(bytes.Count(s, strColon))
	n += uint(bytes.Count(s, strStar))
	return uint16(n)
}

var foo = strings.Repeat("/:param", 256)

func BenchmarkCountParamsOld(b *testing.B) {
	for i := 0; i < b.N; i++ {
		countParamsOld(foo)
	}
}

func BenchmarkCountParamsNew(b *testing.B) {
	for i := 0; i < b.N; i++ {
		countParamsNew(foo)
	}
}
```

## Performance result

```sh

goos: linux
goarch: amd64
BenchmarkCountParamsOld-48    	 3000000	      1751 ns/op	       0 B/op	       0 allocs/op
BenchmarkCountParamsNew-48    	30000000	       148 ns/op	       0 B/op	       0 allocs/op
```