### PR TITLE
Use buf.String() instead of string(buf.Bytes())

### DIFF
--- a/render/msgpack.go
+++ b/render/msgpack.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
+// Check interface implemented here to support go build tag nomsgpack.
+// See: https://github.com/gin-gonic/gin/pull/1852/
 var (
 	_ Render = MsgPack{}
 )

--- a/render/render_msgpack_test.go
+++ b/render/render_msgpack_test.go
@@ -39,6 +39,6 @@ func TestRenderMsgPack(t *testing.T) {
 	err = codec.NewEncoder(buf, h).Encode(data)
 
 	assert.NoError(t, err)
-	assert.Equal(t, w.Body.String(), string(buf.Bytes()))
+	assert.Equal(t, w.Body.String(), buf.String())
 	assert.Equal(t, "application/msgpack; charset=utf-8", w.Header().Get("Content-Type"))
 }


### PR DESCRIPTION
- Add comments in `render/msgpack.go`.
- Use `buf.String()` instead of `string(buf.Bytes())` according to [(S1030) go-staticcheck](https://staticcheck.io/docs/checks).