### PR TITLE
Removing $ as when you copy the command $ causes an issue in terminal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To install Gin package, you need to install Go and set your Go workspace first.
 1. The first need [Go](https://golang.org/) installed (**version 1.13+ is required**), then you can use the below Go command to install Gin.
 
 ```sh
-$ go get -u github.com/gin-gonic/gin
+go get -u github.com/gin-gonic/gin
 ```
 
 2. Import it in your code:


### PR DESCRIPTION
- Readme Change: Removed the $ sign as when you copy the command it doesn't work in terminal. 

