### PR TITLE
Avoid overwriting the written status code

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -61,6 +61,7 @@ func (w *responseWriter) WriteHeader(code int) {
 	if code > 0 && w.status != code {
 		if w.Written() {
 			debugPrint("[WARNING] Headers were already written. Wanted to override status code %d with %d", w.status, code)
+			return
 		}
 		w.status = code
 	}

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -73,6 +73,10 @@ func TestResponseWriterWriteHeadersNow(t *testing.T) {
 	writer.size = 10
 	w.WriteHeaderNow()
 	assert.Equal(t, 10, w.Size())
+
+	w.WriteHeader(http.StatusOK)
+	assert.Equal(t, http.StatusMultipleChoices, w.Status())
+	assert.Equal(t, http.StatusMultipleChoices, testWriter.Code)
 }
 
 func TestResponseWriterWrite(t *testing.T) {


### PR DESCRIPTION
When the response has been written, the status code saved in `responseWriter`
should no longer be changed by subsequent calls to `WriteHeader()`.

This fixes for example the logging possibly showing the wrong status code, or
any other middleware function checking the status code.

