### PR TITLE
build: convert to go:build directives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,34 +18,6 @@ matrix:
     env:
       - TESTTAGS=nomsgpack
   - go: master
-    # Adding ppc64le jobs
-  - go: 1.11.x
-    arch: ppc64le
-    env: GO111MODULE=on
-  - go: 1.12.x
-    arch: ppc64le
-    env: GO111MODULE=on
-  - go: 1.13.x
-    arch: ppc64le
-  - go: 1.13.x
-    arch: ppc64le
-    env:
-      - TESTTAGS=nomsgpack
-  - go: 1.14.x
-    arch: ppc64le
-  - go: 1.14.x
-    arch: ppc64le
-    env:
-      - TESTTAGS=nomsgpack
-  - go: 1.15.x
-    arch: ppc64le
-  - go: 1.15.x
-    arch: ppc64le
-    env:
-      - TESTTAGS=nomsgpack
-  - go: master
-    arch: ppc64le
-
 
 git:
   depth: 10

--- a/binding/binding.go
+++ b/binding/binding.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // +build !nomsgpack
+//go:build !nomsgpack
 
 package binding
 

--- a/binding/binding.go
+++ b/binding/binding.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-// +build !nomsgpack
 //go:build !nomsgpack
+// +build !nomsgpack
 
 package binding
 

--- a/binding/binding_msgpack_test.go
+++ b/binding/binding_msgpack_test.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // +build !nomsgpack
+//go:build !nomsgpack
 
 package binding
 

--- a/binding/binding_msgpack_test.go
+++ b/binding/binding_msgpack_test.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-// +build !nomsgpack
 //go:build !nomsgpack
+// +build !nomsgpack
 
 package binding
 

--- a/binding/binding_nomsgpack.go
+++ b/binding/binding_nomsgpack.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // +build nomsgpack
+//go:build nomsgpack
 
 package binding
 

--- a/binding/binding_nomsgpack.go
+++ b/binding/binding_nomsgpack.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-// +build nomsgpack
 //go:build nomsgpack
+// +build nomsgpack
 
 package binding
 

--- a/binding/msgpack.go
+++ b/binding/msgpack.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // +build !nomsgpack
+//go:build !nomsgpack
 
 package binding
 

--- a/binding/msgpack.go
+++ b/binding/msgpack.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-// +build !nomsgpack
 //go:build !nomsgpack
+// +build !nomsgpack
 
 package binding
 

--- a/binding/msgpack_test.go
+++ b/binding/msgpack_test.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // +build !nomsgpack
+//go:build !nomsgpack
 
 package binding
 

--- a/binding/msgpack_test.go
+++ b/binding/msgpack_test.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-// +build !nomsgpack
 //go:build !nomsgpack
+// +build !nomsgpack
 
 package binding
 

--- a/context_appengine.go
+++ b/context_appengine.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-// +build appengine
 //go:build appengine
+// +build appengine
 
 package gin
 

--- a/context_appengine.go
+++ b/context_appengine.go
@@ -1,8 +1,9 @@
-// +build appengine
-
 // Copyright 2017 Manu Martinez-Almeida.  All rights reserved.
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
+
+// +build appengine
+//go:build appengine
 
 package gin
 

--- a/errors_1.13_test.go
+++ b/errors_1.13_test.go
@@ -1,4 +1,5 @@
 // +build go1.13
+//go:build go1.13
 
 package gin
 

--- a/errors_1.13_test.go
+++ b/errors_1.13_test.go
@@ -1,5 +1,5 @@
-// +build go1.13
 //go:build go1.13
+// +build go1.13
 
 package gin
 

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-// +build !jsoniter
 //go:build !jsoniter
+// +build !jsoniter
 
 package json
 

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // +build !jsoniter
+//go:build !jsoniter
 
 package json
 

--- a/internal/json/jsoniter.go
+++ b/internal/json/jsoniter.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-// +build jsoniter
 //go:build jsoniter
+// +build jsoniter
 
 package json
 

--- a/internal/json/jsoniter.go
+++ b/internal/json/jsoniter.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // +build jsoniter
+//go:build jsoniter
 
 package json
 

--- a/render/msgpack.go
+++ b/render/msgpack.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-// +build !nomsgpack
 //go:build !nomsgpack
+// +build !nomsgpack
 
 package render
 

--- a/render/msgpack.go
+++ b/render/msgpack.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // +build !nomsgpack
+//go:build !nomsgpack
 
 package render
 

--- a/render/render_msgpack_test.go
+++ b/render/render_msgpack_test.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-// +build !nomsgpack
 //go:build !nomsgpack
+// +build !nomsgpack
 
 package render
 

--- a/render/render_msgpack_test.go
+++ b/render/render_msgpack_test.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // +build !nomsgpack
+//go:build !nomsgpack
 
 package render
 


### PR DESCRIPTION
currently, CI fails on go master branch.

as mentioned in golang/go#41184 and golang/go#44505, Go will probably migrate to a more robust build constraints directive, as explained design doc:

https://golang.org/s/go-build-design

so, we should prepare for that:

for Go-1.17: add all //go:build directives
for Go-1.18: remove all // +build directives
