### PR TITLE
fix(engine): missing route params for CreateTestContext (#2778)

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -146,7 +146,7 @@ func TestSaveUploadedCreateFailed(t *testing.T) {
 
 func TestContextReset(t *testing.T) {
 	router := New()
-	c := router.allocateContext()
+	c := router.allocateContext(0)
 	assert.Equal(t, c.engine, router)
 
 	c.index = 2
@@ -2353,4 +2353,18 @@ func TestContextAddParam(t *testing.T) {
 	v, ok := c.Params.Get(id)
 	assert.Equal(t, ok, true)
 	assert.Equal(t, value, v)
+}
+
+func TestCreateTestContextWithRouteParams(t *testing.T) {
+	w := httptest.NewRecorder()
+	engine := New()
+	engine.GET("/:action/:name", func(ctx *Context) {
+		ctx.String(http.StatusOK, "%s %s", ctx.Param("action"), ctx.Param("name"))
+	})
+	c := CreateTestContextOnly(w, engine)
+	c.Request, _ = http.NewRequest(http.MethodGet, "/hello/gin", nil)
+	engine.HandleContext(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "hello gin", w.Body.String())
 }

--- a/gin.go
+++ b/gin.go
@@ -203,7 +203,7 @@ func New() *Engine {
 	}
 	engine.RouterGroup.engine = engine
 	engine.pool.New = func() any {
-		return engine.allocateContext()
+		return engine.allocateContext(engine.maxParams)
 	}
 	return engine
 }
@@ -225,8 +225,8 @@ func (engine *Engine) Handler() http.Handler {
 	return h2c.NewHandler(engine, h2s)
 }
 
-func (engine *Engine) allocateContext() *Context {
-	v := make(Params, 0, engine.maxParams)
+func (engine *Engine) allocateContext(maxParams uint16) *Context {
+	v := make(Params, 0, maxParams)
 	skippedNodes := make([]skippedNode, 0, engine.maxSections)
 	return &Context{engine: engine, params: &v, skippedNodes: &skippedNodes}
 }

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -9,7 +9,15 @@ import "net/http"
 // CreateTestContext returns a fresh engine and context for testing purposes
 func CreateTestContext(w http.ResponseWriter) (c *Context, r *Engine) {
 	r = New()
-	c = r.allocateContext()
+	c = r.allocateContext(0)
+	c.reset()
+	c.writermem.reset(w)
+	return
+}
+
+// CreateTestContextOnly returns a fresh context base on the engine for testing purposes
+func CreateTestContextOnly(w http.ResponseWriter, r *Engine) (c *Context) {
+	c = r.allocateContext(r.maxParams)
 	c.reset()
 	c.writermem.reset(w)
 	return


### PR DESCRIPTION
This PR trying to fix the issue we met, which exact same with https://github.com/gin-gonic/gin/issues/2778

If you guys have better idea to fix this, just let me know.

