### PR TITLE
test(route): expose performRequest func

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -2036,8 +2036,8 @@ func TestRaceParamsContextCopy(t *testing.T) {
 			}(c.Copy(), c.Param("name"))
 		})
 	}
-	performRequest(router, "GET", "/name1/api")
-	performRequest(router, "GET", "/name2/api")
+	PerformRequest(router, "GET", "/name1/api")
+	PerformRequest(router, "GET", "/name2/api")
 	wg.Wait()
 }
 

--- a/gin_test.go
+++ b/gin_test.go
@@ -395,7 +395,6 @@ func TestNoMethodWithoutGlobalHandlers(t *testing.T) {
 }
 
 func TestRebuild404Handlers(t *testing.T) {
-
 }
 
 func TestNoMethodWithGlobalHandlers(t *testing.T) {
@@ -491,7 +490,7 @@ func TestEngineHandleContext(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		w := performRequest(r, "GET", "/")
+		w := PerformRequest(r, "GET", "/")
 		assert.Equal(t, 301, w.Code)
 	})
 }
@@ -524,7 +523,7 @@ func TestEngineHandleContextManyReEntries(t *testing.T) {
 	})
 
 	assert.NotPanics(t, func() {
-		w := performRequest(r, "GET", "/"+strconv.Itoa(expectValue-1)) // include 0 value
+		w := PerformRequest(r, "GET", "/"+strconv.Itoa(expectValue-1)) // include 0 value
 		assert.Equal(t, 200, w.Code)
 		assert.Equal(t, expectValue, w.Body.Len())
 	})
@@ -636,7 +635,6 @@ func TestPrepareTrustedCIRDsWith(t *testing.T) {
 		assert.Nil(t, r.trustedCIDRs)
 		assert.Nil(t, err)
 	}
-
 }
 
 func parseCIDR(cidr string) *net.IPNet {

--- a/githubapi_test.go
+++ b/githubapi_test.go
@@ -302,7 +302,7 @@ func TestShouldBindUri(t *testing.T) {
 	})
 
 	path, _ := exampleFromPath("/rest/:name/:id")
-	w := performRequest(router, http.MethodGet, path)
+	w := PerformRequest(router, http.MethodGet, path)
 	assert.Equal(t, "ShouldBindUri test OK", w.Body.String())
 	assert.Equal(t, http.StatusOK, w.Code)
 }
@@ -324,7 +324,7 @@ func TestBindUri(t *testing.T) {
 	})
 
 	path, _ := exampleFromPath("/rest/:name/:id")
-	w := performRequest(router, http.MethodGet, path)
+	w := PerformRequest(router, http.MethodGet, path)
 	assert.Equal(t, "BindUri test OK", w.Body.String())
 	assert.Equal(t, http.StatusOK, w.Code)
 }
@@ -342,7 +342,7 @@ func TestBindUriError(t *testing.T) {
 	})
 
 	path1, _ := exampleFromPath("/new/rest/:num")
-	w1 := performRequest(router, http.MethodGet, path1)
+	w1 := PerformRequest(router, http.MethodGet, path1)
 	assert.Equal(t, http.StatusBadRequest, w1.Code)
 }
 
@@ -358,7 +358,7 @@ func TestRaceContextCopy(t *testing.T) {
 		go readWriteKeys(c.Copy())
 		c.String(http.StatusOK, "run OK, no panics")
 	})
-	w := performRequest(router, http.MethodGet, "/test/copy/race")
+	w := PerformRequest(router, http.MethodGet, "/test/copy/race")
 	assert.Equal(t, "run OK, no panics", w.Body.String())
 }
 
