### PR TITLE
Opt render

### DIFF
--- a/render/text.go
+++ b/render/text.go
@@ -7,6 +7,8 @@ package render
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/gin-gonic/gin/internal/bytesconv"
 )
 
 // String contains the given interface object slice and its format.
@@ -34,6 +36,6 @@ func WriteString(w http.ResponseWriter, format string, data []interface{}) (err 
 		_, err = fmt.Fprintf(w, format, data...)
 		return
 	}
-	_, err = w.Write([]byte(format))
+	_, err = w.Write(bytesconv.StringToBytes(format))
 	return
 }

--- a/utils.go
+++ b/utils.go
@@ -103,7 +103,11 @@ func parseAccept(acceptHeader string) []string {
 	parts := strings.Split(acceptHeader, ",")
 	out := make([]string, 0, len(parts))
 	for _, part := range parts {
-		if part = strings.TrimSpace(strings.Split(part, ";")[0]); part != "" {
+		i := strings.IndexByte(part, ';')
+		if i > 0 {
+			part = part[:i]
+		}
+		if part = strings.TrimSpace(part); part != "" {
 			out = append(out, part)
 		}
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -18,6 +18,12 @@ func init() {
 	SetMode(TestMode)
 }
 
+func BenchmarkParseAccept(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		parseAccept("text/html , application/xhtml+xml,application/xml;q=0.9,  */* ;q=0.8")
+	}
+}
+
 type testStruct struct {
 	T *testing.T
 }


### PR DESCRIPTION
benchcmp result:
```
benchmark                     old ns/op     new ns/op     delta
BenchmarkReader_Render-12     581           545           -6.20%

benchmark                     old allocs     new allocs     delta
BenchmarkReader_Render-12     9              8              -11.11%

benchmark                     old bytes     new bytes     delta
BenchmarkReader_Render-12     1008          992           -1.59%
```
the new is use `bytesconv.StringToBytes`
