### PR TITLE
reduce allocs and improve the render `WriteString`

### DIFF
--- a/render/text.go
+++ b/render/text.go
@@ -7,6 +7,8 @@ package render
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/gin-gonic/gin/internal/bytesconv"
 )
 
 // String contains the given interface object slice and its format.
@@ -34,6 +36,6 @@ func WriteString(w http.ResponseWriter, format string, data []interface{}) (err 
 		_, err = fmt.Fprintf(w, format, data...)
 		return
 	}
-	_, err = w.Write([]byte(format))
+	_, err = w.Write(bytesconv.StringToBytes(format))
 	return
 }


### PR DESCRIPTION
bencmp result

```
benchmark                     old ns/op     new ns/op     delta
BenchmarkReader_Render-12     581           545           -6.20%

benchmark                     old allocs     new allocs     delta
BenchmarkReader_Render-12     9              8              -11.11%

benchmark                     old bytes     new bytes     delta
BenchmarkReader_Render-12     1008          992           -1.59%
```