### PR TITLE
Support for case-insensitive HTTP methods.

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -586,7 +586,7 @@ func (engine *Engine) HandleContext(c *Context) {
 }
 
 func (engine *Engine) handleHTTPRequest(c *Context) {
-	httpMethod := c.Request.Method
+	httpMethod := strings.ToUpper(c.Request.Method)
 	rPath := c.Request.URL.Path
 	unescape := false
 	if engine.UseRawPath && len(c.Request.URL.RawPath) > 0 {


### PR DESCRIPTION
Add support for case-insensitive HTTP methods. [#3239](https://github.com/gin-gonic/gin/issues/3239)

Before:

```go
g := gin.Default()
g.GET("/hello/:name", func(c *gin.Context) {
    c.String(200, "Hello %s", c.Param("name"))
})
g.Run(":9001")
```

When we use lowercase `get` to initiate a request through `http.NewRequest`, the request method received by the HTTP server is also `get`. At this time, the `GET` route we defined cannot be matched:

```
[GIN] 2022/07/12 - 17:35:38 | 404 |           378ns |       127.0.0.1 | get      "/hello/dog"
[GIN] 2022/07/12 - 17:35:38 | 200 |      29.046µs |       127.0.0.1 | GET      "/hello/cat"
```

Maybe for some user applications, the http request method needs to be compatible with lowercase, so before processing the HTTP request, convert the HTTP request method to uppercase to be compatible with these situations:

```go
httpMethod := strings.ToUpper(c.Request.Method)
```
