### PR TITLE
Use std http method constant instead of raw string

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -539,7 +539,7 @@ func (engine *Engine) handleHTTPRequest(c *Context) {
 			c.writermem.WriteHeaderNow()
 			return
 		}
-		if httpMethod != "CONNECT" && rPath != "/" {
+		if httpMethod != http.MethodConnect && rPath != "/" {
 			if value.tsr && engine.RedirectTrailingSlash {
 				redirectTrailingSlash(c)
 				return


### PR DESCRIPTION
- Use std `net/http` http method constant instead of raw string in `gin.go`.