### PR TITLE
treat http.ErrAbortHandler as broken pipe too

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -66,6 +66,9 @@ func CustomRecoveryWithWriter(out io.Writer, handle RecoveryFunc) HandlerFunc {
 						}
 					}
 				}
+				if err == http.ErrAbortHandler {
+					brokenPipe = true
+				}
 				if logger != nil {
 					stack := stack(3)
 					httpRequest, _ := httputil.DumpRequest(c.Request, false)


### PR DESCRIPTION
cc #1714

similar to https://github.com/gorilla/handlers/pull/159/files