### PR TITLE
TextUnmarshaler support for binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2080,6 +2080,67 @@ func ListHandler(s *Service) func(ctx *gin.Context) {
 }
 ```
 
+### Bind form-data request with custom field type
+
+Gin can support the encoding.TextUnmarshaler interface for non-struct types
+
+```go
+type HexInteger int
+
+func (f *HexInteger) UnmarshalText(text []byte) error {
+	v, err := strconv.ParseInt(string(text), 16, 64)
+	if err != nil {
+		return err
+	}
+	*f = HexInteger(v)
+	return nil
+}
+
+type FormA struct {
+	FieldA HexInteger `form:"field_a"`
+}
+
+// query with field_a = "0f"
+func GetDataA(c *gin.Context) {
+	var a FormA
+	c.Bind(&a)
+	// a.FieldA == 15
+}
+```
+
+For struct types, you can implement your own custom Unmarshaler using the `binding.BindUnmarshaler` 
+interface, which has the interface signature of `UnmarshalParam(param string) error`.
+
+```go
+type customType struct {
+	Protocol string
+	Path     string
+	Name     string
+}
+
+func (f *customType) UnmarshalParam(param string) error {
+	parts := strings.Split(param, ":")
+	if len(parts) != 3 {
+		return fmt.Errorf("invalid format")
+	}
+	f.Protocol = parts[0]
+	f.Path = parts[1]
+	f.Name = parts[2]
+	return nil
+}
+
+type FormA struct {
+	FieldA customType `form:"field_a"`
+}
+
+// query with field_a = "file:/:foo"
+func GetDataA(c *gin.Context) {
+	var a FormA
+	c.Bind(&a)
+	// a.FieldA.Protocol == "file", a.FieldA.Path == "/", and a.FieldA.Name == "foo"
+}
+```
+
 ### http2 server push
 
 http.Pusher is supported only **go1.8+**. See the [golang blog](https://blog.golang.org/h2push) for detail information.

--- a/binding/binding.go
+++ b/binding/binding.go
@@ -46,6 +46,10 @@ type BindingUri interface {
 	BindUri(map[string][]string, any) error
 }
 
+type BindUnmarshaler interface {
+	UnmarshalParam(param string) error
+}
+
 // StructValidator is the minimal interface which needs to be implemented in
 // order for it to be used as the validator engine for ensuring the correctness
 // of the request. Gin provides a default implementation for this using


### PR DESCRIPTION
- Adds encoding.TextUnmarshaler checking to support unmarshaling custom non-struct types. 
- Adds binding.BindUnmarshaler to support unmarshaling custom structs (from the suggestion in #2673)

As of this PR you can support any kind of custom type without breaking support for time.Time and other structs that might implement TextUnmarshaler

Closes #2673
Closes #2631