### PR TITLE
Use `Header()` instead of deprecated `HeaderMap`

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -1044,7 +1044,7 @@ func TestContextRenderAttachment(t *testing.T) {
 
 	assert.Equal(t, 200, w.Code)
 	assert.Contains(t, w.Body.String(), "func New() *Engine {")
-	assert.Equal(t, fmt.Sprintf("attachment; filename=\"%s\"", newFilename), w.HeaderMap.Get("Content-Disposition"))
+	assert.Equal(t, fmt.Sprintf("attachment; filename=\"%s\"", newFilename), w.Header().Get("Content-Disposition"))
 }
 
 // TestContextRenderYAML tests that the response is serialized as YAML


### PR DESCRIPTION
`HeaderMap` is deprecated and should avoid to use.
Ref: https://golang.org/pkg/net/http/httptest/#ResponseRecorder
