### PR TITLE
fix: Nil pointer dereference when context has no engine defined

### DIFF
--- a/context.go
+++ b/context.go
@@ -1195,7 +1195,7 @@ func (c *Context) Value(key any) any {
 			return val
 		}
 	}
-	if !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
+	if c == nil || c.engine == nil || !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
 		return nil
 	}
 	return c.Request.Context().Value(key)


### PR DESCRIPTION
Issue: #3178

