### PR TITLE
fix: Duplicate close net.Listener

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -518,7 +518,6 @@ func (engine *Engine) RunUnix(file string) (err error) {
 	if err != nil {
 		return
 	}
-	defer listener.Close()
 	defer os.Remove(file)
 
 	err = http.Serve(listener, engine.Handler())
@@ -542,7 +541,6 @@ func (engine *Engine) RunFd(fd int) (err error) {
 	if err != nil {
 		return
 	}
-	defer listener.Close()
 	err = engine.RunListener(listener)
 	return
 }


### PR DESCRIPTION
http/server.go:
line: 3016
net.Listener is close in func http.Server.Serve() by default.

// Some code piece of http.Server.Serve()
func (srv *Server) Serve(l net.Listener) error {
	if fn := testHookServerServe; fn != nil {
		fn(srv, l) // call hook with unwrapped listener
	}

	origListener := l
	l = &onceCloseListener{Listener: l}
	// HERE: listener is close by default
	defer l.Close()

- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

