### PR TITLE
Fix: missing `sameSite` when do context.reset()

### DIFF
--- a/context.go
+++ b/context.go
@@ -98,6 +98,7 @@ func (c *Context) reset() {
 	c.Accepted = nil
 	c.queryCache = nil
 	c.formCache = nil
+	c.sameSite = 0
 	*c.params = (*c.params)[:0]
 	*c.skippedNodes = (*c.skippedNodes)[:0]
 }


### PR DESCRIPTION
I find a bug about  missing `sameSite` when do context.reset()

Here is the bad case example:
```
package main

import (
	"bytes"
	"fmt"
	"net/http"
	"net/http/httptest"
	"net/url"
	"strings"

	"github.com/gin-gonic/gin"
)

type responseBodyWriter struct {
	gin.ResponseWriter
	body *bytes.Buffer //cache
}

func (r responseBodyWriter) Write(b []byte) (int, error) {
	r.body.Write(b)
	return r.ResponseWriter.Write(b)
}

func (r responseBodyWriter) WriteString(s string) (n int, err error) {
	r.body.WriteString(s)
	return r.ResponseWriter.WriteString(s)
}

// test gonic context
func main() {
	e := gin.New()

	// middleware
	e.Use(func(c *gin.Context) {
		w := &responseBodyWriter{body: &bytes.Buffer{}, ResponseWriter: c.Writer}
		c.Writer = w

		c.Next()
		// body := w.body.String()

		path := c.Request.URL.Path
		header := dumpHeader(w.Header())
		fmt.Printf("path:%s,response header:%s\n", path, header)
		if path == "/http" && strings.Contains(header, "SameSite=None") {
			err := fmt.Errorf("path:%s,response header:%s", path, header)
			panic(err)
		}
	})

	// route
	e.GET("/*any", func(c *gin.Context) {
		if c.Request.URL.Path == "/https" {
			c.SetSameSite(http.SameSiteNoneMode)
		}
		c.SetCookie("count", "1", 1, "", "x.com", false, false)
	})

	// mock requests
	for i := 0; ; i++ {
		URL, _ := url.Parse("http://x.com/https")
		if i%2 == 0 {
			URL, _ = url.Parse("http://x.com/http")
		}
		req := &http.Request{
			Method:     "GET",
			Header:     make(http.Header),
			Proto:      "HTTP/1.1",
			ProtoMajor: 1,
			ProtoMinor: 1,
			URL:        URL,
		}
		writer := httptest.NewRecorder()
		e.ServeHTTP(writer, req)
	}

}

func dumpHeader(header http.Header) string {
	var res strings.Builder
	headers := sortHeader(header)
	for _, kv := range headers {
		res.WriteString(kv[0] + ": " + kv[1] + "\n")
	}
	return res.String()
}

// sortHeaders
func sortHeader(header http.Header) [][2]string {
	headers := [][2]string{}
	for k, vs := range header {
		for _, v := range vs {
			headers = append(headers, [2]string{k, v})
		}
	}
	n := len(headers)
	for i := 0; i < n; i++ {
		for j := n - 1; j > i; j-- {
			jj := j - 1
			h1, h2 := headers[j], headers[jj]
			if h1[0] < h2[0] {
				headers[jj], headers[j] = headers[j], headers[jj]
			}
		}
	}
	return headers
}

```




