### PR TITLE
Use the out.Write to write the log content immediately, because the LogFormatter returns a string, the fmt.Fprint is unnecessary here

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -6,6 +6,7 @@ package gin
 
 import (
 	"fmt"
+	"github.com/gin-gonic/gin/internal/bytesconv"
 	"io"
 	"net/http"
 	"os"
@@ -264,7 +265,7 @@ func LoggerWithConfig(conf LoggerConfig) HandlerFunc {
 
 			param.Path = path
 
-			fmt.Fprint(out, formatter(param))
+			out.Write(bytesconv.StringToBytes(formatter(param)))
 		}
 	}
 }


### PR DESCRIPTION
As the title says.