### PR TITLE
Fix logging of IPv6 addresses with scope

### DIFF
--- a/context.go
+++ b/context.go
@@ -760,9 +760,10 @@ func (c *Context) ClientIP() string {
 	// It also checks if the remoteIP is a trusted proxy or not.
 	// In order to perform this validation, it will see if the IP is contained within at least one of the CIDR blocks
 	// defined by Engine.SetTrustedProxies()
+	// If the IP could not be parsed (because, for instance, it is an ipv6 address with a scope), it will return the remote IP as-is.
 	remoteIP := net.ParseIP(c.RemoteIP())
 	if remoteIP == nil {
-		return ""
+		return c.RemoteIP()
 	}
 	trusted := c.engine.isTrustedProxy(remoteIP)
 


### PR DESCRIPTION
The `net.ParseIP()` function does not handle IPv6 addresses with a scope (with `%en0` at the end, for instance).

It may make sense to move to something with better IPv6 support like https://pkg.go.dev/inet.af/netaddr in the future.

See https://tailscale.com/blog/netaddr-new-ip-type-for-go/ for more details.