### PR TITLE
Add fuzzer

### DIFF
--- a/render/fuzz.go
+++ b/render/fuzz.go
@@ -1,0 +1,21 @@
+// Copyright 2020 Manu Martinez-Almeida.  All rights reserved.
+// Use of this source code is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+// +build gofuzz
+
+package render
+
+import (
+	"net/http/httptest"
+)
+
+func FuzzRender(data []byte) int {
+	w := httptest.NewRecorder()
+	(YAML{string(data)}).WriteContentType(w)
+	err := (YAML{string(data)}).Render(w)
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR introduces fuzzing for Gin. The fuzzer in this PR is implemented by way of the [go-fuzz](https://github.com/dvyukov/go-fuzz) fuzzing engine.

Fuzzing is a way of testing applications whereby pseudo-random data is passed to a target function with the goal of finding bugs and vulnerabilities. The fuzzer in this PR is implemented with the go-fuzz fuzzing engine.

I have worked on setting continuous fuzzing up for the fuzzer which will allow it to run for longer and find harder-to-find bugs as well. I will shortly set up the integration for Gin on OSS-fuzz, and upon merging the fuzzer here, it will be able to run continuously through OSS-fuzz. OSS-fuzz is a free service for open source projects, and if/when bugs are found, maintainers get notified with an email containing a link to a detailed bug report with stacktrace and reproducer test-case. While it is a free service it is offered with an implied expectation that bugs are fixed, so that the resources spent on fuzzing Gin go towards resolving bugs in the codebase.

All that is needed to setup continuous fuzzing would be at least one maintainer email address.

For some examples of previous bugs found from fuzzing Golang projects I recommend checking out the trophy list on the go-fuzz repository: https://github.com/dvyukov/go-fuzz#trophies

