### PR TITLE
fix #2505: make Recovery respect gin.DisableConsoleColor

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -33,7 +33,7 @@ const (
 	reset   = "\033[0m"
 )
 
-var consoleColorMode = autoColor
+var ConsoleColorMode = autoColor
 
 // LoggerConfig defines the config for Logger middleware.
 type LoggerConfig struct {
@@ -125,7 +125,7 @@ func (p *LogFormatterParams) ResetColor() string {
 
 // IsOutputColor indicates whether can colors be outputted to the log.
 func (p *LogFormatterParams) IsOutputColor() bool {
-	return consoleColorMode == forceColor || (consoleColorMode == autoColor && p.isTerm)
+	return ConsoleColorMode == forceColor || (ConsoleColorMode == autoColor && p.isTerm)
 }
 
 // defaultLogFormatter is the default log format function Logger middleware uses.
@@ -154,12 +154,12 @@ var defaultLogFormatter = func(param LogFormatterParams) string {
 
 // DisableConsoleColor disables color output in the console.
 func DisableConsoleColor() {
-	consoleColorMode = disableColor
+	ConsoleColorMode = disableColor
 }
 
 // ForceConsoleColor force color output in the console.
 func ForceConsoleColor() {
-	consoleColorMode = forceColor
+	ConsoleColorMode = forceColor
 }
 
 // ErrorLogger returns a handlerfunc for any error type.

--- a/logger_test.go
+++ b/logger_test.go
@@ -326,7 +326,7 @@ func TestIsOutputColor(t *testing.T) {
 		isTerm: true,
 	}
 
-	consoleColorMode = autoColor
+	ConsoleColorMode = autoColor
 	assert.Equal(t, true, p.IsOutputColor())
 
 	ForceConsoleColor()
@@ -340,7 +340,7 @@ func TestIsOutputColor(t *testing.T) {
 		isTerm: false,
 	}
 
-	consoleColorMode = autoColor
+	ConsoleColorMode = autoColor
 	assert.Equal(t, false, p.IsOutputColor())
 
 	ForceConsoleColor()
@@ -350,7 +350,7 @@ func TestIsOutputColor(t *testing.T) {
 	assert.Equal(t, false, p.IsOutputColor())
 
 	// reset console color mode.
-	consoleColorMode = autoColor
+	ConsoleColorMode = autoColor
 }
 
 func TestErrorLogger(t *testing.T) {
@@ -415,20 +415,20 @@ func TestLoggerWithConfigSkippingPaths(t *testing.T) {
 
 func TestDisableConsoleColor(t *testing.T) {
 	New()
-	assert.Equal(t, autoColor, consoleColorMode)
+	assert.Equal(t, autoColor, ConsoleColorMode)
 	DisableConsoleColor()
-	assert.Equal(t, disableColor, consoleColorMode)
+	assert.Equal(t, disableColor, ConsoleColorMode)
 
 	// reset console color mode.
-	consoleColorMode = autoColor
+	ConsoleColorMode = autoColor
 }
 
 func TestForceConsoleColor(t *testing.T) {
 	New()
-	assert.Equal(t, autoColor, consoleColorMode)
+	assert.Equal(t, autoColor, ConsoleColorMode)
 	ForceConsoleColor()
-	assert.Equal(t, forceColor, consoleColorMode)
+	assert.Equal(t, forceColor, ConsoleColorMode)
 
 	// reset console color mode.
-	consoleColorMode = autoColor
+	ConsoleColorMode = autoColor
 }

--- a/recovery.go
+++ b/recovery.go
@@ -50,8 +50,15 @@ func RecoveryWithWriter(out io.Writer, recovery ...RecoveryFunc) HandlerFunc {
 // CustomRecoveryWithWriter returns a middleware for a given writer that recovers from any panics and calls the provided handle func to handle it.
 func CustomRecoveryWithWriter(out io.Writer, handle RecoveryFunc) HandlerFunc {
 	var logger *log.Logger
+
+	// If gin.DisableConsoleColor() is invoked, respect it.
+	prefix := "\n\n"
+	if ConsoleColorMode != 1 {
+		prefix = "\n\n\x1b[31m"
+	}
+
 	if out != nil {
-		logger = log.New(out, "\n\n\x1b[31m", log.LstdFlags)
+		logger = log.New(out, prefix, log.LstdFlags)
 	}
 	return func(c *Context) {
 		defer func() {


### PR DESCRIPTION
This addresses #2505. Since Recovery doesn't provide the same config as Layout, this is a naive approach with unexporting ConsoleColorMode variable.

If that's not appropriate I can work over the weekend on `RecoveryWithLogger` which would make Recovery use Logger internally. That would mean however a hard dependency between Recovery and Logger parts.

If there is any other approach you'd like me to pursue I'm open to feedback. :)
