### PR TITLE
gin.Context.SetParam shortcut for e2e tests

### DIFF
--- a/context.go
+++ b/context.go
@@ -383,7 +383,7 @@ func (c *Context) Param(key string) string {
 	return c.Params.ByName(key)
 }
 
-// AddParam adds param to context an
+// AddParam adds param to context and
 // replaces path param key with given value for e2e testing purposes
 // Example Route: "/user/:id"
 // AddParam("id", 1)

--- a/context.go
+++ b/context.go
@@ -383,6 +383,15 @@ func (c *Context) Param(key string) string {
 	return c.Params.ByName(key)
 }
 
+// SetParam adds param to context an
+// replaces path param key with given value for e2e testing purposes
+// Example Route: "/user/:id"
+// SetParam("id", 1)
+// Result: "/user/1"
+func (c *Context) SetParam(key, value string) {
+	c.Params = append(c.Params, Param{Key: key,Value: value})
+}
+
 // Query returns the keyed url query value if it exists,
 // otherwise it returns an empty string `("")`.
 // It is shortcut for `c.Request.URL.Query().Get(key)`

--- a/context.go
+++ b/context.go
@@ -383,13 +383,13 @@ func (c *Context) Param(key string) string {
 	return c.Params.ByName(key)
 }
 
-// SetParam adds param to context an
+// AddParam adds param to context an
 // replaces path param key with given value for e2e testing purposes
 // Example Route: "/user/:id"
-// SetParam("id", 1)
+// AddParam("id", 1)
 // Result: "/user/1"
-func (c *Context) SetParam(key, value string) {
-	c.Params = append(c.Params, Param{Key: key,Value: value})
+func (c *Context) AddParam(key, value string) {
+	c.Params = append(c.Params, Param{Key: key, Value: value})
 }
 
 // Query returns the keyed url query value if it exists,

--- a/context_test.go
+++ b/context_test.go
@@ -2150,3 +2150,14 @@ func TestContextWithFallbackValueFromRequestContext(t *testing.T) {
 		})
 	}
 }
+
+func TestContextSetParam(t *testing.T) {
+	c := &Context{}
+	id := "id"
+	value := "1"
+	c.SetParam(id, value)
+
+	v, ok := c.Params.Get(id)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, value, v)
+}

--- a/context_test.go
+++ b/context_test.go
@@ -2151,11 +2151,11 @@ func TestContextWithFallbackValueFromRequestContext(t *testing.T) {
 	}
 }
 
-func TestContextSetParam(t *testing.T) {
+func TestContextAddParam(t *testing.T) {
 	c := &Context{}
 	id := "id"
 	value := "1"
-	c.SetParam(id, value)
+	c.AddParam(id, value)
 
 	v, ok := c.Params.Get(id)
 	assert.Equal(t, ok, true)


### PR DESCRIPTION
While writing e2e tests I noticed that adding path params can be simplified further. 
Instead of appending params to the gin context like this:
`c.Params = append(c.Params, Param{Key: key,Value: value})`
The function `SetParam` will do the same but increase usability for writing e2e tests.