### PR TITLE
Feature: Add DataFromStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1308,6 +1308,37 @@ func main() {
 }
 ```
 
+### Streaming data
+
+```go
+func main() {
+	router := gin.Default()
+	router.GET("/someDataFromStream", func(c *gin.Context) {
+		pr, pw := io.Pipe()
+		defer pr.Close()
+
+		go func() {
+			defer pw.Close()
+			var counter int
+			for {
+				select {
+				case <-c.Done():
+					return
+				case <-time.Tick(500 * time.Millisecond):
+					if _, err := fmt.Fprintf(pw, "message: %d\n", counter); err != nil {
+						return
+					}
+				}
+			}
+		}()
+
+		contentType := "text/plain"
+		c.DataFromStream(http.StatusOK, contentType, pr, nil)
+	})
+	router.Run(":8080")
+}
+```
+
 ### HTML rendering
 
 Using LoadHTMLGlob() or LoadHTMLFiles()

--- a/context.go
+++ b/context.go
@@ -1018,6 +1018,19 @@ func (c *Context) DataFromReader(code int, contentLength int64, contentType stri
 	})
 }
 
+// DataFromStream streams the specified reader into the body stream without delay and updates the HTTP code.
+func (c *Context) DataFromStream(code int, contentType string, reader io.Reader, extraHeaders map[string]string) {
+	sr := render.StreamReader{
+		Reader: render.Reader{
+			Headers:       extraHeaders,
+			ContentType:   contentType,
+			ContentLength: -1,
+			Reader:        reader,
+		},
+	}
+	c.Render(code, sr)
+}
+
 // File writes the specified file into the body stream in an efficient way.
 func (c *Context) File(filepath string) {
 	http.ServeFile(c.Writer, c.Request, filepath)

--- a/render/render.go
+++ b/render/render.go
@@ -26,6 +26,7 @@ var (
 	_ Render     = HTML{}
 	_ HTMLRender = HTMLDebug{}
 	_ HTMLRender = HTMLProduction{}
+	_ Render     = StreamReader{}
 	_ Render     = YAML{}
 	_ Render     = Reader{}
 	_ Render     = AsciiJSON{}

--- a/render/stream_reader.go
+++ b/render/stream_reader.go
@@ -1,0 +1,31 @@
+// Copyright 2018 Gin Core Team. All rights reserved.
+// Use of this source code is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+package render
+
+import (
+	"net/http"
+)
+
+// StreamReader contains the IO reader and its length, and custom ContentType and other headers.
+type StreamReader struct {
+	Reader
+}
+
+type writerFlusher struct {
+	http.ResponseWriter
+}
+
+func (w *writerFlusher) Write(buf []byte) (n int, err error) {
+	n, err = w.ResponseWriter.Write(buf)
+	if err == nil {
+		w.ResponseWriter.(http.Flusher).Flush()
+	}
+	return
+}
+
+// Render (StreamReader) writes data with custom ContentType and headers.
+func (r StreamReader) Render(w http.ResponseWriter) (err error) {
+	return r.Reader.Render(&writerFlusher{w})
+}


### PR DESCRIPTION
`DataFromReader` has buffering on the HTTP response, so it is not suitable to stream data to a client. `DataFromStream` disables buffering and flushes data as soon as it is sent to the HTTP body.

Admittedly, we could let users control when we do the flushing, say, every N bytes. But I wanted to know if there's interest in this feature before building more things.