### PR TITLE
set engine.TrustedProxies For items that don't use gin.RUN

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -368,7 +368,7 @@ func (engine *Engine) prepareTrustedCIDRs() ([]*net.IPNet, error) {
 
 // SetTrustedProxies  set Engine.TrustedProxies
 func (engine *Engine) SetTrustedProxies(trustedProxies []string) error {
-	engine.ForwardedByClientIP = true
+	//engine.ForwardedByClientIP = true
 	engine.TrustedProxies = trustedProxies
 	return engine.parseTrustedProxies()
 }
@@ -376,11 +376,8 @@ func (engine *Engine) SetTrustedProxies(trustedProxies []string) error {
 // parseTrustedProxies parse Engine.TrustedProxies to Engine.trustedCIDRs
 func (engine *Engine) parseTrustedProxies() error {
 	trustedCIDRs, err := engine.prepareTrustedCIDRs()
-	if err != nil {
-		return err
-	}
 	engine.trustedCIDRs = trustedCIDRs
-	return nil
+	return err
 }
 
 // parseIP parse a string representation of an IP and returns a net.IP with the

--- a/gin.go
+++ b/gin.go
@@ -326,11 +326,11 @@ func iterate(path, method string, routes RoutesInfo, root *node) RoutesInfo {
 func (engine *Engine) Run(addr ...string) (err error) {
 	defer func() { debugPrintError(err) }()
 
-	trustedCIDRs, err := engine.prepareTrustedCIDRs()
+	err = engine.parseTrustedProxies()
 	if err != nil {
 		return err
 	}
-	engine.trustedCIDRs = trustedCIDRs
+
 	address := resolveAddress(addr)
 	debugPrint("Listening and serving HTTP on %s\n", address)
 	err = http.ListenAndServe(address, engine)
@@ -364,6 +364,23 @@ func (engine *Engine) prepareTrustedCIDRs() ([]*net.IPNet, error) {
 		cidr = append(cidr, cidrNet)
 	}
 	return cidr, nil
+}
+
+// SetTrustedProxies  set Engine.TrustedProxies
+func (engine *Engine) SetTrustedProxies(trustedProxies []string) error {
+	engine.ForwardedByClientIP = true
+	engine.TrustedProxies = trustedProxies
+	return engine.parseTrustedProxies()
+}
+
+// parseTrustedProxies parse Engine.TrustedProxies to Engine.trustedCIDRs
+func (engine *Engine) parseTrustedProxies() error {
+	trustedCIDRs, err := engine.prepareTrustedCIDRs()
+	if err != nil {
+		return err
+	}
+	engine.trustedCIDRs = trustedCIDRs
+	return nil
 }
 
 // parseIP parse a string representation of an IP and returns a net.IP with the

--- a/gin_integration_test.go
+++ b/gin_integration_test.go
@@ -62,7 +62,7 @@ func TestBadTrustedCIDRsForRun(t *testing.T) {
 	assert.Error(t, router.Run(":8080"))
 }
 
-func TestBadTrustedCIDRsForRunUnix(t *testing.T){
+func TestBadTrustedCIDRsForRunUnix(t *testing.T) {
 	router := New()
 	router.TrustedProxies = []string{"hello/world"}
 
@@ -79,7 +79,7 @@ func TestBadTrustedCIDRsForRunUnix(t *testing.T){
 	time.Sleep(5 * time.Millisecond)
 }
 
-func TestBadTrustedCIDRsForRunFd(t *testing.T){
+func TestBadTrustedCIDRsForRunFd(t *testing.T) {
 	router := New()
 	router.TrustedProxies = []string{"hello/world"}
 
@@ -99,7 +99,7 @@ func TestBadTrustedCIDRsForRunFd(t *testing.T){
 	time.Sleep(5 * time.Millisecond)
 }
 
-func TestBadTrustedCIDRsForRunListener(t *testing.T){
+func TestBadTrustedCIDRsForRunListener(t *testing.T) {
 	router := New()
 	router.TrustedProxies = []string{"hello/world"}
 

--- a/gin_integration_test.go
+++ b/gin_integration_test.go
@@ -55,11 +55,72 @@ func TestRunEmpty(t *testing.T) {
 	testRequest(t, "http://localhost:8080/example")
 }
 
-func TestTrustedCIDRsForRun(t *testing.T) {
+func TestBadTrustedCIDRsForRun(t *testing.T) {
 	os.Setenv("PORT", "")
 	router := New()
 	router.TrustedProxies = []string{"hello/world"}
 	assert.Error(t, router.Run(":8080"))
+}
+
+func TestBadTrustedCIDRsForRunUnix(t *testing.T){
+	router := New()
+	router.TrustedProxies = []string{"hello/world"}
+
+	unixTestSocket := filepath.Join(os.TempDir(), "unix_unit_test")
+
+	defer os.Remove(unixTestSocket)
+
+	go func() {
+		router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
+		assert.Error(t, router.RunUnix(unixTestSocket))
+	}()
+	// have to wait for the goroutine to start and run the server
+	// otherwise the main thread will complete
+	time.Sleep(5 * time.Millisecond)
+}
+
+func TestBadTrustedCIDRsForRunFd(t *testing.T){
+	router := New()
+	router.TrustedProxies = []string{"hello/world"}
+
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	assert.NoError(t, err)
+	listener, err := net.ListenTCP("tcp", addr)
+	assert.NoError(t, err)
+	socketFile, err := listener.File()
+	assert.NoError(t, err)
+
+	go func() {
+		router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
+		assert.Error(t, router.RunFd(int(socketFile.Fd())))
+	}()
+	// have to wait for the goroutine to start and run the server
+	// otherwise the main thread will complete
+	time.Sleep(5 * time.Millisecond)
+}
+
+func TestBadTrustedCIDRsForRunListener(t *testing.T){
+	router := New()
+	router.TrustedProxies = []string{"hello/world"}
+
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	assert.NoError(t, err)
+	listener, err := net.ListenTCP("tcp", addr)
+	assert.NoError(t, err)
+	go func() {
+		router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
+		assert.Error(t, router.RunListener(listener))
+	}()
+	// have to wait for the goroutine to start and run the server
+	// otherwise the main thread will complete
+	time.Sleep(5 * time.Millisecond)
+}
+
+func TestBadTrustedCIDRsForRunTLS(t *testing.T) {
+	os.Setenv("PORT", "")
+	router := New()
+	router.TrustedProxies = []string{"hello/world"}
+	assert.Error(t, router.RunTLS(":8080", "./testdata/certificate/cert.pem", "./testdata/certificate/key.pem"))
 }
 
 func TestRunTLS(t *testing.T) {


### PR DESCRIPTION
#2632 

https://github.com/gin-gonic/gin/pull/2675

#2675 causes the `engine.prepareTrustedCIDRS` to never execute if `gin` is not started via `gin.RUN()`.

this pr set `engine.TrustedProxies` and execute `engine.prepareTrustedCIDRS` For items that don't use `gin.RUN`

Our project uses `http.Handler` to start the service instead of `gin.Run`