### PR TITLE
fix(readme): graceful shutdown should use buffered signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1841,7 +1841,7 @@ func main() {
 
 	// Wait for interrupt signal to gracefully shutdown the server with
 	// a timeout of 5 seconds.
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	// kill (no param) default send syscall.SIGTERM
 	// kill -2 is syscall.SIGINT
 	// kill -9 is syscall.SIGKILL but can't be caught, so don't need to add it


### PR DESCRIPTION
According to [Notify document](https://pkg.go.dev/os/signal#Notify), the channel used with signal.Notify should be buffered. Otherwise, there will be a risk that the signal might be missed.
Linters will also report this problem:
sigchanyzer: misuse of unbuffered os.Signal channel as argument to signal.Notify (govet)go-golangci-lint
SA1017: the channel used with signal.Notify should be buffered (staticcheck)go-golangci-lint


- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