@@ -389,7 +389,7 @@ func TestGithubAPI(t *testing.T) {
 
 	for _, route := range githubAPI {
 		path, values := exampleFromPath(route.path)
-		w := performRequest(router, route.method, path)
+		w := PerformRequest(router, route.method, path)
 
 		// TEST
 		assert.Contains(t, w.Body.String(), "\"status\":\"good\"")

--- a/logger_test.go
+++ b/logger_test.go
@@ -31,7 +31,7 @@ func TestLogger(t *testing.T) {
 	router.HEAD("/example", func(c *Context) {})
 	router.OPTIONS("/example", func(c *Context) {})
 
-	performRequest(router, "GET", "/example?a=100")
+	PerformRequest(router, "GET", "/example?a=100")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "GET")
 	assert.Contains(t, buffer.String(), "/example")
@@ -41,43 +41,43 @@ func TestLogger(t *testing.T) {
 	// like integration tests because they test the whole logging process rather
 	// than individual functions.  Im not sure where these should go.
 	buffer.Reset()
-	performRequest(router, "POST", "/example")
+	PerformRequest(router, "POST", "/example")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "POST")
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	performRequest(router, "PUT", "/example")
+	PerformRequest(router, "PUT", "/example")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "PUT")
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	performRequest(router, "DELETE", "/example")
+	PerformRequest(router, "DELETE", "/example")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "DELETE")
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	performRequest(router, "PATCH", "/example")
+	PerformRequest(router, "PATCH", "/example")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "PATCH")
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	performRequest(router, "HEAD", "/example")
+	PerformRequest(router, "HEAD", "/example")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "HEAD")
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	performRequest(router, "OPTIONS", "/example")
+	PerformRequest(router, "OPTIONS", "/example")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "OPTIONS")
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	performRequest(router, "GET", "/notfound")
+	PerformRequest(router, "GET", "/notfound")
 	assert.Contains(t, buffer.String(), "404")
 	assert.Contains(t, buffer.String(), "GET")
 	assert.Contains(t, buffer.String(), "/notfound")
@@ -95,7 +95,7 @@ func TestLoggerWithConfig(t *testing.T) {
 	router.HEAD("/example", func(c *Context) {})
 	router.OPTIONS("/example", func(c *Context) {})
 
-	performRequest(router, "GET", "/example?a=100")
+	PerformRequest(router, "GET", "/example?a=100")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "GET")
 	assert.Contains(t, buffer.String(), "/example")
@@ -105,43 +105,43 @@ func TestLoggerWithConfig(t *testing.T) {
 	// like integration tests because they test the whole logging process rather
 	// than individual functions.  Im not sure where these should go.
 	buffer.Reset()
-	performRequest(router, "POST", "/example")
+	PerformRequest(router, "POST", "/example")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "POST")
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	performRequest(router, "PUT", "/example")
+	PerformRequest(router, "PUT", "/example")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "PUT")
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	performRequest(router, "DELETE", "/example")
+	PerformRequest(router, "DELETE", "/example")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "DELETE")
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	performRequest(router, "PATCH", "/example")
+	PerformRequest(router, "PATCH", "/example")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "PATCH")
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	performRequest(router, "HEAD", "/example")
+	PerformRequest(router, "HEAD", "/example")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "HEAD")
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	performRequest(router, "OPTIONS", "/example")
+	PerformRequest(router, "OPTIONS", "/example")
 	assert.Contains(t, buffer.String(), "200")
 	assert.Contains(t, buffer.String(), "OPTIONS")
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	performRequest(router, "GET", "/notfound")
+	PerformRequest(router, "GET", "/notfound")
 	assert.Contains(t, buffer.String(), "404")
 	assert.Contains(t, buffer.String(), "GET")
 	assert.Contains(t, buffer.String(), "/notfound")
@@ -169,7 +169,7 @@ func TestLoggerWithFormatter(t *testing.T) {
 		)
 	}))
 	router.GET("/example", func(c *Context) {})
-	performRequest(router, "GET", "/example?a=100")
+	PerformRequest(router, "GET", "/example?a=100")
 
 	// output test
 	assert.Contains(t, buffer.String(), "[FORMATTER TEST]")
@@ -209,7 +209,7 @@ func TestLoggerWithConfigFormatting(t *testing.T) {
 		c.Request.Header.Set("X-Forwarded-For", "20.20.20.20")
 		gotKeys = c.Keys
 	})
-	performRequest(router, "GET", "/example?a=100")
+	PerformRequest(router, "GET", "/example?a=100")
 
 	// output test
 	assert.Contains(t, buffer.String(), "[FORMATTER TEST]")
@@ -228,7 +228,6 @@ func TestLoggerWithConfigFormatting(t *testing.T) {
 	assert.Equal(t, "/example?a=100", gotParam.Path)
 	assert.Empty(t, gotParam.ErrorMessage)
 	assert.Equal(t, gotKeys, gotParam.Keys)
-
 }
 
 func TestDefaultLogFormatter(t *testing.T) {
@@ -282,7 +281,6 @@ func TestDefaultLogFormatter(t *testing.T) {
 
 	assert.Equal(t, "[GIN] 2018/12/07 - 09:11:42 |\x1b[97;42m 200 \x1b[0m|            5s |     20.20.20.20 |\x1b[97;44m GET     \x1b[0m \"/\"\n", defaultLogFormatter(termTrueParam))
 	assert.Equal(t, "[GIN] 2018/12/07 - 09:11:42 |\x1b[97;42m 200 \x1b[0m|    2743h29m3s |     20.20.20.20 |\x1b[97;44m GET     \x1b[0m \"/\"\n", defaultLogFormatter(termTrueLongDurationParam))
-
 }
 
 func TestColorForMethod(t *testing.T) {
@@ -369,15 +367,15 @@ func TestErrorLogger(t *testing.T) {
 		c.String(http.StatusInternalServerError, "hola!")
 	})
 
-	w := performRequest(router, "GET", "/error")
+	w := PerformRequest(router, "GET", "/error")
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "{\"error\":\"this is an error\"}", w.Body.String())
 
