### PR TITLE
RoutesInfo: HandlersChain support for routes behavior better testing

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -42,10 +42,11 @@ func (c HandlersChain) Last() HandlerFunc {
 
 // RouteInfo represents a request route's specification which contains method and path and its handler.
 type RouteInfo struct {
-	Method      string
-	Path        string
-	Handler     string
-	HandlerFunc HandlerFunc
+	Method        string
+	Path          string
+	Handler       string
+	HandlerFunc   HandlerFunc
+	HandlersChain HandlersChain
 }
 
 // RoutesInfo defines a RouteInfo array.
@@ -287,10 +288,11 @@ func iterate(path, method string, routes RoutesInfo, root *node) RoutesInfo {
 	if len(root.handlers) > 0 {
 		handlerFunc := root.handlers.Last()
 		routes = append(routes, RouteInfo{
-			Method:      method,
-			Path:        path,
-			Handler:     nameOfFunction(handlerFunc),
-			HandlerFunc: handlerFunc,
+			Method:        method,
+			Path:          path,
+			Handler:       nameOfFunction(handlerFunc),
+			HandlerFunc:   handlerFunc,
+			HandlersChain: root.handlers,
 		})
 	}
 	for _, child := range root.children {


### PR DESCRIPTION
For testing routes middlewares (e.g. authorization, tracking, etc.) and their complex behavior, I need to have an end list of handlers for each route. 