### PR TITLE
Doc fix: Small fix on Context's ClientIP() method.

### DIFF
--- a/context.go
+++ b/context.go
@@ -748,7 +748,7 @@ func (c *Context) ShouldBindBodyWith(obj any, bb binding.BindingBody) (err error
 }
 
 // ClientIP implements one best effort algorithm to return the real client IP.
-// It called c.RemoteIP() under the hood, to check if the remote IP is a trusted proxy or not.
+// It calls c.RemoteIP() under the hood, to check if the remote IP is a trusted proxy or not.
 // If it is it will then try to parse the headers defined in Engine.RemoteIPHeaders (defaulting to [X-Forwarded-For, X-Real-Ip]).
 // If the headers are not syntactically valid OR the remote IP does not correspond to a trusted proxy,
 // the remote IP (coming from Request.RemoteAddr) is returned.


### PR DESCRIPTION
Noticed a small tense error on the doc for the `ClientIP()` method while reading the docs.

