### PR TITLE
Use bit shift operation instead of division

### DIFF
--- a/context.go
+++ b/context.go
@@ -40,7 +40,8 @@ const (
 // BodyBytesKey indicates a default body bytes key.
 const BodyBytesKey = "_gin-gonic/gin/bodybyteskey"
 
-const abortIndex int8 = math.MaxInt8 / 2
+// abortIndex represents a typical value used in abort functions.
+const abortIndex int8 = math.MaxInt8 >> 1
 
 // Context is the most important part of gin. It allows us to pass variables between middleware,
 // manage the flow, validate the JSON of a request and render a JSON response for example.


### PR DESCRIPTION
- Use bit shift operation instead of division in `context.go`.
- Add constant comments.