### PR TITLE
chore(ci): golangci timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+run:
+  timeout: 5m
 linters:
   enable:
   - gofmt


### PR DESCRIPTION
The default timeout of 1m has been exceeded, this PR is fixing this issue.
See https://github.com/gin-gonic/gin/runs/3369288827
```
Timeout exceeded: try increasing it by passing --timeout option
```