### PR TITLE
implement io.ReaderFrom for gin.ResponseWriter

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -22,6 +22,7 @@ type ResponseWriter interface {
 	http.Hijacker
 	http.Flusher
 	http.CloseNotifier
+	io.ReaderFrom
 
 	// Status returns the HTTP response status code of the current request.
 	Status() int
@@ -84,6 +85,15 @@ func (w *responseWriter) WriteString(s string) (n int, err error) {
 	w.WriteHeaderNow()
 	n, err = io.WriteString(w.ResponseWriter, s)
 	w.size += n
+	return
+}
+
+// ReadFrom implements the io.ReaderFrom interface, allowing Go to automatically
+// use the sendfile syscall in methods such as http.ServeFile
+func (w *responseWriter) ReadFrom(src io.Reader) (n int64, err error) {
+	w.WriteHeaderNow()
+	n, err = io.Copy(w.ResponseWriter, src)
+	w.size += int(n)
 	return
 }
 


### PR DESCRIPTION
Follow-up to fix the merge conflict in https://github.com/gin-gonic/gin/pull/1610. Credit to @heyimalex (marked as a co-author in Git) for writing most of this diff.

This causes io.Copy, which calls io.copyBuffer, to automatically use the sendfile syscall by calling the underlying http.ResponseWriter's ReadFrom implementation [1].

[1] https://github.com/golang/go/blob/7eeec1f6e4/src/io/io.go#L410-L413

This can be a significant performance improvement. For example, downloading a 1 GB file is now 33% faster:

```shell
# After this patch
$ hyperfine --warmup 2 "curl 'http://localhost:8080/local/file' -o /dev/null"
Benchmark 1: curl 'http://localhost:8080/local/file' -o /dev/null
  Time (mean ± σ):     338.6 ms ±   7.8 ms    [User: 46.9 ms, System: 288.6 ms]
  Range (min … max):   323.0 ms … 348.4 ms    10 runs

# Before this patch
$ hyperfine --warmup 2 "curl 'http://localhost:8080/local/file' -o /dev/null"
Benchmark 1: curl 'http://localhost:8080/local/file' -o /dev/null
  Time (mean ± σ):     509.9 ms ±  17.3 ms    [User: 82.2 ms, System: 282.3 ms]
  Range (min … max):   489.0 ms … 540.7 ms    10 runs
```