### PR TITLE
add ResetTrees in gin.go

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -213,6 +213,10 @@ func (engine *Engine) allocateContext() *Context {
 	return &Context{engine: engine, params: &v, skippedNodes: &skippedNodes}
 }
 
+func (e *Engine) ResetTrees() {
+	e.trees = make(methodTrees, 0, 9)
+}
+
 // Delims sets template left and right delims and returns an Engine instance.
 func (engine *Engine) Delims(left, right string) *Engine {
 	engine.delims = render.Delims{Left: left, Right: right}


### PR DESCRIPTION
The function ResetTrees allow us remapping endpoint and handler. 

