### PR TITLE
Return HandlerChain from Routes()

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -42,10 +42,11 @@ func (c HandlersChain) Last() HandlerFunc {
 
 // RouteInfo represents a request route's specification which contains method and path and its handler.
 type RouteInfo struct {
-	Method      string
-	Path        string
-	Handler     string
-	HandlerFunc HandlerFunc
+	Method        string
+	Path          string
+	Handler       string
+	HandlerFunc   HandlerFunc
+	HandlersChain []HandlerFunc
 }
 
 // RoutesInfo defines a RouteInfo array.
@@ -287,10 +288,11 @@ func iterate(path, method string, routes RoutesInfo, root *node) RoutesInfo {
 	if len(root.handlers) > 0 {
 		handlerFunc := root.handlers.Last()
 		routes = append(routes, RouteInfo{
-			Method:      method,
-			Path:        path,
-			Handler:     nameOfFunction(handlerFunc),
-			HandlerFunc: handlerFunc,
+			Method:        method,
+			Path:          path,
+			Handler:       nameOfFunction(handlerFunc),
+			HandlerFunc:   handlerFunc,
+			HandlersChain: root.handlers,
 		})
 	}
 	for _, child := range root.children {

--- a/gin_test.go
+++ b/gin_test.go
@@ -444,7 +444,11 @@ func TestListOfRoutes(t *testing.T) {
 	{
 		group.GET("/", handlerTest2)
 		group.GET("/:id", handlerTest1)
-		group.POST("/:id", handlerTest2)
+	}
+	postGroup := group.Group("")
+	postGroup.Use(handlerTest1)
+	{
+		postGroup.POST("/:id", handlerTest2)
 	}
 	router.Static("/static", ".")
 
@@ -452,29 +456,34 @@ func TestListOfRoutes(t *testing.T) {
 
 	assert.Len(t, list, 7)
 	assertRoutePresent(t, list, RouteInfo{
-		Method:  "GET",
-		Path:    "/favicon.ico",
-		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest1$",
+		Method:        "GET",
+		Path:          "/favicon.ico",
+		Handler:       "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest1$",
+		HandlersChain: []HandlerFunc{handlerTest1},
 	})
 	assertRoutePresent(t, list, RouteInfo{
-		Method:  "GET",
-		Path:    "/",
-		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest1$",
+		Method:        "GET",
+		Path:          "/",
+		Handler:       "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest1$",
+		HandlersChain: []HandlerFunc{handlerTest1},
 	})
 	assertRoutePresent(t, list, RouteInfo{
-		Method:  "GET",
-		Path:    "/users/",
-		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest2$",
+		Method:        "GET",
+		Path:          "/users/",
+		Handler:       "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest2$",
+		HandlersChain: []HandlerFunc{handlerTest2},
 	})
 	assertRoutePresent(t, list, RouteInfo{
-		Method:  "GET",
-		Path:    "/users/:id",
-		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest1$",
+		Method:        "GET",
+		Path:          "/users/:id",
+		Handler:       "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest1$",
+		HandlersChain: []HandlerFunc{handlerTest1},
 	})
 	assertRoutePresent(t, list, RouteInfo{
-		Method:  "POST",
-		Path:    "/users/:id",
-		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest2$",
+		Method:        "POST",
+		Path:          "/users/:id",
+		Handler:       "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest2$",
+		HandlersChain: []HandlerFunc{handlerTest1, handlerTest2},
 	})
 }
 
@@ -535,6 +544,7 @@ func TestEngineHandleContextManyReEntries(t *testing.T) {
 func assertRoutePresent(t *testing.T, gotRoutes RoutesInfo, wantRoute RouteInfo) {
 	for _, gotRoute := range gotRoutes {
 		if gotRoute.Path == wantRoute.Path && gotRoute.Method == wantRoute.Method {
+			assert.ObjectsAreEqualValues(gotRoute.HandlersChain, wantRoute.HandlersChain)
 			assert.Regexp(t, wantRoute.Handler, gotRoute.Handler)
 			return
 		}


### PR DESCRIPTION
This PR adds  `HandlersChain []HandlerFunc` to the `RouteInfo` object returned from `Engine.Routes()`. This will return the handlers, in order, associated with each route.

Unlike `context.HandlerNames()`, this can be called for all routes, and can be used at service startup, during unit tests, etc. Our service at work applies different middleware to different routes dynamically, and my intention is to use this to catch unintended changes to the chain.

Inspired by https://github.com/gin-gonic/gin/pull/1131 and https://github.com/gin-gonic/gin/pull/1729

Sample usage:
```
type RouteDetail struct {
	Method   string   `json:"method"`
	Path     string   `json:"path"`
	Handlers []string `json:"handlers"`
}
routeDetails := make([]RouteDetail, 0)
for _, route := range engine.Routes() {
	handlers := []string{}
	for _, handler := range route.HandlersChain {
		handlers = append(handlers, runtime.FuncForPC(reflect.ValueOf(handler).Pointer()).Name())
	}
	routeDetails = append(routeDetails, RouteDetail{
		Method:   route.Method,
		Path:     route.Path,
		Handlers: handlers,
	})
}
file, _ := json.MarshalIndent(routeDetails, "", " ")
_ = ioutil.WriteFile("routes.json", file, 0644)
```
