### PR TITLE
feat: skip url with prefixes in LoggerConfig

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/mattn/go-isatty"
@@ -47,6 +48,10 @@ type LoggerConfig struct {
 	// SkipPaths is an url path array which logs are not written.
 	// Optional.
 	SkipPaths []string
+
+	// SkipPrefixes is an url path prefix array with which logs are not written.
+	// Optional.
+	SkipPrefixes []string
 }
 
 // LogFormatter gives the signature of the formatter function passed to LoggerWithFormatter
@@ -211,8 +216,6 @@ func LoggerWithConfig(conf LoggerConfig) HandlerFunc {
 		out = DefaultWriter
 	}
 
-	notlogged := conf.SkipPaths
-
 	isTerm := true
 
 	if w, ok := out.(*os.File); !ok || os.Getenv("TERM") == "dumb" ||
@@ -220,13 +223,23 @@ func LoggerWithConfig(conf LoggerConfig) HandlerFunc {
 		isTerm = false
 	}
 
-	var skip map[string]struct{}
+	var skipPaths map[string]struct{}
 
-	if length := len(notlogged); length > 0 {
-		skip = make(map[string]struct{}, length)
+	if length := len(conf.SkipPaths); length > 0 {
+		skipPaths = make(map[string]struct{}, length)
 
-		for _, path := range notlogged {
-			skip[path] = struct{}{}
+		for _, path := range conf.SkipPaths {
+			skipPaths[path] = struct{}{}
+		}
+	}
+
+	var skipPrefixes map[string]struct{}
+
+	if length := len(conf.SkipPrefixes); length > 0 {
+		skipPrefixes = make(map[string]struct{}, length)
+
+		for _, path := range conf.SkipPrefixes {
+			skipPrefixes[path] = struct{}{}
 		}
 	}
 
@@ -240,7 +253,21 @@ func LoggerWithConfig(conf LoggerConfig) HandlerFunc {
 		c.Next()
 
 		// Log only when path is not being skipped
-		if _, ok := skip[path]; !ok {
+
+		var skipByPath bool
+		var skipByPrefix bool
+
+		_, skipByPath = skipPaths[path]
+		if !skipByPath {
+			for prefix := range skipPrefixes {
+				if strings.HasPrefix(path, prefix) {
+					skipByPrefix = true
+					break
+				}
+			}
+		}
+
+		if !skipByPath && !skipByPrefix {
 			param := LogFormatterParams{
 				Request: c.Request,
 				isTerm:  isTerm,

--- a/logger_test.go
+++ b/logger_test.go
@@ -414,6 +414,34 @@ func TestLoggerWithConfigSkippingPaths(t *testing.T) {
 	assert.Contains(t, buffer.String(), "")
 }
 
+func TestLoggerWithConfigSkippingPathPrefix(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	router := New()
+	router.Use(LoggerWithConfig(LoggerConfig{
+		Output:       buffer,
+		SkipPrefixes: []string{"/skippedPrefix"},
+	}))
+	router.GET("/logged", func(c *Context) {})
+	router.GET("/skippedPrefix", func(c *Context) {})
+	router.GET("/skippedPrefix2", func(c *Context) {})
+	router.GET("/skippedPrefix/subdir", func(c *Context) {})
+
+	PerformRequest(router, "GET", "/logged")
+	assert.Contains(t, buffer.String(), "200")
+
+	buffer.Reset()
+	PerformRequest(router, "GET", "/skippedPrefix")
+	assert.Contains(t, buffer.String(), "")
+
+	buffer.Reset()
+	PerformRequest(router, "GET", "/skippedPrefix2")
+	assert.Contains(t, buffer.String(), "")
+
+	buffer.Reset()
+	PerformRequest(router, "GET", "/skippedPrefix/subdir")
+	assert.Contains(t, buffer.String(), "")
+}
+
 func TestDisableConsoleColor(t *testing.T) {
 	New()
 	assert.Equal(t, autoColor, consoleColorMode)


### PR DESCRIPTION
As in a RESTful url design, resource identities often appear as part of url, such as `/resources/show/:id`. With `SkipPaths` alone in `LoggerConfig`, we can not handle `skipping-logging-by-path` with urls one by one. So here comes the `prefix` way of `skipping-logging-by-prefix-match`. 

Tests delievered.