### PR TITLE
"gin mode unknown" error: show available mode

### DIFF
--- a/mode.go
+++ b/mode.go
@@ -63,7 +63,7 @@ func SetMode(value string) {
 	case TestMode:
 		ginMode = testCode
 	default:
-		panic("gin mode unknown: " + value)
+		panic("gin mode unknown: " + value + " (available mode: debug release test)")
 	}
 
 	modeName = value


### PR DESCRIPTION
Before:

```
panic: gin mode unknown: development

goroutine 1 [running]:
github.com/gin-gonic/gin.SetMode(...)
	/home/flatearther/go/packages/pkg/mod/github.com/gin-gonic/gin@v1.6.3/mode.go:61
github.com/gin-gonic/gin.init.0()
	/home/flatearther/go/packages/pkg/mod/github.com/gin-gonic/gin@v1.6.3/mode.go:48 +0x16a
exit status 2
```

After:

```
panic: gin mode unknown: development (available mode: debug release test)

goroutine 1 [running]:
github.com/gin-gonic/gin.SetMode(...)
	/home/flatearther/go/packages/pkg/mod/github.com/gin-gonic/gin@v1.6.3/mode.go:61
github.com/gin-gonic/gin.init.0()
	/home/flatearther/go/packages/pkg/mod/github.com/gin-gonic/gin@v1.6.3/mode.go:48 +0x16a
exit status 2
```