### PR TITLE
Update json.go

### DIFF
--- a/render/json.go
+++ b/render/json.go
@@ -52,6 +52,9 @@ var jsonAsciiContentType = []string{"application/json"}
 
 // Render (JSON) writes data with custom ContentType.
 func (r JSON) Render(w http.ResponseWriter) (err error) {
+	if _, isJson := r.Data.([]byte); isJson {
+		return
+	}
 	if err = WriteJSON(w, r.Data); err != nil {
 		panic(err)
 	}

--- a/render/json.go
+++ b/render/json.go
@@ -66,8 +66,8 @@ func (r JSON) WriteContentType(w http.ResponseWriter) {
 // WriteJSON marshals the given interface object and writes it with custom ContentType.
 func WriteJSON(w http.ResponseWriter, obj interface{}) error {
 	writeContentType(w, jsonContentType)
-	if _, isJson := r.Data.([]byte); isJson {
-		_, err = w.Write(jsonBytes)
+	if _, isJson := obj.([]byte); isJson {
+		_, err := w.Write(obj.([]byte))
 	        return err
 	}
 	jsonBytes, err := json.Marshal(obj)

--- a/render/json.go
+++ b/render/json.go
@@ -52,9 +52,6 @@ var jsonAsciiContentType = []string{"application/json"}
 
 // Render (JSON) writes data with custom ContentType.
 func (r JSON) Render(w http.ResponseWriter) (err error) {
-	if _, isJson := r.Data.([]byte); isJson {
-		return
-	}
 	if err = WriteJSON(w, r.Data); err != nil {
 		panic(err)
 	}
@@ -69,6 +66,10 @@ func (r JSON) WriteContentType(w http.ResponseWriter) {
 // WriteJSON marshals the given interface object and writes it with custom ContentType.
 func WriteJSON(w http.ResponseWriter, obj interface{}) error {
 	writeContentType(w, jsonContentType)
+	if _, isJson := r.Data.([]byte); isJson {
+		_, err = w.Write(jsonBytes)
+	        return err
+	}
 	jsonBytes, err := json.Marshal(obj)
 	if err != nil {
 		return err


### PR DESCRIPTION
Add a judgment of JSON format. Under normal circumstances, we may not need this function. However, in the process of using middleware or microservices, the data we may get is already in JSON format. At this time, we need to convert JSON to stuct, and then convert it in line by gin. In this process, we not only need to create a new struct, but also The useless JSON—— struct, struct —— JSON, therefore, I added the JSON type judgment
