### PR TITLE
Prevent panic in Context.GetQuery() when there is no Request

### DIFF
--- a/context.go
+++ b/context.go
@@ -416,7 +416,11 @@ func (c *Context) QueryArray(key string) []string {
 
 func (c *Context) initQueryCache() {
 	if c.queryCache == nil {
-		c.queryCache = c.Request.URL.Query()
+		if c.Request != nil {
+			c.queryCache = c.Request.URL.Query()
+		} else {
+			c.queryCache = url.Values{}
+		}
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -410,6 +410,21 @@ func TestContextQuery(t *testing.T) {
 	assert.Empty(t, c.PostForm("foo"))
 }
 
+func TestContextDefaultQueryOnEmptyRequest(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder()) // here c.Request == nil
+	assert.NotPanics(t, func() {
+		value, ok := c.GetQuery("NoKey")
+		assert.False(t, ok)
+		assert.Empty(t, value)
+	})
+	assert.NotPanics(t, func() {
+		assert.Equal(t, "nada", c.DefaultQuery("NoKey", "nada"))
+	})
+	assert.NotPanics(t, func() {
+		assert.Empty(t, c.Query("NoKey"))
+	})
+}
+
 func TestContextQueryAndPostForm(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	body := bytes.NewBufferString("foo=bar&page=11&both=&foo=second")


### PR DESCRIPTION
I have an endpoint that uses an optional query parameter via DefaultQuery(). 
In one unit test case I want to test the route with that parameter.
I write that test as
```go
	w := httptest.NewRecorder()
	c, _ := gin.CreateTestContext(w)
	routeHandler(c)
```
And this panics when routeHandler() calls c.DefaultQuery() because c.Request == nil.

- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as TravisCI.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

