### PR TITLE
Fix NegotiateFormat

### DIFF
--- a/context.go
+++ b/context.go
@@ -1131,7 +1131,8 @@ func (c *Context) NegotiateFormat(offered ...string) string {
 			// According to RFC 2616 and RFC 2396, non-ASCII characters are not allowed in headers,
 			// therefore we can just iterate over the string without casting it into []rune
 			i := 0
-			for ; i < len(accepted); i++ {
+			minLen := min(len(accepted), len(offer))
+			for ; i < minLen; i++ {
 				if accepted[i] == '*' || offer[i] == '*' {
 					return offer
 				}

--- a/context_test.go
+++ b/context_test.go
@@ -1311,6 +1311,15 @@ func TestContextNegotiationFormatCustom(t *testing.T) {
 	assert.Equal(t, MIMEJSON, c.NegotiateFormat(MIMEJSON))
 }
 
+func TestContextNegotiationFormatWithShorterOfferLength(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest("POST", "/", nil)
+	c.Request.Header.Add("Accept", "text/html")
+
+	assert.Equal(t, "", c.NegotiateFormat("text/htm"))
+	assert.Equal(t, "text/*", c.NegotiateFormat("text/*"))
+}
+
 func TestContextIsAborted(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	assert.False(t, c.IsAborted())


### PR DESCRIPTION
Fix issue [#3241](https://github.com/gin-gonic/gin/issues/3241)

When the length of the `offered` mime type string is inconsistent with the request's `accepted` mime length, it may cause a panic, but it should actually return an empty string.

