### PR TITLE
basic auth: fix timing oracle

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -5,6 +5,7 @@
 package gin
 
 import (
+	"crypto/subtle"
 	"encoding/base64"
 	"net/http"
 	"strconv"
@@ -30,7 +31,7 @@ func (a authPairs) searchCredential(authValue string) (string, bool) {
 		return "", false
 	}
 	for _, pair := range a {
-		if pair.value == authValue {
+		if subtle.ConstantTimeCompare([]byte(pair.value), []byte(authValue)) == 1 {
 			return pair.user, true
 		}
 	}


### PR DESCRIPTION
Fix #2226 

I've read discussion in #2226, but there are few reasons to consider on behalf of merge of this PR:

* It's pretty easy to fix it
* Even if Basic Auth should not be considered as a secure auth method, it will be often misused in the wild. It'll be hard to make people using basic auth middleware always make informed decision.
* There are cases like server to server integration via HTTPS where basic auth is just good enough.