### PR TITLE
Multiple `Accept` header fix

### DIFF
--- a/context.go
+++ b/context.go
@@ -1100,7 +1100,9 @@ func (c *Context) NegotiateFormat(offered ...string) string {
 	assert1(len(offered) > 0, "you must provide at least one offer")
 
 	if c.Accepted == nil {
-		c.Accepted = parseAccept(c.requestHeader("Accept"))
+		for _, a := range c.Request.Header.Values("Accept") {
+			c.Accepted = append(c.Accepted, parseAccept(a)...)
+		}
 	}
 	if len(c.Accepted) == 0 {
 		return offered[0]

--- a/context_test.go
+++ b/context_test.go
@@ -1231,6 +1231,18 @@ func TestContextNegotiationFormatWithAccept(t *testing.T) {
 	assert.Empty(t, c.NegotiateFormat(MIMEJSON))
 }
 
+func TestContextNegotiationFormatWithMultipleAccept(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest("POST", "/", nil)
+	c.Request.Header.Add("Accept", "text/html")
+	c.Request.Header.Add("Accept", "application/xhtml+xml")
+	c.Request.Header.Add("Accept", "application/xml;q=0.9;q=0.8")
+
+	assert.Equal(t, MIMEXML, c.NegotiateFormat(MIMEJSON, MIMEXML))
+	assert.Equal(t, MIMEHTML, c.NegotiateFormat(MIMEXML, MIMEHTML))
+	assert.Empty(t, c.NegotiateFormat(MIMEJSON))
+}
+
 func TestContextNegotiationFormatWithWildcardAccept(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Request, _ = http.NewRequest("POST", "/", nil)


### PR DESCRIPTION
This PR updates Accept content negotiation to iterate through multiple Accept headers to find possible negotiable formats, rather than just taking the first Accept header and ignoring the others.