### PR TITLE
make it clear that the context will be reset after the request ends, …

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -165,7 +165,10 @@ func Default() *Engine {
 
 func (engine *Engine) allocateContext() *Context {
 	v := make(Params, 0, engine.maxParams)
-	return &Context{engine: engine, params: &v}
+	c := &Context{engine: engine, params: &v}
+	// init ctx struct
+	c.reset()
+	return c
 }
 
 // Delims sets template left and right delims and returns a Engine instance.
@@ -371,10 +374,11 @@ func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	c := engine.pool.Get().(*Context)
 	c.writermem.reset(w)
 	c.Request = req
-	c.reset()
 
 	engine.handleHTTPRequest(c)
 
+	// clear request data
+	c.reset()
 	engine.pool.Put(c)
 }
 


### PR DESCRIPTION
The `copy()` function cannot forcefully restrict the use of `*gin.context` within the coroutine, so it is easy to cause variable competition. Unconscious things need to be restricted, and the kv carried in a clear context will be recycled after the request ends.