### PR TITLE
fix typo

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -296,7 +296,7 @@ func (n *node) insertChild(path string, fullPath string, handlers HandlersChain)
 			break
 		}
 
-		// The wildcard name must not contain ':' and '*'
+		// The wildcard name must only contain one ':' or '*' charactor
 		if !valid {
 			panic("only one wildcard per path segment is allowed, has: '" +
 				wildcard + "' in path '" + fullPath + "'")

--- a/tree.go
+++ b/tree.go
@@ -296,7 +296,7 @@ func (n *node) insertChild(path string, fullPath string, handlers HandlersChain)
 			break
 		}
 
-		// The wildcard name must only contain one ':' or '*' charactor
+		// The wildcard name must only contain one ':' or '*' character
 		if !valid {
 			panic("only one wildcard per path segment is allowed, has: '" +
 				wildcard + "' in path '" + fullPath + "'")


### PR DESCRIPTION
the `findWildcard`  function returns the value of valid. If it is false which means 
the wildcard name must only contain one : or * charactor 
**instead of** not contain : and *
> such as when the path is "/cmd/:tool/:sub" the expect wildcard name is **:tool** so the expect vaild is **true** and only contain one ':'
> if the path is "/cmd/:tool:/:sub" the expect wildcard name is **:tool:** so vaild is **false**


## Update about addChild function
the legal tree node at most has one wildcardChild