-	w = performRequest(router, "GET", "/abort")
+	w = PerformRequest(router, "GET", "/abort")
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	assert.Equal(t, "{\"error\":\"no authorized\"}", w.Body.String())
 
-	w = performRequest(router, "GET", "/print")
+	w = PerformRequest(router, "GET", "/print")
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Equal(t, "hola!{\"error\":\"this is an error\"}", w.Body.String())
 }
@@ -389,11 +387,11 @@ func TestLoggerWithWriterSkippingPaths(t *testing.T) {
 	router.GET("/logged", func(c *Context) {})
 	router.GET("/skipped", func(c *Context) {})
 
-	performRequest(router, "GET", "/logged")
+	PerformRequest(router, "GET", "/logged")
 	assert.Contains(t, buffer.String(), "200")
 
 	buffer.Reset()
-	performRequest(router, "GET", "/skipped")
+	PerformRequest(router, "GET", "/skipped")
 	assert.Contains(t, buffer.String(), "")
 }
 
@@ -407,11 +405,11 @@ func TestLoggerWithConfigSkippingPaths(t *testing.T) {
 	router.GET("/logged", func(c *Context) {})
 	router.GET("/skipped", func(c *Context) {})
 
-	performRequest(router, "GET", "/logged")
+	PerformRequest(router, "GET", "/logged")
 	assert.Contains(t, buffer.String(), "200")
 
 	buffer.Reset()
-	performRequest(router, "GET", "/skipped")
+	PerformRequest(router, "GET", "/skipped")
 	assert.Contains(t, buffer.String(), "")
 }
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -35,7 +35,7 @@ func TestMiddlewareGeneralCase(t *testing.T) {
 		signature += " XX "
 	})
 	// RUN
-	w := performRequest(router, "GET", "/")
+	w := PerformRequest(router, "GET", "/")
 
 	// TEST
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -71,7 +71,7 @@ func TestMiddlewareNoRoute(t *testing.T) {
 		signature += " X "
 	})
 	// RUN
-	w := performRequest(router, "GET", "/")
+	w := PerformRequest(router, "GET", "/")
 
 	// TEST
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -108,7 +108,7 @@ func TestMiddlewareNoMethodEnabled(t *testing.T) {
 		signature += " XX "
 	})
 	// RUN
-	w := performRequest(router, "GET", "/")
+	w := PerformRequest(router, "GET", "/")
 
 	// TEST
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
@@ -149,7 +149,7 @@ func TestMiddlewareNoMethodDisabled(t *testing.T) {
 	})
 
 	// RUN
-	w := performRequest(router, "GET", "/")
+	w := PerformRequest(router, "GET", "/")
 
 	// TEST
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -175,7 +175,7 @@ func TestMiddlewareAbort(t *testing.T) {
 	})
 
 	// RUN
-	w := performRequest(router, "GET", "/")
+	w := PerformRequest(router, "GET", "/")
 
 	// TEST
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
@@ -190,14 +190,13 @@ func TestMiddlewareAbortHandlersChainAndNext(t *testing.T) {
 		c.Next()
 		c.AbortWithStatus(http.StatusGone)
 		signature += "B"
-
 	})
 	router.GET("/", func(c *Context) {
 		signature += "C"
 		c.Next()
 	})
 	// RUN
-	w := performRequest(router, "GET", "/")
+	w := PerformRequest(router, "GET", "/")
 
 	// TEST
 	assert.Equal(t, http.StatusGone, w.Code)
@@ -220,7 +219,7 @@ func TestMiddlewareFailHandlersChain(t *testing.T) {
 		signature += "C"
 	})
 	// RUN
-	w := performRequest(router, "GET", "/")
+	w := PerformRequest(router, "GET", "/")
 
 	// TEST
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
@@ -247,7 +246,7 @@ func TestMiddlewareWrite(t *testing.T) {
 		})
 	})
 
