### PR TITLE
binding: avoid 2038 problem on 32-bit architectures

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -270,7 +270,7 @@ func setTimeField(val string, structField reflect.StructField, value reflect.Val
 
 	switch tf := strings.ToLower(timeFormat); tf {
 	case "unix", "unixnano":
-		tv, err := strconv.ParseInt(val, 10, 0)
+		tv, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Function setTimeField calls strconv.ParseInt with bit size 0 when
parsing Unix time, which means it is equivalent to specifying 32 on
32-bit architectures. This causes the function to suffer from the year
2038 problem. To fix it and keep the behavior the same on both 32-bit
and 64-bit architectures, explicitly specify bit size 64.

I am not sure if I should add a test for this pull request. It only affects 32-bit systems, but the CI only tests 64-bit systems.