### PR TITLE
delete const MINEXML2

### DIFF
--- a/context.go
+++ b/context.go
@@ -29,7 +29,6 @@ const (
 	MIMEJSON              = binding.MIMEJSON
 	MIMEHTML              = binding.MIMEHTML
 	MIMEXML               = binding.MIMEXML
-	MIMEXML2              = binding.MIMEXML2
 	MIMEPlain             = binding.MIMEPlain
 	MIMEPOSTForm          = binding.MIMEPOSTForm
 	MIMEMultipartPOSTForm = binding.MIMEMultipartPOSTForm


### PR DESCRIPTION
Hi,
This PR,
Deleted the constant "MINEXML2".
Because, according to [RFC7303](https://tools.ietf.org/html/rfc7303),
text/xml and application/xml are the same, 
and It was written that is recommended to use application/xml to avoid confusion with past usage.
Therefore, I think it is better to remove it from the constants that users can use.