-	w := performRequest(router, "GET", "/")
+	w := PerformRequest(router, "GET", "/")
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, strings.Replace("hola\n<map><foo>bar</foo></map>{\"foo\":\"bar\"}{\"foo\":\"bar\"}event:test\ndata:message\n\n", " ", "", -1), strings.Replace(w.Body.String(), " ", "", -1))

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -27,7 +27,7 @@ func TestPanicClean(t *testing.T) {
 		panic("Oupps, Houston, we have a problem")
 	})
 	// RUN
-	w := performRequest(router, "GET", "/recovery",
+	w := PerformRequest(router, "GET", "/recovery",
 		header{
 			Key:   "Host",
 			Value: "www.google.com",
@@ -57,7 +57,7 @@ func TestPanicInHandler(t *testing.T) {
 		panic("Oupps, Houston, we have a problem")
 	})
 	// RUN
-	w := performRequest(router, "GET", "/recovery")
+	w := PerformRequest(router, "GET", "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, buffer.String(), "panic recovered")
@@ -68,7 +68,7 @@ func TestPanicInHandler(t *testing.T) {
 	// Debug mode prints the request
 	SetMode(DebugMode)
 	// RUN
-	w = performRequest(router, "GET", "/recovery")
+	w = PerformRequest(router, "GET", "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, buffer.String(), "GET /recovery")
@@ -85,7 +85,7 @@ func TestPanicWithAbort(t *testing.T) {
 		panic("Oupps, Houston, we have a problem")
 	})
 	// RUN
-	w := performRequest(router, "GET", "/recovery")
+	w := PerformRequest(router, "GET", "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -122,7 +122,6 @@ func TestPanicWithBrokenPipe(t *testing.T) {
 
 	for errno, expectMsg := range expectMsgs {
 		t.Run(expectMsg, func(t *testing.T) {
-
 			var buf bytes.Buffer
 
 			router := New()
@@ -137,7 +136,7 @@ func TestPanicWithBrokenPipe(t *testing.T) {
 				panic(e)
 			})
 			// RUN
-			w := performRequest(router, "GET", "/recovery")
+			w := PerformRequest(router, "GET", "/recovery")
 			// TEST
 			assert.Equal(t, expectCode, w.Code)
 			assert.Contains(t, strings.ToLower(buf.String()), expectMsg)
@@ -158,7 +157,7 @@ func TestCustomRecoveryWithWriter(t *testing.T) {
 		panic("Oupps, Houston, we have a problem")
 	})
 	// RUN
-	w := performRequest(router, "GET", "/recovery")
+	w := PerformRequest(router, "GET", "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, buffer.String(), "panic recovered")
@@ -169,7 +168,7 @@ func TestCustomRecoveryWithWriter(t *testing.T) {
 	// Debug mode prints the request
 	SetMode(DebugMode)
 	// RUN
-	w = performRequest(router, "GET", "/recovery")
+	w = PerformRequest(router, "GET", "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, buffer.String(), "GET /recovery")
@@ -193,7 +192,7 @@ func TestCustomRecovery(t *testing.T) {
 		panic("Oupps, Houston, we have a problem")
 	})
 	// RUN
-	w := performRequest(router, "GET", "/recovery")
+	w := PerformRequest(router, "GET", "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, buffer.String(), "panic recovered")
@@ -204,7 +203,7 @@ func TestCustomRecovery(t *testing.T) {
 	// Debug mode prints the request
 	SetMode(DebugMode)
 	// RUN
-	w = performRequest(router, "GET", "/recovery")
+	w = PerformRequest(router, "GET", "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, buffer.String(), "GET /recovery")
@@ -228,7 +227,7 @@ func TestRecoveryWithWriterWithCustomRecovery(t *testing.T) {
 		panic("Oupps, Houston, we have a problem")
 	})
 	// RUN
-	w := performRequest(router, "GET", "/recovery")
+	w := PerformRequest(router, "GET", "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, buffer.String(), "panic recovered")
@@ -239,7 +238,7 @@ func TestRecoveryWithWriterWithCustomRecovery(t *testing.T) {
 	// Debug mode prints the request
 	SetMode(DebugMode)
 	// RUN
-	w = performRequest(router, "GET", "/recovery")
+	w = PerformRequest(router, "GET", "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, buffer.String(), "GET /recovery")

--- a/routergroup_test.go
+++ b/routergroup_test.go
@@ -80,11 +80,11 @@ func performRequestInGroup(t *testing.T, method string) {
 		panic("unknown method")
 	}
 
-	w := performRequest(router, method, "/v1/login/test")
+	w := PerformRequest(router, method, "/v1/login/test")
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, "the method was "+method+" and index 3", w.Body.String())
 
-	w = performRequest(router, method, "/v1/test")
+	w = PerformRequest(router, method, "/v1/test")
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, "the method was "+method+" and index 1", w.Body.String())
 }

--- a/routes_test.go
+++ b/routes_test.go
@@ -21,7 +21,8 @@ type header struct {
 	Value string
 }
 
-func performRequest(r http.Handler, method, path string, headers ...header) *httptest.ResponseRecorder {
+// PerformRequest for testing gin router.
+func PerformRequest(r http.Handler, method, path string, headers ...header) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(method, path, nil)
 	for _, h := range headers {
 		req.Header.Add(h.Key, h.Value)
@@ -42,11 +43,11 @@ func testRouteOK(method string, t *testing.T) {
 		passed = true
 	})
 
-	w := performRequest(r, method, "/test")
+	w := PerformRequest(r, method, "/test")
 	assert.True(t, passed)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	performRequest(r, method, "/test2")
+	PerformRequest(r, method, "/test2")
 	assert.True(t, passedAny)
 }
 
@@ -58,7 +59,7 @@ func testRouteNotOK(method string, t *testing.T) {
 		passed = true
 	})
 
-	w := performRequest(router, method, "/test")
+	w := PerformRequest(router, method, "/test")
 
 	assert.False(t, passed)
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -79,7 +80,7 @@ func testRouteNotOK2(method string, t *testing.T) {
 		passed = true
 	})
 
-	w := performRequest(router, method, "/test")
+	w := PerformRequest(router, method, "/test")
 
 	assert.False(t, passed)
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
@@ -99,7 +100,7 @@ func TestRouterMethod(t *testing.T) {
 		c.String(http.StatusOK, "sup3")
 	})
 
-	w := performRequest(router, http.MethodPut, "/hey")
+	w := PerformRequest(router, http.MethodPut, "/hey")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "called", w.Body.String())
@@ -150,50 +151,50 @@ func TestRouteRedirectTrailingSlash(t *testing.T) {
 	router.POST("/path3", func(c *Context) {})
 	router.PUT("/path4/", func(c *Context) {})
 
-	w := performRequest(router, http.MethodGet, "/path/")
+	w := PerformRequest(router, http.MethodGet, "/path/")
 	assert.Equal(t, "/path", w.Header().Get("Location"))
 	assert.Equal(t, http.StatusMovedPermanently, w.Code)
 
-	w = performRequest(router, http.MethodGet, "/path2")
+	w = PerformRequest(router, http.MethodGet, "/path2")
 	assert.Equal(t, "/path2/", w.Header().Get("Location"))
 	assert.Equal(t, http.StatusMovedPermanently, w.Code)
 
-	w = performRequest(router, http.MethodPost, "/path3/")
+	w = PerformRequest(router, http.MethodPost, "/path3/")
 	assert.Equal(t, "/path3", w.Header().Get("Location"))
 	assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
 
-	w = performRequest(router, http.MethodPut, "/path4")
+	w = PerformRequest(router, http.MethodPut, "/path4")
 	assert.Equal(t, "/path4/", w.Header().Get("Location"))
 	assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
 
-	w = performRequest(router, http.MethodGet, "/path")
+	w = PerformRequest(router, http.MethodGet, "/path")
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	w = performRequest(router, http.MethodGet, "/path2/")
+	w = PerformRequest(router, http.MethodGet, "/path2/")
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	w = performRequest(router, http.MethodPost, "/path3")
+	w = PerformRequest(router, http.MethodPost, "/path3")
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	w = performRequest(router, http.MethodPut, "/path4/")
+	w = PerformRequest(router, http.MethodPut, "/path4/")
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	w = performRequest(router, http.MethodGet, "/path2", header{Key: "X-Forwarded-Prefix", Value: "/api"})
+	w = PerformRequest(router, http.MethodGet, "/path2", header{Key: "X-Forwarded-Prefix", Value: "/api"})
 	assert.Equal(t, "/api/path2/", w.Header().Get("Location"))
 	assert.Equal(t, 301, w.Code)
 
-	w = performRequest(router, http.MethodGet, "/path2/", header{Key: "X-Forwarded-Prefix", Value: "/api/"})
+	w = PerformRequest(router, http.MethodGet, "/path2/", header{Key: "X-Forwarded-Prefix", Value: "/api/"})
 	assert.Equal(t, 200, w.Code)
 
 	router.RedirectTrailingSlash = false
 
-	w = performRequest(router, http.MethodGet, "/path/")
+	w = PerformRequest(router, http.MethodGet, "/path/")
 	assert.Equal(t, http.StatusNotFound, w.Code)
-	w = performRequest(router, http.MethodGet, "/path2")
+	w = PerformRequest(router, http.MethodGet, "/path2")
 	assert.Equal(t, http.StatusNotFound, w.Code)
-	w = performRequest(router, http.MethodPost, "/path3/")
+	w = PerformRequest(router, http.MethodPost, "/path3/")
 	assert.Equal(t, http.StatusNotFound, w.Code)
-	w = performRequest(router, http.MethodPut, "/path4")
+	w = PerformRequest(router, http.MethodPut, "/path4")
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
@@ -207,19 +208,19 @@ func TestRouteRedirectFixedPath(t *testing.T) {
 	router.POST("/PATH3", func(c *Context) {})
 	router.POST("/Path4/", func(c *Context) {})
 
-	w := performRequest(router, http.MethodGet, "/PATH")
+	w := PerformRequest(router, http.MethodGet, "/PATH")
 	assert.Equal(t, "/path", w.Header().Get("Location"))
 	assert.Equal(t, http.StatusMovedPermanently, w.Code)
 
-	w = performRequest(router, http.MethodGet, "/path2")
+	w = PerformRequest(router, http.MethodGet, "/path2")
 	assert.Equal(t, "/Path2", w.Header().Get("Location"))
 	assert.Equal(t, http.StatusMovedPermanently, w.Code)
 
-	w = performRequest(router, http.MethodPost, "/path3")
+	w = PerformRequest(router, http.MethodPost, "/path3")
 	assert.Equal(t, "/PATH3", w.Header().Get("Location"))
 	assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
 
-	w = performRequest(router, http.MethodPost, "/path4")
+	w = PerformRequest(router, http.MethodPost, "/path4")
 	assert.Equal(t, "/Path4/", w.Header().Get("Location"))
 	assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
 }
@@ -248,7 +249,7 @@ func TestRouteParamsByName(t *testing.T) {
 		assert.False(t, ok)
 	})
 
-	w := performRequest(router, http.MethodGet, "/test/john/smith/is/super/great")
+	w := PerformRequest(router, http.MethodGet, "/test/john/smith/is/super/great")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "john", name)
@@ -281,7 +282,7 @@ func TestRouteParamsByNameWithExtraSlash(t *testing.T) {
 		assert.False(t, ok)
 	})
 
-	w := performRequest(router, http.MethodGet, "//test//john//smith//is//super//great")
+	w := PerformRequest(router, http.MethodGet, "//test//john//smith//is//super//great")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "john", name)
@@ -309,16 +310,16 @@ func TestRouteStaticFile(t *testing.T) {
 	router.Static("/using_static", dir)
 	router.StaticFile("/result", f.Name())
 
-	w := performRequest(router, http.MethodGet, "/using_static/"+filename)
-	w2 := performRequest(router, http.MethodGet, "/result")
+	w := PerformRequest(router, http.MethodGet, "/using_static/"+filename)
+	w2 := PerformRequest(router, http.MethodGet, "/result")
 
 	assert.Equal(t, w, w2)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "Gin Web Framework", w.Body.String())
 	assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
 
-	w3 := performRequest(router, http.MethodHead, "/using_static/"+filename)
-	w4 := performRequest(router, http.MethodHead, "/result")
+	w3 := PerformRequest(router, http.MethodHead, "/using_static/"+filename)
+	w4 := PerformRequest(router, http.MethodHead, "/result")
 
 	assert.Equal(t, w3, w4)
 	assert.Equal(t, http.StatusOK, w3.Code)
@@ -329,7 +330,7 @@ func TestRouteStaticListingDir(t *testing.T) {
 	router := New()
 	router.StaticFS("/", Dir("./", true))
 
-	w := performRequest(router, http.MethodGet, "/")
+	w := PerformRequest(router, http.MethodGet, "/")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "gin.go")
@@ -341,7 +342,7 @@ func TestRouteStaticNoListing(t *testing.T) {
 	router := New()
 	router.Static("/", "./")
 
-	w := performRequest(router, http.MethodGet, "/")
+	w := PerformRequest(router, http.MethodGet, "/")
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 	assert.NotContains(t, w.Body.String(), "gin.go")
@@ -356,7 +357,7 @@ func TestRouterMiddlewareAndStatic(t *testing.T) {
 	})
 	static.Static("/", "./")
 
-	w := performRequest(router, http.MethodGet, "/gin.go")
+	w := PerformRequest(router, http.MethodGet, "/gin.go")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "package gin")
@@ -372,13 +373,13 @@ func TestRouteNotAllowedEnabled(t *testing.T) {
 	router := New()
 	router.HandleMethodNotAllowed = true
 	router.POST("/path", func(c *Context) {})
-	w := performRequest(router, http.MethodGet, "/path")
+	w := PerformRequest(router, http.MethodGet, "/path")
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 
 	router.NoMethod(func(c *Context) {
 		c.String(http.StatusTeapot, "responseText")
 	})
-	w = performRequest(router, http.MethodGet, "/path")
+	w = PerformRequest(router, http.MethodGet, "/path")
 	assert.Equal(t, "responseText", w.Body.String())
 	assert.Equal(t, http.StatusTeapot, w.Code)
 }
@@ -389,7 +390,7 @@ func TestRouteNotAllowedEnabled2(t *testing.T) {
 	// add one methodTree to trees
 	router.addRoute(http.MethodPost, "/", HandlersChain{func(_ *Context) {}})
 	router.GET("/path2", func(c *Context) {})
-	w := performRequest(router, http.MethodPost, "/path2")
+	w := PerformRequest(router, http.MethodPost, "/path2")
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 }
 
@@ -397,13 +398,13 @@ func TestRouteNotAllowedDisabled(t *testing.T) {
 	router := New()
 	router.HandleMethodNotAllowed = false
 	router.POST("/path", func(c *Context) {})
-	w := performRequest(router, http.MethodGet, "/path")
+	w := PerformRequest(router, http.MethodGet, "/path")
 	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	router.NoMethod(func(c *Context) {
 		c.String(http.StatusTeapot, "responseText")
 	})
-	w = performRequest(router, http.MethodGet, "/path")
+	w = PerformRequest(router, http.MethodGet, "/path")
 	assert.Equal(t, "404 page not found", w.Body.String())
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
@@ -423,7 +424,7 @@ func TestRouterNotFoundWithRemoveExtraSlash(t *testing.T) {
 		{"/nope", http.StatusNotFound, ""}, // NotFound
 	}
 	for _, tr := range testRoutes {
-		w := performRequest(router, "GET", tr.route)
+		w := PerformRequest(router, "GET", tr.route)
 		assert.Equal(t, tr.code, w.Code)
 		if w.Code != http.StatusNotFound {
 			assert.Equal(t, tr.location, fmt.Sprint(w.Header().Get("Location")))
@@ -453,7 +454,7 @@ func TestRouterNotFound(t *testing.T) {
 		{"/nope", http.StatusNotFound, ""},                 // NotFound
 	}
 	for _, tr := range testRoutes {
-		w := performRequest(router, http.MethodGet, tr.route)
+		w := PerformRequest(router, http.MethodGet, tr.route)
 		assert.Equal(t, tr.code, w.Code)
 		if w.Code != http.StatusNotFound {
 			assert.Equal(t, tr.location, fmt.Sprint(w.Header().Get("Location")))
@@ -466,20 +467,20 @@ func TestRouterNotFound(t *testing.T) {
 		c.AbortWithStatus(http.StatusNotFound)
 		notFound = true
 	})
-	w := performRequest(router, http.MethodGet, "/nope")
+	w := PerformRequest(router, http.MethodGet, "/nope")
 	assert.Equal(t, http.StatusNotFound, w.Code)
 	assert.True(t, notFound)
 
 	// Test other method than GET (want 307 instead of 301)
 	router.PATCH("/path", func(c *Context) {})
-	w = performRequest(router, http.MethodPatch, "/path/")
+	w = PerformRequest(router, http.MethodPatch, "/path/")
 	assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
 	assert.Equal(t, "map[Location:[/path]]", fmt.Sprint(w.Header()))
 
 	// Test special case where no node for the prefix "/" exists
 	router = New()
 	router.GET("/a", func(c *Context) {})
-	w = performRequest(router, http.MethodGet, "/")
+	w = PerformRequest(router, http.MethodGet, "/")
 	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	// Reproduction test for the bug of issue #2843
@@ -492,9 +493,9 @@ func TestRouterNotFound(t *testing.T) {
 	router.GET("/logout", func(c *Context) {
 		c.String(200, "logout")
 	})
-	w = performRequest(router, http.MethodGet, "/login")
+	w = PerformRequest(router, http.MethodGet, "/login")
 	assert.Equal(t, "login", w.Body.String())
-	w = performRequest(router, http.MethodGet, "/logout")
+	w = PerformRequest(router, http.MethodGet, "/logout")
 	assert.Equal(t, "logout", w.Body.String())
 }
 
@@ -505,10 +506,10 @@ func TestRouterStaticFSNotFound(t *testing.T) {
 		c.String(404, "non existent")
 	})
 
-	w := performRequest(router, http.MethodGet, "/nonexistent")
+	w := PerformRequest(router, http.MethodGet, "/nonexistent")
 	assert.Equal(t, "non existent", w.Body.String())
 
-	w = performRequest(router, http.MethodHead, "/nonexistent")
+	w = PerformRequest(router, http.MethodHead, "/nonexistent")
 	assert.Equal(t, "non existent", w.Body.String())
 }
 
@@ -518,7 +519,7 @@ func TestRouterStaticFSFileNotFound(t *testing.T) {
 	router.StaticFS("/", http.FileSystem(http.Dir(".")))
 
 	assert.NotPanics(t, func() {
-		performRequest(router, http.MethodGet, "/nonexistent")
+		PerformRequest(router, http.MethodGet, "/nonexistent")
 	})
 }
 
@@ -535,11 +536,11 @@ func TestMiddlewareCalledOnceByRouterStaticFSNotFound(t *testing.T) {
 	router.StaticFS("/", http.FileSystem(http.Dir("/thisreallydoesntexist/")))
 
 	// First access
-	performRequest(router, http.MethodGet, "/nonexistent")
+	PerformRequest(router, http.MethodGet, "/nonexistent")
 	assert.Equal(t, 1, middlewareCalledNum)
 
 	// Second access
-	performRequest(router, http.MethodHead, "/nonexistent")
+	PerformRequest(router, http.MethodHead, "/nonexistent")
 	assert.Equal(t, 2, middlewareCalledNum)
 }
 
@@ -558,7 +559,7 @@ func TestRouteRawPath(t *testing.T) {
 		assert.Equal(t, "222", num)
 	})
 
-	w := performRequest(route, http.MethodPost, "/project/Some%2FOther%2FProject/build/222")
+	w := PerformRequest(route, http.MethodPost, "/project/Some%2FOther%2FProject/build/222")
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
@@ -578,7 +579,7 @@ func TestRouteRawPathNoUnescape(t *testing.T) {
 		assert.Equal(t, "333", num)
 	})
 
-	w := performRequest(route, http.MethodPost, "/project/Some%2FOther%2FProject/build/333")
+	w := PerformRequest(route, http.MethodPost, "/project/Some%2FOther%2FProject/build/333")
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
@@ -589,7 +590,7 @@ func TestRouteServeErrorWithWriteHeader(t *testing.T) {
 		c.Next()
 	})
 
-	w := performRequest(route, http.MethodGet, "/NotFound")
+	w := PerformRequest(route, http.MethodGet, "/NotFound")
 	assert.Equal(t, 421, w.Code)
 	assert.Equal(t, 0, w.Body.Len())
 }
