### PR TITLE
fix context.Value-engine is nil panic

### DIFF
--- a/context.go
+++ b/context.go
@@ -1205,7 +1205,7 @@ func (c *Context) Value(key any) any {
 			return val
 		}
 	}
-	if !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
+	if c.engine == nil || !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
 		return nil
 	}
 	return c.Request.Context().Value(key)

--- a/context_test.go
+++ b/context_test.go
@@ -2354,3 +2354,11 @@ func TestContextAddParam(t *testing.T) {
 	assert.Equal(t, ok, true)
 	assert.Equal(t, value, v)
 }
+
+func TestContextValue(t *testing.T) {
+	c := &Context{}
+	id := "id"
+	// gin@v1.8.1 will panic
+	value := c.Value(id)
+	assert.Nil(t, value)
+}


### PR DESCRIPTION
## Description

> Source code: https://github.com/gin-gonic/gin/blob/b04917c53e310e3746ec90cd93106cda8c956211/context.go#L1208

The attribute `engine` is not judged whether it is `nil` in the `Value` method of `gin.Context`，may cause program panic

## How to reproduce

- example
  ```go
  package main
  
  import (
	  "fmt"
	  "github.com/gin-gonic/gin" // v1.8.1
  )
  
  func main() {
	  ctx := gin.Context{}
	  data := ctx.Value("test")
	  fmt.Println(data)
  }
  ```
- error
  ```
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x2 addr=0x71 pc=0x1027a45c0]
  
  goroutine 1 [running]:
  github.com/gin-gonic/gin.(*Context).Value(0x140000ee000, {0x10283b820?, 0x1028964d8?})
          /Users/atopx/go/pkg/mod/github.com/gin-gonic/gin@v1.8.1/context.go:1198 +0x110
  main.main()
          /Users/atopx/workspace/stu-gin/main.go:10 +0x3c
  exit status 2
  ```
