### PR TITLE
Cant parse encoded url as url param

### DIFF
--- a/tree_test.go
+++ b/tree_test.go
@@ -192,6 +192,7 @@ func TestTreeWildcard(t *testing.T) {
 		"/get/abc/123abg/:param",
 		"/get/abc/123abf/:param",
 		"/get/abc/123abfff/:param",
+		"/get/address/:address",
 	}
 	for _, route := range routes {
 		tree.addRoute(route, fakeHandler(route))
@@ -315,6 +316,7 @@ func TestTreeWildcard(t *testing.T) {
 		{"/get/abc/123abg/test", false, "/get/abc/123abg/:param", Params{Param{Key: "param", Value: "test"}}},
 		{"/get/abc/123abf/testss", false, "/get/abc/123abf/:param", Params{Param{Key: "param", Value: "testss"}}},
 		{"/get/abc/123abfff/te", false, "/get/abc/123abfff/:param", Params{Param{Key: "param", Value: "te"}}},
+		{"/get/address/B", false, "/get/address/:address", Params{{Key: "address", Value: "B"}}},
 	})
 
 	checkPriorities(t, tree)

--- a/tree_test.go
+++ b/tree_test.go
@@ -317,6 +317,8 @@ func TestTreeWildcard(t *testing.T) {
 		{"/get/abc/123abf/testss", false, "/get/abc/123abf/:param", Params{Param{Key: "param", Value: "testss"}}},
 		{"/get/abc/123abfff/te", false, "/get/abc/123abfff/:param", Params{Param{Key: "param", Value: "te"}}},
 		{"/get/address/B", false, "/get/address/:address", Params{{Key: "address", Value: "B"}}},
+		{"/get/address/https://nono.de", false, "/get/address/:address", Params{{Key: "address", Value: "https://nono.de"}}},
+		{"/get/address/https%3A%2F%2Fnono.de", false, "/get/address/:address", Params{{Key: "address", Value: "https://nono.de"}}},
 	})
 
 	checkPriorities(t, tree)


### PR DESCRIPTION
this is a demo of the *bug* i face - is this not cached yet or is there some sort of wildcard?

upstream issue: https://github.com/woodpecker-ci/woodpecker/issues/520