### PR TITLE
Improve router group tests

### DIFF
--- a/routergroup_test.go
+++ b/routergroup_test.go
@@ -112,15 +112,19 @@ func TestRouterGroupInvalidStaticFile(t *testing.T) {
 }
 
 func TestRouterGroupTooManyHandlers(t *testing.T) {
+	const (
+		panicValue = "too many handlers"
+		maximumCnt = abortIndex
+	)
 	router := New()
-	handlers1 := make([]HandlerFunc, 40)
+	handlers1 := make([]HandlerFunc, maximumCnt-1)
 	router.Use(handlers1...)
 
-	handlers2 := make([]HandlerFunc, 26)
-	assert.Panics(t, func() {
+	handlers2 := make([]HandlerFunc, maximumCnt+1)
+	assert.PanicsWithValue(t, panicValue, func() {
 		router.Use(handlers2...)
 	})
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, panicValue, func() {
 		router.GET("/", handlers2...)
 	})
 }


### PR DESCRIPTION
- Use relative value instead of hard coded number in `TestRouterGroupTooManyHandlers`.
- Also check the panic value in test.