### PR TITLE
Skip unnecessary variable assignment in timeFormat

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -167,6 +167,5 @@ func function(pc uintptr) []byte {
 
 // timeFormat returns a customized time string for logger.
 func timeFormat(t time.Time) string {
-	timeString := t.Format("2006/01/02 - 15:04:05")
-	return timeString
+	return t.Format("2006/01/02 - 15:04:05")
 }


### PR DESCRIPTION
- Skip unnecessary variable assignment in `timeFormat`.