### PR TITLE
feat: add StaticFileFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1241,7 +1241,7 @@ func main() {
 	router.Static("/assets", "./assets")
 	router.StaticFS("/more_static", http.Dir("my_file_system"))
 	router.StaticFile("/favicon.ico", "./resources/favicon.ico")
-    router.StaticFileFS("/more_favicon.ico", "more_favicon.ico", http.Dir("my_file_system"))
+	router.StaticFileFS("/more_favicon.ico", "more_favicon.ico", http.Dir("my_file_system"))
 	
 	// Listen and serve on 0.0.0.0:8080
 	router.Run(":8080")

--- a/README.md
+++ b/README.md
@@ -1241,7 +1241,8 @@ func main() {
 	router.Static("/assets", "./assets")
 	router.StaticFS("/more_static", http.Dir("my_file_system"))
 	router.StaticFile("/favicon.ico", "./resources/favicon.ico")
-
+    router.StaticFileFS("/more_favicon.ico", "more_favicon.ico", http.Dir("my_file_system"))
+	
 	// Listen and serve on 0.0.0.0:8080
 	router.Run(":8080")
 }

--- a/routergroup.go
+++ b/routergroup.go
@@ -183,7 +183,7 @@ func (group *RouterGroup) StaticFileFS(relativePath, filepath string, fs http.Fi
 // of the Router's NotFound handler.
 // To use the operating system's file system implementation,
 // use :
-//     router.Static("/static", "/var/www", http)
+//     router.Static("/static", "/var/www")
 func (group *RouterGroup) Static(relativePath, root string) IRoutes {
 	return group.StaticFS(relativePath, Dir(root, false))
 }

--- a/routergroup.go
+++ b/routergroup.go
@@ -152,26 +152,23 @@ func (group *RouterGroup) Any(relativePath string, handlers ...HandlerFunc) IRou
 // StaticFile registers a single route in order to serve a single file of the local filesystem.
 // router.StaticFile("favicon.ico", "./resources/favicon.ico")
 func (group *RouterGroup) StaticFile(relativePath, filepath string) IRoutes {
-	if strings.Contains(relativePath, ":") || strings.Contains(relativePath, "*") {
-		panic("URL parameters can not be used when serving a static file")
-	}
-	handler := func(c *Context) {
+	return group.staticFileHandler(relativePath, func(c *Context) {
 		c.File(filepath)
-	}
-	group.GET(relativePath, handler)
-	group.HEAD(relativePath, handler)
-	return group.returnObj()
+	})
 }
 
 // StaticFileFS works just like `StaticFile` but a custom `http.FileSystem` can be used instead..
 // router.StaticFileFS("favicon.ico", "./resources/favicon.ico", Dir{".", false})
 // Gin by default user: gin.Dir()
 func (group *RouterGroup) StaticFileFS(relativePath, filepath string, fs http.FileSystem) IRoutes {
+	return group.staticFileHandler(relativePath, func(c *Context) {
+		c.FileFromFS(filepath, fs)
+	})
+}
+
+func (group *RouterGroup) staticFileHandler(relativePath string, handler HandlerFunc) IRoutes {
 	if strings.Contains(relativePath, ":") || strings.Contains(relativePath, "*") {
 		panic("URL parameters can not be used when serving a static file")
-	}
-	handler := func(c *Context) {
-		c.FileFromFS(filepath, fs)
 	}
 	group.GET(relativePath, handler)
 	group.HEAD(relativePath, handler)

--- a/routergroup_test.go
+++ b/routergroup_test.go
@@ -111,6 +111,17 @@ func TestRouterGroupInvalidStaticFile(t *testing.T) {
 	})
 }
 
+func TestRouterGroupInvalidStaticFileFS(t *testing.T) {
+	router := New()
+	assert.Panics(t, func() {
+		router.StaticFileFS("/path/:param", "favicon.ico", Dir(".", false))
+	})
+
+	assert.Panics(t, func() {
+		router.StaticFileFS("/path/*param", "favicon.ico", Dir(".", false))
+	})
+}
+
 func TestRouterGroupTooManyHandlers(t *testing.T) {
 	router := New()
 	handlers1 := make([]HandlerFunc, 40)
@@ -173,6 +184,7 @@ func testRoutesInterface(t *testing.T, r IRoutes) {
 	assert.Equal(t, r, r.HEAD("/", handler))
 
 	assert.Equal(t, r, r.StaticFile("/file", "."))
+	assert.Equal(t, r, r.StaticFileFS("/static2", ".", Dir(".", false)))
 	assert.Equal(t, r, r.Static("/static", "."))
 	assert.Equal(t, r, r.StaticFS("/static2", Dir(".", false)))
 }

--- a/routes_test.go
+++ b/routes_test.go
@@ -324,6 +324,40 @@ func TestRouteStaticFile(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w3.Code)
 }
 
+// TestHandleStaticFile - ensure the static file handles properly
+func TestRouteStaticFileFS(t *testing.T) {
+	// SETUP file
+	testRoot, _ := os.Getwd()
+	f, err := ioutil.TempFile(testRoot, "")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(f.Name())
+	_, err = f.WriteString("Gin Web Framework")
+	assert.NoError(t, err)
+	f.Close()
+
+	dir, filename := filepath.Split(f.Name())
+	// SETUP gin
+	router := New()
+	router.Static("/using_static", dir)
+	router.StaticFileFS("/result_fs", filename, Dir(dir, false))
+
+	w := performRequest(router, http.MethodGet, "/using_static/"+filename)
+	w2 := performRequest(router, http.MethodGet, "/result_fs")
+
+	assert.Equal(t, w, w2)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "Gin Web Framework", w.Body.String())
+	assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
+
+	w3 := performRequest(router, http.MethodHead, "/using_static/"+filename)
+	w4 := performRequest(router, http.MethodHead, "/result_fs")
+
+	assert.Equal(t, w3, w4)
+	assert.Equal(t, http.StatusOK, w3.Code)
+}
+
 // TestHandleStaticDir - ensure the root/sub dir handles properly
 func TestRouteStaticListingDir(t *testing.T) {
 	router := New()


### PR DESCRIPTION
I was miising feature of Serving file form http.FileSystem
there has StaticFile,Static,StaticFS method, since go1.16 embed feature, I am not find how to get a file from embed fs. follow is my want
```
//go:embed mypic.png
var pic embed.FS

func main() {
	r := gin.Default()
        r.StaticFileFS("/alias_pic.png", "mypic.png", http.FS(pic))
        
	err := r.Run(":9000")
	if err != nil {
		panic(err)
	}
}
```
Use cases:
    - Serve file by alias  from `http.FileSystem`
