### PR TITLE
Add note about `nomsgpack` tag to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Gin is a web framework written in Go (Golang). It features a martini-like API wi
   - [Benchmarks](#benchmarks)
   - [Gin v1. stable](#gin-v1-stable)
   - [Build with jsoniter/go-json](#build-with-json-replacement)
+  - [Build without `MsgPack` rendering feature](#build-without-msgpack-rendering-feature)
   - [API Examples](#api-examples)
     - [Using GET, POST, PUT, PATCH, DELETE and OPTIONS](#using-get-post-put-patch-delete-and-options)
     - [Parameters in path](#parameters-in-path)
@@ -194,6 +195,16 @@ $ go build -tags=jsoniter .
 ```sh
 $ go build -tags=go_json .
 ```
+
+## Build without `MsgPack` rendering feature
+
+Gin enables `MsgPack` rendering feature by default. But you can disable this feature by specifying `nomsgpack` build tag.
+
+```sh
+$ go build -tags=nomsgpack .
+```
+
+This is useful to reduce the binary size of executable files. See the [detail information](https://github.com/gin-gonic/gin/pull/1852).
 
 ## API Examples
 


### PR DESCRIPTION
I think this information is useful for users that don't use `MsgPack` rendering.

