### PR TITLE
Setting trusted platform using an enum-like

### DIFF
--- a/context_appengine.go
+++ b/context_appengine.go
@@ -8,5 +8,5 @@
 package gin
 
 func init() {
-	defaultAppEngine = true
+	defaultPlatform = PlatformGoogleAppEngine
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1410,7 +1410,7 @@ func TestContextClientIP(t *testing.T) {
 
 	c.Request.Header.Del("X-Forwarded-For")
 	c.Request.Header.Del("X-Real-IP")
-	c.engine.AppEngine = true
+	c.engine.TrustedPlatform = PlatformGoogleAppEngine
 	assert.Equal(t, "50.50.50.50", c.ClientIP())
 
 	c.Request.Header.Del("X-Appengine-Remote-Addr")
@@ -1470,18 +1470,26 @@ func TestContextClientIP(t *testing.T) {
 	assert.Equal(t, "10.10.10.10", c.ClientIP())
 
 	c.engine.RemoteIPHeaders = []string{}
+	c.engine.TrustedPlatform = PlatformGoogleAppEngine
+	assert.Equal(t, "50.50.50.50", c.ClientIP())
+
+	// Test the legacy flag
+	c.engine.TrustedPlatform = ""
 	c.engine.AppEngine = true
 	assert.Equal(t, "50.50.50.50", c.ClientIP())
+	c.engine.AppEngine = false
+	c.engine.TrustedPlatform = PlatformGoogleAppEngine
 
 	c.Request.Header.Del("X-Appengine-Remote-Addr")
 	assert.Equal(t, "40.40.40.40", c.ClientIP())
 
-	c.engine.AppEngine = false
-	c.engine.CloudflareProxy = true
+	c.engine.TrustedPlatform = PlatformCloudflare
 	assert.Equal(t, "60.60.60.60", c.ClientIP())
 
 	c.Request.Header.Del("CF-Connecting-IP")
 	assert.Equal(t, "40.40.40.40", c.ClientIP())
+
+	c.engine.TrustedPlatform = ""
 
 	// no port
 	c.Request.RemoteAddr = "50.50.50.50"
@@ -1494,6 +1502,7 @@ func resetContextForClientIPTests(c *Context) {
 	c.Request.Header.Set("X-Appengine-Remote-Addr", "50.50.50.50")
 	c.Request.Header.Set("CF-Connecting-IP", "60.60.60.60")
 	c.Request.RemoteAddr = "  40.40.40.40:42123 "
+	c.engine.TrustedPlatform = ""
 	c.engine.AppEngine = false
 }
 

--- a/gin.go
+++ b/gin.go
@@ -25,7 +25,7 @@ var (
 	default405Body = []byte("405 method not allowed")
 )
 
-var defaultAppEngine bool
+var defaultPlatform string
 
 // HandlerFunc defines the handler used by gin middleware as return value.
 type HandlerFunc func(*Context)
@@ -51,6 +51,16 @@ type RouteInfo struct {
 
 // RoutesInfo defines a RouteInfo array.
 type RoutesInfo []RouteInfo
+
+// Trusted platforms
+const (
+	// When running on Google App Engine. Trust X-Appengine-Remote-Addr
+	// for determining the client's IP
+	PlatformGoogleAppEngine = "google-app-engine"
+	// When using Cloudflare's CDN. Trust CF-Connecting-IP for determining
+	// the client's IP
+	PlatformCloudflare = "cloudflare"
+)
 
 // Engine is the framework's instance, it contains the muxer, middleware and configuration settings.
 // Create an instance of Engine, by using New() or Default()
@@ -101,13 +111,14 @@ type Engine struct {
 	// `true`.
 	TrustedProxies []string
 
+	// If set to a constant of value gin.Platform*, trusts the headers set by
+	// that platform, for example to determine the client IP
+	TrustedPlatform string
+
+	// DEPRECATED: USE `TrustedPlatform` WITH VALUE `gin.GoogleAppEngine` INSTEAD
 	// #726 #755 If enabled, it will trust some headers starting with
 	// 'X-AppEngine...' for better integration with that PaaS.
 	AppEngine bool
-
-	// If enabled, it will trust the CF-Connecting-IP header to determine the
-	// IP of the client.
-	CloudflareProxy bool
 
 	// If enabled, the url.RawPath will be used to find parameters.
 	UseRawPath bool
@@ -164,7 +175,7 @@ func New() *Engine {
 		ForwardedByClientIP:    true,
 		RemoteIPHeaders:        []string{"X-Forwarded-For", "X-Real-IP"},
 		TrustedProxies:         []string{"0.0.0.0/0"},
-		AppEngine:              defaultAppEngine,
+		TrustedPlatform:        defaultPlatform,
 		UseRawPath:             false,
 		RemoveExtraSlash:       false,
 		UnescapePathValues:     true,


### PR DESCRIPTION
Updated #2723 using an enum-like.

This also marks `AppEngine` as deprecated (note that we can't detect people using `AppEngine: false` because that's also the zero value, so we can only show an error message to people who set `AppEngine: true`).

This removes the `Cloudflare` property set in #2723, which was never released anyways.