### PR TITLE
Export struct sliceValidateError to allow error casting

### DIFF
--- a/binding/default_validator.go
+++ b/binding/default_validator.go
@@ -18,10 +18,10 @@ type defaultValidator struct {
 	validate *validator.Validate
 }
 
-type sliceValidateError []error
+type SliceValidationError []error
 
-// Error concatenates all error elements in sliceValidateError into a single string separated by \n.
-func (err sliceValidateError) Error() string {
+// Error concatenates all error elements in SliceValidationError into a single string separated by \n.
+func (err SliceValidationError) Error() string {
 	n := len(err)
 	switch n {
 	case 0:
@@ -59,7 +59,7 @@ func (v *defaultValidator) ValidateStruct(obj interface{}) error {
 		return v.validateStruct(obj)
 	case reflect.Slice, reflect.Array:
 		count := value.Len()
-		validateRet := make(sliceValidateError, 0)
+		validateRet := make(SliceValidationError, 0)
 		for i := 0; i < count; i++ {
 			if err := v.ValidateStruct(value.Index(i).Interface()); err != nil {
 				validateRet = append(validateRet, err)

--- a/binding/default_validator_benchmark_test.go
+++ b/binding/default_validator_benchmark_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 )
 
-func BenchmarkSliceValidateError(b *testing.B) {
+func BenchmarkSliceValidationError(b *testing.B) {
 	const size int = 100
 	for i := 0; i < b.N; i++ {
-		e := make(sliceValidateError, size)
+		e := make(SliceValidationError, size)
 		for j := 0; j < size; j++ {
 			e[j] = errors.New(strconv.Itoa(j))
 		}

--- a/binding/default_validator_test.go
+++ b/binding/default_validator_test.go
@@ -9,24 +9,24 @@ import (
 	"testing"
 )
 
-func TestSliceValidateError(t *testing.T) {
+func TestSliceValidationError(t *testing.T) {
 	tests := []struct {
 		name string
-		err  sliceValidateError
+		err  SliceValidationError
 		want string
 	}{
-		{"has nil elements", sliceValidateError{errors.New("test error"), nil}, "[0]: test error"},
-		{"has zero elements", sliceValidateError{}, ""},
-		{"has one element", sliceValidateError{errors.New("test one error")}, "[0]: test one error"},
+		{"has nil elements", SliceValidationError{errors.New("test error"), nil}, "[0]: test error"},
+		{"has zero elements", SliceValidationError{}, ""},
+		{"has one element", SliceValidationError{errors.New("test one error")}, "[0]: test one error"},
 		{"has two elements",
-			sliceValidateError{
+			SliceValidationError{
 				errors.New("first error"),
 				errors.New("second error"),
 			},
 			"[0]: first error\n[1]: second error",
 		},
 		{"has many elements",
-			sliceValidateError{
+			SliceValidationError{
 				errors.New("first error"),
 				errors.New("second error"),
 				nil,
@@ -40,7 +40,7 @@ func TestSliceValidateError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.err.Error(); got != tt.want {
-				t.Errorf("sliceValidateError.Error() = %v, want %v", got, tt.want)
+				t.Errorf("SliceValidationError.Error() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR allows to cast error returned by ShouldBindWith functions when input parameter is a slice.

