### PR TITLE
support random port display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ count.out
 test
 profile.out
 tmp.out
+.idea


### PR DESCRIPTION
Random port display is not friendly
```
_ = gin.New().Run(":0")
[GIN-debug] Listening and serving HTTP on :0
```