### PR TITLE
adding QueryMapArr

### DIFF
--- a/context.go
+++ b/context.go
@@ -463,6 +463,20 @@ func (c *Context) GetQueryMap(key string) (map[string]string, bool) {
 	return c.get(c.queryCache, key)
 }
 
+// QueryMapArray returns a map for a given query key.
+// Same as QueryMap, but the value in the map is an array
+func (c *Context) QueryMapArray(key string) map[string][]string {
+	dicts, _ := c.GetQueryMapArray(key)
+	return dicts
+}
+
+// GetQueryMapArray returns a map for a given query key, plus a boolean value
+// whether at least one value exists for the given key.
+func (c *Context) GetQueryMapArray(key string) (map[string][]string, bool) {
+	c.initQueryCache()
+	return c.getarr(c.queryCache, key)
+}
+
 // PostForm returns the specified key from a POST urlencoded form or multipart form
 // when it exists, otherwise it returns an empty string `("")`.
 func (c *Context) PostForm(key string) string {
@@ -546,6 +560,22 @@ func (c *Context) get(m map[string][]string, key string) (map[string]string, boo
 			if j := strings.IndexByte(k[i+1:], ']'); j >= 1 {
 				exist = true
 				dicts[k[i+1:][:j]] = v[0]
+			}
+		}
+	}
+	return dicts, exist
+}
+
+// getarr is an internal method. same as get, but the value in the map is an array
+// since get only returns the first value
+func (c *Context) getarr(m map[string][]string, key string) (map[string][]string, bool) {
+	dicts := make(map[string][]string)
+	exist := false
+	for k, v := range m {
+		if i := strings.IndexByte(k, '['); i >= 1 && k[0:i] == key {
+			if j := strings.IndexByte(k[i+1:], ']'); j >= 1 {
+				exist = true
+				dicts[k[i+1:][:j]] = v
 			}
 		}
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -441,7 +441,7 @@ func TestContextQueryAndPostForm(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	body := bytes.NewBufferString("foo=bar&page=11&both=&foo=second")
 	c.Request, _ = http.NewRequest("POST",
-		"/?both=GET&id=main&id=omit&array[]=first&array[]=second&ids[a]=hi&ids[b]=3.14", body)
+		"/?both=GET&id=main&id=omit&array[]=first&array[]=second&ids[a]=hi&ids[b]=3.14&filter[t]=hi&filter[t]=hello", body)
 	c.Request.Header.Add("Content-Type", MIMEPOSTForm)
 
 	assert.Equal(t, "bar", c.DefaultPostForm("foo", "none"))
@@ -530,6 +530,10 @@ func TestContextQueryAndPostForm(t *testing.T) {
 	dicts = c.QueryMap("ids")
 	assert.Equal(t, "hi", dicts["a"])
 	assert.Equal(t, "3.14", dicts["b"])
+
+	maparr := c.QueryMapArray("filter")
+	assert.Equal(t, "hi", maparr["t"][0])
+	assert.Equal(t, "hello", maparr["t"][1])
 
 	dicts = c.QueryMap("nokey")
 	assert.Equal(t, 0, len(dicts))


### PR DESCRIPTION
Adding a new function to context called `QueryMapArray`
at the moment QueryMap only returns the first value from the query params 

example:
let's say this is my query:
`filter[name]=Peter&filter[name]=David`

If do this:
```go
filter := context.QueryMap("filter")
fmt.Println(filter["name"])
```
that would print only the first value (so `Peter`)

QueryMapArray is resolving this, by returning the whole array via `func getarr` instead of just the first value like in `func get`: https://github.com/gin-gonic/gin/blob/1bdf86b722026fd650fddfef7fe9bd8342b51b7a/context.go#L548


Note: maybe there is an existing way to do this, but this one seems a bit more straightforward to me

thanks


