### PR TITLE
feat(gracefulstop): add wrapper of Shutdown

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -165,7 +165,7 @@ type Engine struct {
 	maxSections      uint16
 	trustedProxies   []string
 	trustedCIDRs     []*net.IPNet
-	
+
 	// http.Server list for graceful Shutdown
 	serverList []*http.Server
 }

--- a/gin_test.go
+++ b/gin_test.go
@@ -696,3 +696,26 @@ func assertRoutePresent(t *testing.T, gotRoutes RoutesInfo, wantRoute RouteInfo)
 
 func handlerTest1(c *Context) {}
 func handlerTest2(c *Context) {}
+
+// TestEngine_Shutdown to test engine.Shutdown.
+func TestEngine_Shutdown(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Println(err)
+	}
+	r := Default()
+	r.serverList = append(r.serverList, nil)
+	go func() {
+		err = r.RunListener(ln)
+		assert.Equal(t, err, http.ErrServerClosed)
+	}()
+	time.Sleep(time.Millisecond)
+	assert.Equal(t, len(r.serverList), 2)
+	r.serverList = append(r.serverList, nil)
+	ctx, _ := context.WithTimeout(context.Background(), time.Nanosecond)
+	time.Sleep(time.Nanosecond)
+	err = r.Shutdown(ctx)
+	assert.Error(t, err, context.DeadlineExceeded)
+	err = r.Shutdown(context.TODO())
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
We start httpServer by gin as example below In my project.
Here is a case:
1. Start gin http server
2. Receive data from gin http server and send task to worker to process.
3. The worker stop at first when my process go to exit. But my gin http server is running, some error happened.

We expect to stop gin http server at first by calling func 'http.Server.Shutdown(context.TODO())' to avoid process error.
So, can i make a mr and add wrapper func 'Shutdown()' to gin for graceful stop my process.

Here are my use case.
```golang
func main() {
	// Set up a http server.
	r := gin.Default()
	// ...
	go func() {
		// Run http server
		if err := r.Run(":8899"); err != nil {
			log.Fatalf("could not run server: %v", err)
		}
	}()
	// Run worker
	go RunWorker()
	// wait signal to stop
	WaitSignal()
}

// RunWorker run worker in one goroutine
func RunWorker() {
	for !isStop {
		// ... some request received by gin http server ...
		// ... do some work ...
	}
}

// WaitSignal stop signal handle
func WaitSignal() {
	shutdownHook := make(chan os.Signal, 1)
	signal.Notify(shutdownHook, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt)
	<-shutdownHook

	GracefulStop()
	// wait 2 second for graceful stop.
	time.Sleep(2 * time.Second)
	os.Exit(0)
}

// GracefulStop graceful stop http.Server at first, then stop all workers.
func GracefulStop() {
	// 1. stop http.Server and refuse new data are received.
	err := server.Shutdown(context.TODO())
	// 2. stop worker and finish tasks in process.
	// StopWorker() ...
}
```

- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

