### PR TITLE
reuse http.request.body

### DIFF
--- a/context.go
+++ b/context.go
@@ -801,6 +801,7 @@ func (c *Context) GetHeader(key string) string {
 // GetRawData return stream data.
 func (c *Context) GetRawData() ([]byte, error) {
 	// return ioutil.ReadAll(c.Request.Body)
+	c.initFormCache()
 	return c.rawData, nil
 }
 


### PR DESCRIPTION
```
r := gin.New()
r.Use(func (ctx *gin.Context) {
    var (
        sign = ctx.Query("sign")
        start = time.Now()
    )
    if sign == "" {
        sign = ctx.PostForm("sign")
    }
    // check request sign
    // if !BOOL {ctx.Abort();return}

    ctx.Next()
}, func (ctx, *gin.Context) {
    requestData, _ := ctx.GetRawData()
    ctx.Request.Body = ioutil.NopCloser(bytes.NewBuffer(requestData))
    ctx.Next()

    var (
        latency = time.Now().Sub(start) / time.Millisecond
        logData, _ = json.Marshal(gin.H{
                "latency": latency,
                "request": requestData,
        })
    )
    log.Info(requestData )
})
r.POST("/doit", func (ctx *gin.Context) {
    var raw = ctx.GetRawData() // raw is empty
   //  ......
})
```

- when i used like this, handler get raw data is empty
- so change like these, no use  ioutil.NopCloser, no empty

> sorry for my english