### PR TITLE
Revert "Adding ppc64le architecture support on travis-ci (#2538)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,34 +18,6 @@ matrix:
     env:
       - TESTTAGS=nomsgpack
   - go: master
-    # Adding ppc64le jobs
-  - go: 1.11.x
-    arch: ppc64le
-    env: GO111MODULE=on
-  - go: 1.12.x
-    arch: ppc64le
-    env: GO111MODULE=on
-  - go: 1.13.x
-    arch: ppc64le
-  - go: 1.13.x
-    arch: ppc64le
-    env:
-      - TESTTAGS=nomsgpack
-  - go: 1.14.x
-    arch: ppc64le
-  - go: 1.14.x
-    arch: ppc64le
-    env:
-      - TESTTAGS=nomsgpack
-  - go: 1.15.x
-    arch: ppc64le
-  - go: 1.15.x
-    arch: ppc64le
-    env:
-      - TESTTAGS=nomsgpack
-  - go: master
-    arch: ppc64le
-
 
 git:
   depth: 10


### PR DESCRIPTION
This reverts commit fca3f95d7cdfdef203c78f220b84118f44590512.

details: https://github.com/gin-gonic/gin/pull/2538#issuecomment-753717649

cc @kishorkunal-raj