### PR TITLE
Fix: sql.NullString binding for form-data

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -236,7 +236,20 @@ func setWithProperType(val string, value reflect.Value, field reflect.StructFiel
 		case time.Time:
 			return setTimeField(val, field, value)
 		}
-		return json.Unmarshal(bytesconv.StringToBytes(val), value.Addr().Interface())
+
+		err := json.Unmarshal(bytesconv.StringToBytes(val), value.Addr().Interface())
+
+		if err == nil {
+			return err
+		}
+
+		ms, err := json.Marshal(val)
+
+		if err != nil {
+			return err
+		}
+
+		return json.Unmarshal(ms, value.Addr().Interface())
 	case reflect.Map:
 		return json.Unmarshal(bytesconv.StringToBytes(val), value.Addr().Interface())
 	default:

--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -243,13 +243,13 @@ func setWithProperType(val string, value reflect.Value, field reflect.StructFiel
 			return err
 		}
 
-		ms, err := json.Marshal(val)
+		mv, err := json.Marshal(val)
 
 		if err != nil {
 			return err
 		}
 
-		return json.Unmarshal(ms, value.Addr().Interface())
+		return json.Unmarshal(mv, value.Addr().Interface())
 	case reflect.Map:
 		return json.Unmarshal(bytesconv.StringToBytes(val), value.Addr().Interface())
 	default:


### PR DESCRIPTION
Hello! When trying to bind a struct with sql.NullString, an error occurs: "invalid character 'e' in literal true (expecting 'r')"

## Example

CURL:
```curl
curl -X POST 'http://localhost:8080/form-data' \
     -H "Content-Type: multipart/form-data" \
     -F 'name="test"' \
     -F 'test="test"'
```

```go
package main

import (
	"database/sql"
	"github.com/gin-gonic/gin"
)

type TestStruct struct {
	Name string         `form:"name" json:"name"`
	Test sql.NullString `form:"test" json:"test"`
}

func main() {
	r := gin.Default()
	r.POST("/form-data", func(c *gin.Context) {
		var test TestStruct

		err := c.ShouldBind(&test)
		if err != nil {
			c.JSON(500, gin.H{
				"err": err.Error(),
			})
			return
		}

		c.JSON(200, gin.H{
			"message": "success",
		})
		return
	})
	r.Run()
}
```