### PR TITLE
Add iterator for exclusive key/value pairs in context

### DIFF
--- a/context.go
+++ b/context.go
@@ -260,6 +260,16 @@ func (c *Context) Get(key string) (value interface{}, exists bool) {
 	return
 }
 
+// Do iterates the key/value pairs stored in c.Keys and executes the callback.
+// It does nothing if c.Keys is nil or empty.
+func (c *Context) Do(fn func(key string, value interface{})) {
+	c.mu.RLock()
+	for k, v := range c.Keys {
+		fn(k,v)
+	} 
+	c.mu.RUnlock()
+}
+
 // MustGet returns the value for the given key if it exists, otherwise it panics.
 func (c *Context) MustGet(key string) interface{} {
 	if value, exists := c.Get(key); exists {

--- a/context.go
+++ b/context.go
@@ -260,16 +260,6 @@ func (c *Context) Get(key string) (value interface{}, exists bool) {
 	return
 }
 
-// Do iterates the key/value pairs stored in c.Keys and executes the callback.
-// It does nothing if c.Keys is nil or empty.
-func (c *Context) Do(fn func(key string, value interface{})) {
-	c.mu.RLock()
-	for k, v := range c.Keys {
-		fn(k,v)
-	} 
-	c.mu.RUnlock()
-}
-
 // MustGet returns the value for the given key if it exists, otherwise it panics.
 func (c *Context) MustGet(key string) interface{} {
 	if value, exists := c.Get(key); exists {
@@ -380,6 +370,16 @@ func (c *Context) GetStringMapStringSlice(key string) (smss map[string][]string)
 		smss, _ = val.(map[string][]string)
 	}
 	return
+}
+
+// Iterate iterates the key/value pairs stored in c.Keys and executes the callback.
+// It does nothing if c.Keys is nil or empty.
+func (c *Context) Iterate(fn func(key string, value interface{})) {
+	c.mu.RLock()
+	for k, v := range c.Keys {
+		fn(k, v)
+	}
+	c.mu.RUnlock()
 }
 
 /************************************/

--- a/context_test.go
+++ b/context_test.go
@@ -222,6 +222,22 @@ func TestContextSetGetValues(t *testing.T) {
 	assert.Exactly(t, c.MustGet("intInterface").(int), 1)
 }
 
+func TestContextIterate(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.Set("string", "this is a string")
+	c.Set("int32", int32(-42))
+	c.Set("int64", int64(42424242424242))
+	c.Set("uint64", uint64(42))
+	c.Set("float32", float32(4.2))
+	c.Set("float64", 4.2)
+	var a interface{} = 1
+	c.Set("intInterface", a)
+
+	c.Iterate(func(key string, value interface{}) {
+		assert.Exactly(t, c.MustGet(key), value)
+	})
+}
+
 func TestContextGetString(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Set("string", "this is a string")


### PR DESCRIPTION
when attached exclusive tracing info into `gin.Context`,it is much more elegant to get all k/v pairs from c.Keys using iterator. When using c.Keys directly, it's not thread safe.
```go
ctx.Set("request_id","xxx")
ctx.Set("invoker_id","xxx")
...

func dump(ctx *gin.Context) {
    ctx.Iterate(func(k string, v interface{}){
        log.Println(k,v)
    })
}
```

