### PR TITLE
Move msgpack interface implementation check variable to render.go

### DIFF
--- a/render/msgpack.go
+++ b/render/msgpack.go
@@ -13,10 +13,6 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
-var (
-	_ Render = MsgPack{}
-)
-
 // MsgPack contains the given interface object.
 type MsgPack struct {
 	Data interface{}

--- a/render/render.go
+++ b/render/render.go
@@ -30,6 +30,7 @@ var (
 	_ Render     = Reader{}
 	_ Render     = AsciiJSON{}
 	_ Render     = ProtoBuf{}
+	_ Render     = MsgPack{}
 )
 
 func writeContentType(w http.ResponseWriter, value []string) {

--- a/render/render_msgpack_test.go
+++ b/render/render_msgpack_test.go
@@ -39,6 +39,6 @@ func TestRenderMsgPack(t *testing.T) {
 	err = codec.NewEncoder(buf, h).Encode(data)
 
 	assert.NoError(t, err)
-	assert.Equal(t, w.Body.String(), string(buf.Bytes()))
+	assert.Equal(t, w.Body.String(), buf.String())
 	assert.Equal(t, "application/msgpack; charset=utf-8", w.Header().Get("Content-Type"))
 }


### PR DESCRIPTION
- Move `msgpack` interface implementation check variable to `render.go`.
- Use `buf.String()` instead of `string(buf.Bytes())` according to [(S1030) go-staticcheck](https://staticcheck.io/docs/checks).
