### PR TITLE
Context resetting should be placed before context recycling

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -371,10 +371,11 @@ func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	c := engine.pool.Get().(*Context)
 	c.writermem.reset(w)
 	c.Request = req
-	c.reset()
 
 	engine.handleHTTPRequest(c)
 
+	// Given expectations, make it clear that the context will be reset after the request ends.
+	c.reset()
 	engine.pool.Put(c)
 }
 

--- a/gin.go
+++ b/gin.go
@@ -165,7 +165,10 @@ func Default() *Engine {
 
 func (engine *Engine) allocateContext() *Context {
 	v := make(Params, 0, engine.maxParams)
-	return &Context{engine: engine, params: &v}
+	c := &Context{engine: engine, params: &v}
+	// init context struct
+	c.reset()
+	return c
 }
 
 // Delims sets template left and right delims and returns a Engine instance.


### PR DESCRIPTION
https://github.com/gin-gonic/gin/blob/master/gin.go#L369:L379
```
// ServeHTTP conforms to the http.Handler interface.
func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request) {
	c := engine.pool.Get().(*Context)
	c.writermem.reset(w)
	c.Request = req
	c.reset()

	engine.handleHTTPRequest(c)

	engine.pool.Put(c)
}
```

Context resets should be placed before context recycling.

Gin has a `Copy()` function to copy the context, which can be used to safely use the context outside the request, but this function is easy to be forgotten when the context is not reset in time. Moreover, the reset time of the context is not clear, which will bring unpredictable problems to the system. another, I think that a context gets from `sync.pool`, which means that this context serves the current request. Should not deal with the content left by the previous request.