### PR TITLE
docs:close the body of the response

### DIFF
--- a/README.md
+++ b/README.md
@@ -1255,6 +1255,7 @@ func main() {
 		}
 
 		reader := response.Body
+ 		defer reader.Close()
 		contentLength := response.ContentLength
 		contentType := response.Header.Get("Content-Type")
 


### PR DESCRIPTION
Closing the response body after serving data from reader 