@@ -623,7 +624,7 @@ func TestRouteContextHoldsFullPath(t *testing.T) {
 	}
 
 	for _, route := range routes {
-		w := performRequest(router, http.MethodGet, route)
+		w := PerformRequest(router, http.MethodGet, route)
 		assert.Equal(t, http.StatusOK, w.Code)
 	}
 
@@ -633,6 +634,6 @@ func TestRouteContextHoldsFullPath(t *testing.T) {
 		assert.Equal(t, "", c.FullPath())
 	})
 
-	w := performRequest(router, http.MethodGet, "/not-found")
+	w := PerformRequest(router, http.MethodGet, "/not-found")
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -45,11 +45,11 @@ func TestWrap(t *testing.T) {
 		fmt.Fprint(w, "hola!")
 	}))
 
-	w := performRequest(router, "POST", "/path")
+	w := PerformRequest(router, "POST", "/path")
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Equal(t, "hello", w.Body.String())
 
-	w = performRequest(router, "GET", "/path2")
+	w = PerformRequest(router, "GET", "/path2")
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, "hola!", w.Body.String())
 }
@@ -119,13 +119,13 @@ func TestBindMiddleware(t *testing.T) {
 		called = true
 		value = c.MustGet(BindKey).(*bindTestStruct)
 	})
-	performRequest(router, "GET", "/?foo=hola&bar=10")
+	PerformRequest(router, "GET", "/?foo=hola&bar=10")
 	assert.True(t, called)
 	assert.Equal(t, "hola", value.Foo)
 	assert.Equal(t, 10, value.Bar)
 
 	called = false
-	performRequest(router, "GET", "/?foo=hola&bar=1")
+	PerformRequest(router, "GET", "/?foo=hola&bar=1")
 	assert.False(t, called)
 
 	assert.Panics(t, func() {


### PR DESCRIPTION
There are many packages that need to testing gin router like as below:

https://github.com/gin-contrib/static/blob/0b63c38653d9941a7851807d76e2692655cf6fc7/static_test.go#L16-L21 

So we can expose the `performRequest` function.