### PR TITLE
Cookies added to return all cookies at once.

### DIFF
--- a/context.go
+++ b/context.go
@@ -897,6 +897,16 @@ func (c *Context) Cookie(name string) (string, error) {
 	return val, nil
 }
 
+// Cookies parses and returns the HTTP cookies sent with the request.
+func (c *Context) Cookies() []string {
+	var cookies []string
+	for _, cookie := range c.Request.Cookies() {
+		val, _ := url.QueryUnescape(cookie.Value)
+		cookies = append(cookies, val)
+	}
+	return cookies
+}
+
 // Render writes the response headers and calls render.Render to render data.
 func (c *Context) Render(code int, r render.Render) {
 	c.Status(code)


### PR DESCRIPTION
http.Request has two methods called Cookie and Cookies, I think it's a good option for Gin to have both of them, not limiting them to only one method.
without this commit, user should call cookies one by one, handle errors (cookie doesn't exist) and user can't find out what other cookies are there.
Also Express that is gin inspiration can handle multiple cookies at once.