### PR TITLE
Use `Duration.Truncate` for truncating precision

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -138,8 +138,7 @@ var defaultLogFormatter = func(param LogFormatterParams) string {
 	}
 
 	if param.Latency > time.Minute {
-		// Truncate in a golang < 1.8 safe way
-		param.Latency = param.Latency - param.Latency%time.Second
+		param.Latency = param.Latency.Truncate(time.Second)
 	}
 	return fmt.Sprintf("[GIN] %v |%s %3d %s| %13v | %15s |%s %-7s %s %#v\n%s",
 		param.TimeStamp.Format("2006/01/02 - 15:04:05"),


### PR DESCRIPTION
`Duration.Truncate` was added in Go 1.9 and Gin required Go version 1.13+ now.
So we can use `Duration.Truncate`.

- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as TravisCI.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

