### PR TITLE
Update `DefaultQuery` method to accept interface as a default value instead of string.

### DIFF
--- a/context.go
+++ b/context.go
@@ -415,7 +415,7 @@ func (c *Context) Query(key string) (value string) {
 //     c.DefaultQuery("name", "unknown") == "Manu"
 //     c.DefaultQuery("id", "none") == "none"
 //     c.DefaultQuery("lastname", "none") == ""
-func (c *Context) DefaultQuery(key, defaultValue string) string {
+func (c *Context) DefaultQuery(key, defaultValue interface{}) interface{} {
 	if value, ok := c.GetQuery(key); ok {
 		return value
 	}


### PR DESCRIPTION
This PR provides a simple change in a `DefaultQuery()` method, in which makes this method support any types of default values comes through the route's query. Without needing to convert the returned string to the value we want.

