### PR TITLE
Prevent slice out of bounds access before panic

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -349,7 +349,11 @@ func (n *node) insertChild(path string, fullPath string, handlers HandlersChain)
 		}
 
 		if len(n.path) > 0 && n.path[len(n.path)-1] == '/' {
-			pathSeg := strings.SplitN(n.children[0].path, "/", 2)[0]
+			// Wildcard conflict
+			pathSeg := path
+			if len(n.children) != 0 {
+				pathSeg = strings.SplitN(n.children[0].path, "/", 2)[0]
+			}
 			panic("catch-all wildcard '" + path +
 				"' in new path '" + fullPath +
 				"' conflicts with existing path segment '" + pathSeg +


### PR DESCRIPTION
Previously, when the error would be triggered, it was possible that a slice out of bounds panic would occur before the intended panic message. I've added a nil/slice length check to make sure that does not happen.

With that said, I am not very familiar with the library so I cannot determine what this catch was supposed to mean, or convey, to users of the library. It would be helpful to know what I can do to make the error message more useful.

Thanks.

Fixes #3126