### PR TITLE
use IndexByte replace Split to improve performance

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -103,7 +103,10 @@ func parseAccept(acceptHeader string) []string {
 	parts := strings.Split(acceptHeader, ",")
 	out := make([]string, 0, len(parts))
 	for _, part := range parts {
-		if part = strings.TrimSpace(strings.Split(part, ";")[0]); part != "" {
+		if i := strings.IndexByte(part, ';'); i > 0 {
+			part = part[:i]
+		}
+		if part = strings.TrimSpace(part); part != "" {
 			out = append(out, part)
 		}
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -18,6 +18,12 @@ func init() {
 	SetMode(TestMode)
 }
 
+func BenchmarkParseAccept(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		parseAccept("text/html , application/xhtml+xml,application/xml;q=0.9,  */* ;q=0.8")
+	}
+}
+
 type testStruct struct {
 	T *testing.T
 }


### PR DESCRIPTION
benchmark cmp result:
```
benchmark                   old ns/op     new ns/op     delta
BenchmarkParseAccept-12     362           176           -51.38%

benchmark                   old allocs     new allocs     delta
BenchmarkParseAccept-12     6              2              -66.67%

benchmark                   old bytes     new bytes     delta
BenchmarkParseAccept-12     224           128           -42.86%
```
