### PR TITLE
Fix : save the return line #3116

### DIFF
--- a/context.go
+++ b/context.go
@@ -824,8 +824,12 @@ func bodyAllowedForStatus(status int) bool {
 }
 
 // Status sets the HTTP response code.
-func (c *Context) Status(code int) {
-	c.Writer.WriteHeader(code)
+func (c *Context) Status(code int) error {
+	if code > 0 {
+		c.Writer.WriteHeader(code)
+		return nil
+	}
+	return errors.New("invalid status code")
 }
 
 // Header is an intelligent shortcut for c.Writer.Header().Set(key, value).


### PR DESCRIPTION
Adding error return for c.Status(code) so that this function call can be used as return c.Status(code)