### PR TITLE
prettify error message for catch-all conflict with existing path segment

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -349,7 +349,12 @@ func (n *node) insertChild(path string, fullPath string, handlers HandlersChain)
 		}
 
 		if len(n.path) > 0 && n.path[len(n.path)-1] == '/' {
-			panic("catch-all conflicts with existing handle for the path segment root in path '" + fullPath + "'")
+			pathSeg := strings.SplitN(n.children[0].path, "/", 2)[0]
+			panic("catch-all wildcard '" + path +
+				"' in new path '" + fullPath +
+				"' conflicts with existing path segment '" + pathSeg +
+				"' in existing prefix '" + n.path + pathSeg +
+				"'")
 		}
 
 		// currently fixed width 1 for '/'


### PR DESCRIPTION
Hi, I find that the conflict message for catch-all wildcard with existing path segment is not clear enough during my use of gin framework, i.e. it only suggests that there is a conflict, but gives no hint about where the conflict is.

This PR will give a more user-friendly error message when users are trying to add two conflict routes as bellow:

```go
r := New()
r.GET("/foo/bar", nil)
r.GET("/foo/*bar", nil)
```

Error message before:
```
catch-all conflicts with existing handle for the path segment root in path '/foo/*bar' 
```
Error message now: 
```
catch-all wildcard '*bar' in new path '/foo/*bar' conflicts with existing path segment 'bar' in existing prefix '/foo/bar'
```