### PR TITLE
fix(context): add check to avoid nil pointer

### DIFF
--- a/context.go
+++ b/context.go
@@ -1195,7 +1195,7 @@ func (c *Context) Value(key any) any {
 			return val
 		}
 	}
-	if !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
+	if c.engine != nil && !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
 		return nil
 	}
 	return c.Request.Context().Value(key)

--- a/context_test.go
+++ b/context_test.go
@@ -2294,3 +2294,9 @@ func TestContextAddParam(t *testing.T) {
 	assert.Equal(t, ok, true)
 	assert.Equal(t, value, v)
 }
+
+func TestRetrieveValueNoEngineInContext(t *testing.T) {
+	c := &Context{}
+	v := c.Value("foo")
+	assert.Nil(t, v)
+}


### PR DESCRIPTION
## What?

Proposed fix for https://github.com/gin-gonic/gin/issues/3178

## Why?

In cases where we create a context with no engine (e.g. unit tests), it might lead to a nil pointer dereference.

## How?

Added a new check to verify that the engine is not null.
