### PR TITLE
Refactor for Context.RemoteIP()

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -12,6 +12,7 @@ import (
 	"html/template"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2051,7 +2052,8 @@ func TestRemoteIPFail(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Request, _ = http.NewRequest("POST", "/", nil)
 	c.Request.RemoteAddr = "[:::]:80"
-	ip, trust := c.RemoteIP()
+	ip := net.ParseIP(c.RemoteIP())
+	trust := c.engine.isTrustedProxy(ip)
 	assert.Nil(t, ip)
 	assert.False(t, trust)
 }

--- a/gin.go
+++ b/gin.go
@@ -416,24 +416,23 @@ func (engine *Engine) isTrustedProxy(ip net.IP) bool {
 }
 
 func (engine *Engine) validateHeader(header string) (clientIP string, valid bool) {
-	if header == "" {
-		return "", false
-	}
-	items := strings.Split(header, ",")
-	for i := len(items) - 1; i >= 0; i-- {
-		ipStr := strings.TrimSpace(items[i])
-		ip := net.ParseIP(ipStr)
-		if ip == nil {
-			return "", false
-		}
+	if header != "" {
+		items := strings.Split(header, ",")
+		for i := len(items) - 1; i >= 0; i-- {
+			ipStr := strings.TrimSpace(items[i])
+			ip := net.ParseIP(ipStr)
+			if ip == nil {
+				return "", false
+			}
 
-		// X-Forwarded-For is appended by proxy
-		// Check IPs in reverse order and stop when find untrusted proxy
-		if (i == 0) || (!engine.isTrustedProxy(ip)) {
-			return ipStr, true
+			// X-Forwarded-For is appended by proxy
+			// Check IPs in reverse order and stop when find untrusted proxy
+			if (i == 0) || (!engine.isTrustedProxy(ip)) {
+				return ipStr, true
+			}
 		}
 	}
-	return
+	return "", false
 }
 
 // parseTrustedProxies parse Engine.trustedProxies to Engine.trustedCIDRs

--- a/gin.go
+++ b/gin.go
@@ -416,23 +416,24 @@ func (engine *Engine) isTrustedProxy(ip net.IP) bool {
 }
 
 func (engine *Engine) validateHeader(header string) (clientIP string, valid bool) {
-	if header != "" {
-		items := strings.Split(header, ",")
-		for i := len(items) - 1; i >= 0; i-- {
-			ipStr := strings.TrimSpace(items[i])
-			ip := net.ParseIP(ipStr)
-			if ip == nil {
-				return "", false
-			}
+	if header == "" {
+		return "", false
+	}
+	items := strings.Split(header, ",")
+	for i := len(items) - 1; i >= 0; i-- {
+		ipStr := strings.TrimSpace(items[i])
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			return "", false
+		}
 
-			// X-Forwarded-For is appended by proxy
-			// Check IPs in reverse order and stop when find untrusted proxy
-			if (i == 0) || (!engine.isTrustedProxy(ip)) {
-				return ipStr, true
-			}
+		// X-Forwarded-For is appended by proxy
+		// Check IPs in reverse order and stop when find untrusted proxy
+		if (i == 0) || (!engine.isTrustedProxy(ip)) {
+			return ipStr, true
 		}
 	}
-	return "", false
+	return
 }
 
 // parseTrustedProxies parse Engine.trustedProxies to Engine.trustedCIDRs

--- a/gin_test.go
+++ b/gin_test.go
@@ -678,8 +678,16 @@ func TestEngineValidateHeader(t *testing.T) {
 	}
 
 	{
-		// illegal header
+		// normal header with illegal element
 		header := "123.123.123.123, 30.30.30.30, 256.255.255.255"
+		ip, ok := e.validateHeader(header)
+		assert.False(t, ok)
+		assert.Empty(t, ip)
+	}
+
+	{
+		// illegal header
+		header := "foo/bar"
 		ip, ok := e.validateHeader(header)
 		assert.False(t, ok)
 		assert.Empty(t, ip)

--- a/gin_test.go
+++ b/gin_test.go
@@ -665,7 +665,7 @@ func TestEngineValidateHeader(t *testing.T) {
 		// normal legal header
 		header := "123.123.123.123, 30.30.30.30, 40.40.40.40"
 		ip, ok := e.validateHeader(header)
-		assert.Equal(t, true, ok)
+		assert.True(t, ok)
 		assert.Equal(t, "123.123.123.123", ip)
 	}
 
@@ -673,7 +673,7 @@ func TestEngineValidateHeader(t *testing.T) {
 		// partial legal header
 		header := "50.50.50.50, 123.123.123.123, 30.30.30.30"
 		ip, ok := e.validateHeader(header)
-		assert.Equal(t, true, ok)
+		assert.True(t, ok)
 		assert.Equal(t, "123.123.123.123", ip)
 	}
 
@@ -681,7 +681,15 @@ func TestEngineValidateHeader(t *testing.T) {
 		// illegal header
 		header := "123.123.123.123, 30.30.30.30, 256.255.255.255"
 		ip, ok := e.validateHeader(header)
-		assert.Equal(t, false, ok)
+		assert.False(t, ok)
+		assert.Empty(t, ip)
+	}
+
+	{
+		// empty header
+		header := ""
+		ip, ok := e.validateHeader(header)
+		assert.False(t, ok)
 		assert.Empty(t, ip)
 	}
 }

--- a/gin_test.go
+++ b/gin_test.go
@@ -678,16 +678,8 @@ func TestEngineValidateHeader(t *testing.T) {
 	}
 
 	{
-		// normal header with illegal element
-		header := "123.123.123.123, 30.30.30.30, 256.255.255.255"
-		ip, ok := e.validateHeader(header)
-		assert.False(t, ok)
-		assert.Empty(t, ip)
-	}
-
-	{
 		// illegal header
-		header := "foo/bar"
+		header := "123.123.123.123, 30.30.30.30, 256.255.255.255"
 		ip, ok := e.validateHeader(header)
 		assert.False(t, ok)
 		assert.Empty(t, ip)

--- a/gin_test.go
+++ b/gin_test.go
@@ -657,5 +657,34 @@ func assertRoutePresent(t *testing.T, gotRoutes RoutesInfo, wantRoute RouteInfo)
 	t.Errorf("route not found: %v", wantRoute)
 }
 
+func TestEngineValidateHeader(t *testing.T) {
+	_, e := CreateTestContext(httptest.NewRecorder())
+	_ = e.SetTrustedProxies([]string{"30.30.30.30", "40.40.40.40"})
+
+	{
+		// normal legal header
+		header := "123.123.123.123, 30.30.30.30, 40.40.40.40"
+		ip, ok := e.validateHeader(header)
+		assert.Equal(t, true, ok)
+		assert.Equal(t, "123.123.123.123", ip)
+	}
+
+	{
+		// partial legal header
+		header := "50.50.50.50, 123.123.123.123, 30.30.30.30"
+		ip, ok := e.validateHeader(header)
+		assert.Equal(t, true, ok)
+		assert.Equal(t, "123.123.123.123", ip)
+	}
+
+	{
+		// illegal header
+		header := "123.123.123.123, 30.30.30.30, 256.255.255.255"
+		ip, ok := e.validateHeader(header)
+		assert.Equal(t, false, ok)
+		assert.Empty(t, ip)
+	}
+}
+
 func handlerTest1(c *Context) {}
 func handlerTest2(c *Context) {}

--- a/routergroup.go
+++ b/routergroup.go
@@ -14,6 +14,13 @@ import (
 var (
 	// reg match english letters for http method name
 	regEnLetter = regexp.MustCompile("^[A-Z]+$")
+
+	// anyMethods for RouterGroup Any method
+	anyMethods = []string{
+		http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch,
+		http.MethodHead, http.MethodOptions, http.MethodDelete, http.MethodConnect,
+		http.MethodTrace,
+	}
 )
 
 // IRouter defines all router handle interface includes single and group router.
@@ -136,15 +143,10 @@ func (group *RouterGroup) HEAD(relativePath string, handlers ...HandlerFunc) IRo
 // Any registers a route that matches all the HTTP methods.
 // GET, POST, PUT, PATCH, HEAD, OPTIONS, DELETE, CONNECT, TRACE.
 func (group *RouterGroup) Any(relativePath string, handlers ...HandlerFunc) IRoutes {
-	group.handle(http.MethodGet, relativePath, handlers)
-	group.handle(http.MethodPost, relativePath, handlers)
-	group.handle(http.MethodPut, relativePath, handlers)
-	group.handle(http.MethodPatch, relativePath, handlers)
-	group.handle(http.MethodHead, relativePath, handlers)
-	group.handle(http.MethodOptions, relativePath, handlers)
-	group.handle(http.MethodDelete, relativePath, handlers)
-	group.handle(http.MethodConnect, relativePath, handlers)
-	group.handle(http.MethodTrace, relativePath, handlers)
+	for _, method := range anyMethods {
+		group.handle(method, relativePath, handlers)
+	}
+
 	return group.returnObj()
 }
 


### PR DESCRIPTION
Did some refactors about `Context.RemoteIP()`.

When I just wanna get the remote address, it's not important to know if it's trusted. `RemoteIP()` returns `string` directly so that I don't need to do more works to handle its returned value.

The `RemoteAddr` cannot be maliciously modified in common situations, so its value is correct. Then, it's unnecessary to know if it's trusted when I wanna to get the remote address, it should be checked in parsing `X-Forwarded-For` header.