### PR TITLE
fix file attachment function to make sure all browser will get the sa…

### DIFF
--- a/context.go
+++ b/context.go
@@ -1018,7 +1018,7 @@ func (c *Context) FileFromFS(filepath string, fs http.FileSystem) {
 // FileAttachment writes the specified file into the body stream in an efficient way
 // On the client side, the file will typically be downloaded with the given filename
 func (c *Context) FileAttachment(filepath, filename string) {
-	c.Writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+	c.Writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
 	http.ServeFile(c.Writer, c.Request, filepath)
 }
 


### PR DESCRIPTION
`FileAttachment` function will display different file name in different bowser 
In safari, it will be a `"` in the begin of name and end like `"config_test.bin"`
In chromium, it will be a `_` in the begin of name and end like `_config_test.bin_`
In firefox, it will show correct, like `config_test.bin`
I removed the `\"` to avoid above situation 
now in safari and chromium will show correct like `config_test.bin`