### PR TITLE
fix bug : gin config `RemoveExtraSlash` do not work when  use static …

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -519,6 +519,7 @@ func (engine *Engine) handleHTTPRequest(c *Context) {
 
 	if engine.RemoveExtraSlash {
 		rPath = cleanPath(rPath)
+		c.Request.URL.Path = rPath
 	}
 
 	// Find root of the tree for the given HTTP method


### PR DESCRIPTION
when i  config static path in my project 

code: 
```
	app = gin.Default()
	app.RemoveExtraSlash = true
	app.Static("/static", "my-static-path")
```
request
```
# curl 127.0.0.1/static/test.json
# test.json  

# curl 127.0.0.1///static/test.json
# 404 page not found
```

because  handler `createStaticHandler.func1` ignore `rPath` ,  so  change   request data  then handler will process request in right way . 

```
c.Request.URL.Path = rPath
```




- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

