### PR TITLE
Add mixed param and non-param paths (port of httprouter#329)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -190,6 +190,8 @@ People and companies, who have contributed, in alphabetical order.
 **@rogierlommers (Rogier Lommers)**
 - Add updated static serve example
 
+**@rw-access (Ross Wolf)**
+- Added support to mix exact and param routes
 
 **@se77en (Damon Zhao)**
 - Improve color logging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Gin ChangeLog
 
+## Gin v1.7.0
+
+### ENHANCEMENTS
+
+* Support params and exact routes without creating conflicts [#2663](https://github.com/gin-gonic/gin/pull/2663)
+
 ## Gin v1.6.3
 
 ### ENHANCEMENTS

--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ func main() {
 		c.FullPath() == "/user/:name/*action" // true
 	})
 
+	// This handler will add a new router for /user/groups.
+	// Exact routes are resolved before param routes, regardless of the order they were defined.
+	// Routes starting with /user/groups are never interpreted as /user/:name/... routes
+	router.GET("/user/groups", func(c *gin.Context) {
+		c.String(http.StatusOK, "The available groups are [...]", name)
+	})
+
 	router.Run(":8080")
 }
 ```

--- a/tree_test.go
+++ b/tree_test.go
@@ -137,6 +137,8 @@ func TestTreeWildcard(t *testing.T) {
 		"/",
 		"/cmd/:tool/:sub",
 		"/cmd/:tool/",
+		"/cmd/whoami",
+		"/cmd/whoami/root/",
 		"/src/*filepath",
 		"/search/",
 		"/search/:query",
@@ -155,8 +157,12 @@ func TestTreeWildcard(t *testing.T) {
 
 	checkRequests(t, tree, testRequests{
 		{"/", false, "/", nil},
-		{"/cmd/test/", false, "/cmd/:tool/", Params{Param{Key: "tool", Value: "test"}}},
-		{"/cmd/test", true, "", Params{Param{Key: "tool", Value: "test"}}},
+		{"/cmd/test", true, "/cmd/:tool/", Params{Param{"tool", "test"}}},
+		{"/cmd/test/", false, "/cmd/:tool/", Params{Param{"tool", "test"}}},
+		{"/cmd/whoami", false, "/cmd/whoami", nil},
+		{"/cmd/whoami/", true, "/cmd/whoami", nil},
+		{"/cmd/whoami/root/", false, "/cmd/whoami/root/", nil},
+		{"/cmd/whoami/root", true, "/cmd/whoami/root/", nil},
 		{"/cmd/test/3", false, "/cmd/:tool/:sub", Params{Param{Key: "tool", Value: "test"}, Param{Key: "sub", Value: "3"}}},
 		{"/src/", false, "/src/*filepath", Params{Param{Key: "filepath", Value: "/"}}},
 		{"/src/some/file.png", false, "/src/*filepath", Params{Param{Key: "filepath", Value: "/some/file.png"}}},
@@ -245,20 +251,38 @@ func testRoutes(t *testing.T, routes []testRoute) {
 func TestTreeWildcardConflict(t *testing.T) {
 	routes := []testRoute{
 		{"/cmd/:tool/:sub", false},
-		{"/cmd/vet", true},
+		{"/cmd/vet", false},
+		{"/foo/bar", false},
+		{"/foo/:name", false},
+		{"/foo/:names", true},
+		{"/cmd/*path", true},
+		{"/cmd/:badvar", true},
+		{"/cmd/:tool/names", false},
+		{"/cmd/:tool/:badsub/details", true},
 		{"/src/*filepath", false},
+		{"/src/:file", true},
+		{"/src/static.json", true},
 		{"/src/*filepathx", true},
 		{"/src/", true},
+		{"/src/foo/bar", true},
 		{"/src1/", false},
 		{"/src1/*filepath", true},
 		{"/src2*filepath", true},
+		{"/src2/*filepath", false},
 		{"/search/:query", false},
-		{"/search/invalid", true},
+		{"/search/valid", false},
 		{"/user_:name", false},
-		{"/user_x", true},
+		{"/user_x", false},
 		{"/user_:name", false},
 		{"/id:id", false},
-		{"/id/:id", true},
+		{"/id/:id", false},
+	}
+	testRoutes(t, routes)
+}
+
+func TestCatchAllAfterSlash(t *testing.T) {
+	routes := []testRoute{
+		{"/non-leading-*catchall", true},
 	}
 	testRoutes(t, routes)
 }
@@ -266,14 +290,17 @@ func TestTreeWildcardConflict(t *testing.T) {
 func TestTreeChildConflict(t *testing.T) {
 	routes := []testRoute{
 		{"/cmd/vet", false},
-		{"/cmd/:tool/:sub", true},
+		{"/cmd/:tool", false},
+		{"/cmd/:tool/:sub", false},
+		{"/cmd/:tool/misc", false},
+		{"/cmd/:tool/:othersub", true},
 		{"/src/AUTHORS", false},
 		{"/src/*filepath", true},
 		{"/user_x", false},
-		{"/user_:name", true},
+		{"/user_:name", false},
 		{"/id/:id", false},
-		{"/id:id", true},
-		{"/:id", true},
+		{"/id:id", false},
+		{"/:id", false},
 		{"/*filepath", true},
 	}
 	testRoutes(t, routes)
@@ -688,8 +715,7 @@ func TestTreeWildcardConflictEx(t *testing.T) {
 		{"/who/are/foo", "/foo", `/who/are/\*you`, `/\*you`},
 		{"/who/are/foo/", "/foo/", `/who/are/\*you`, `/\*you`},
 		{"/who/are/foo/bar", "/foo/bar", `/who/are/\*you`, `/\*you`},
-		{"/conxxx", "xxx", `/con:tact`, `:tact`},
-		{"/conooo/xxx", "ooo", `/con:tact`, `:tact`},
+		{"/con:nection", ":nection", `/con:tact`, `:tact`},
 	}
 
 	for _, conflict := range conflicts {


### PR DESCRIPTION
This ports a PR I made to httprouter, https://github.com/julienschmidt/httprouter/pull/329.

It adds the ability to have route schemas like `/users/:name` and `/users/groups` without running into conflicts.

From https://github.com/julienschmidt/httprouter/pull/329:
> I updated the search tree, so that non-wildcard paths are resolved _before_ wildcard paths, but both can be valid children. For instance, now you can finally have `/users/roles/:role` and `/users/:id` at the same time without issue.
> 
> First, non-wildcard children are checked for matches. If those fail to match, then it tries the wildcard children routes. For existing compatible route configurations, there should be no (or negligible) performance impact. Many people prefer compact routes and expect a sort of precedence with `httprouter`, that mirrors this behavior.
> 
> This only works for param wildcards of the form `:name` and doesn't change the existing `*`
> 
> One thing to note, because of the prefix tree structure, if the path `/books/fantasy/2007` would matched a  `/books/fantasy/...` route because it takes priority over a `/books/: category/:year` template route, because exact prefixes take priority over wildcard prefixes. I think this is okay and is still a net positive. This can be merely a documentation issue.
> 
> 
> 
> Overall, I think the changes capture a pretty intuitive behavior, has little to no performance impact and is something many people expect from a router. Personally, I use gin and fizz and would love to have this behavior. So I played around with it and want to share and gather your thoughts @julienschmidt.
> 
> 
> **Related issues**
> Looks like there's a lot of issues in this repo, but mostly in Gin. I did my best to capture them, but I'm sure that I'm missing some.
> 
> 
> Partially resolves https://github.com/julienschmidt/httprouter/issues/73 (doesn't work for catch-all wildcards)
> Resolves https://github.com/julienschmidt/httprouter/issues/91
> Resolves https://github.com/julienschmidt/httprouter/issues/183
> Resolves https://github.com/julienschmidt/httprouter/issues/202
> Resolves https://github.com/julienschmidt/httprouter/issues/203
> 
> Resolves https://github.com/gin-gonic/gin/issues/136
> Resolves https://github.com/gin-gonic/gin/issues/205
> Resolves https://github.com/gin-gonic/gin/issues/360
> Resolves https://github.com/gin-gonic/gin/issues/388
> Resolves https://github.com/gin-gonic/gin/issues/574
> Resolves https://github.com/gin-gonic/gin/issues/957
> Resolves https://github.com/gin-gonic/gin/issues/1148
> Resolves https://github.com/gin-gonic/gin/issues/1065
> Resolves https://github.com/gin-gonic/gin/issues/1132
> Resolves https://github.com/gin-gonic/gin/issues/1301
> Resolves https://github.com/gin-gonic/gin/issues/1681 
> Resolves https://github.com/gin-gonic/gin/issues/1730
> Resolves https://github.com/gin-gonic/gin/issues/1756
> Resolves https://github.com/gin-gonic/gin/issues/1990
> Resolves https://github.com/gin-gonic/gin/issues/1993
> Resolves https://github.com/gin-gonic/gin/issues/2005
> Resolves https://github.com/gin-gonic/gin/issues/2016
> Resolves https://github.com/gin-gonic/gin/issues/2062
> Resolves https://github.com/gin-gonic/gin/issues/2195
> Resolves https://github.com/gin-gonic/gin/issues/2289
> Resolves https://github.com/gin-gonic/gin/issues/2416
> Resolves https://github.com/gin-gonic/gin/issues/2465
> Resolves https://github.com/gin-gonic/gin/issues/2537