### PR TITLE
Add support for FCGI via net/http/fcgi

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Gin is a web framework written in Go (Golang). It features a martini-like API wi
     - [Using BasicAuth() middleware](#using-basicauth-middleware)
     - [Goroutines inside a middleware](#goroutines-inside-a-middleware)
     - [Custom HTTP configuration](#custom-http-configuration)
+    - [Support FCGI](#support-fcgi)
     - [Support Let's Encrypt](#support-lets-encrypt)
     - [Run multiple service using Gin](#run-multiple-service-using-gin)
     - [Graceful shutdown or restart](#graceful-shutdown-or-restart)
@@ -1585,6 +1586,81 @@ func main() {
 	s.ListenAndServe()
 }
 ```
+
+### Support FCGI
+
+Here is how to start Gin as a FCGI server that will listen to `os.Stdin`:
+
+```go
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+
+	// Ping handler
+	r.GET("/ping", func(c *gin.Context) {
+		c.String(200, "pong")
+	})
+
+	r.RunFCGI()
+}
+```
+
+An alternative way of starting the FCGI server is:
+
+```go
+package main
+
+import (
+	"net/http/fcgi"
+
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+
+	// Ping handler
+	r.GET("/ping", func(c *gin.Context) {
+		c.String(200, "pong")
+	})
+
+	fcgi.Serve(nil, r)
+}
+```
+
+Please refer to [fcgi](https://golang.org/pkg/net/http/fcgi/) to see how to use a listener other that `os.Stdin`
+
+For an Apache server, the configuration would look like this:
+
+In the file `/etc/apache2/sites-available/your-project.conf`:
+
+```
+DocumentRoot /var/www/your-project
+<Directory /var/www/your-project>
+	Options FollowSymLinks ExecCGI
+	AllowOverride All
+	Require all granted
+</Directory>
+```
+
+Then in the file `/var/www/your-project/.htaccess`:
+
+```
+# Go serves all files, static and dynamic:
+
+SetHandler fcgid-script
+
+RewriteEngine on
+
+RewriteRule ^(.*)$ your-project [QSA,L]
+```
+
+If `your-project` is the name of your binary in the directory, as created by `go build` with no other parameters.
 
 ### Support Let's Encrypt
 

--- a/gin.go
+++ b/gin.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"net"
 	"net/http"
+	"net/http/fcgi"
 	"os"
 	"path"
 	"sync"
@@ -308,6 +309,16 @@ func (engine *Engine) Run(addr ...string) (err error) {
 	address := resolveAddress(addr)
 	debugPrint("Listening and serving HTTP on %s\n", address)
 	err = http.ListenAndServe(address, engine)
+	return
+}
+
+// RunFCGI attaches the router to a fcgi.child and starts listening to os.Stdin for requests
+// It is a shortcut for fcgi.Serve(nil, router)
+func (engine *Engine) RunFCGI() (err error) {
+	defer func() { debugPrintError(err) }()
+
+	debugPrint("Listening and serving HTTP on FCGI\n")
+	err = fcgi.Serve(nil, engine)
 	return
 }
 


### PR DESCRIPTION
Hi Gin,

As FCGI needs an extra web server, I don't see how this could be tested in CI. Anyway it's part of the standard package so I don't think that the FCGI part would need testing.

About web servers:
1/ I could go into more details with Apache but I'm not sure if the readme is the good place for that,
2/ adding the configuration for Nginx would be nice, one day. If someone is interested in doing it, or maybe I will.

Thanks for you time and efforts.