### PR TITLE
fix: gin Context  check nil engine

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: Go
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/context.go
+++ b/context.go
@@ -524,6 +524,10 @@ func (c *Context) PostFormArray(key string) (values []string) {
 }
 
 func (c *Context) initFormCache() {
+	if c.engine == nil {
+		return
+	}
+
 	if c.formCache == nil {
 		c.formCache = make(url.Values)
 		req := c.Request
@@ -574,6 +578,9 @@ func (c *Context) get(m map[string][]string, key string) (map[string]string, boo
 
 // FormFile returns the first file for the provided form key.
 func (c *Context) FormFile(name string) (*multipart.FileHeader, error) {
+	if c.engine == nil {
+		return nil, nil
+	}
 	if c.Request.MultipartForm == nil {
 		if err := c.Request.ParseMultipartForm(c.engine.MaxMultipartMemory); err != nil {
 			return nil, err
@@ -589,6 +596,9 @@ func (c *Context) FormFile(name string) (*multipart.FileHeader, error) {
 
 // MultipartForm is the parsed multipart form, including file uploads.
 func (c *Context) MultipartForm() (*multipart.Form, error) {
+	if c.engine == nil {
+		return nil, nil
+	}
 	err := c.Request.ParseMultipartForm(c.engine.MaxMultipartMemory)
 	return c.Request.MultipartForm, err
 }
@@ -763,6 +773,9 @@ func (c *Context) ShouldBindBodyWith(obj any, bb binding.BindingBody) (err error
 // If the headers are not syntactically valid OR the remote IP does not correspond to a trusted proxy,
 // the remote IP (coming from Request.RemoteAddr) is returned.
 func (c *Context) ClientIP() string {
+	if c.engine == nil {
+		return ""
+	}
 	// Check if we're running on a trusted platform, continue running backwards if error
 	if c.engine.TrustedPlatform != "" {
 		// Developers can define their own header of Trusted Platform or use predefined constants
@@ -926,6 +939,9 @@ func (c *Context) Render(code int, r render.Render) {
 // It also updates the HTTP code and sets the Content-Type as "text/html".
 // See http://golang.org/doc/articles/wiki/
 func (c *Context) HTML(code int, name string, obj any) {
+	if c.engine == nil {
+		return
+	}
 	instance := c.engine.HTMLRender.Instance(name, obj)
 	c.Render(code, instance)
 }
@@ -942,6 +958,9 @@ func (c *Context) IndentedJSON(code int, obj any) {
 // Default prepends "while(1)," to response body if the given struct is array values.
 // It also sets the Content-Type as "application/json".
 func (c *Context) SecureJSON(code int, obj any) {
+	if c.engine == nil {
+		return
+	}
 	c.Render(code, render.SecureJSON{Prefix: c.engine.secureJSONPrefix, Data: obj})
 }
 
@@ -1168,7 +1187,7 @@ func (c *Context) SetAccepted(formats ...string) {
 
 // Deadline returns that there is no deadline (ok==false) when c.Request has no Context.
 func (c *Context) Deadline() (deadline time.Time, ok bool) {
-	if !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
+	if c.engine == nil || !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
 		return
 	}
 	return c.Request.Context().Deadline()
@@ -1176,7 +1195,7 @@ func (c *Context) Deadline() (deadline time.Time, ok bool) {
 
 // Done returns nil (chan which will wait forever) when c.Request has no Context.
 func (c *Context) Done() <-chan struct{} {
-	if !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
+	if c.engine == nil || !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
 		return nil
 	}
 	return c.Request.Context().Done()
@@ -1184,7 +1203,7 @@ func (c *Context) Done() <-chan struct{} {
 
 // Err returns nil when c.Request has no Context.
 func (c *Context) Err() error {
-	if !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
+	if c.engine == nil || !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
 		return nil
 	}
 	return c.Request.Context().Err()
@@ -1205,7 +1224,7 @@ func (c *Context) Value(key any) any {
 			return val
 		}
 	}
-	if !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
+	if c.engine == nil || !c.engine.ContextWithFallback || c.Request == nil || c.Request.Context() == nil {
 		return nil
 	}
 	return c.Request.Context().Value(key)


### PR DESCRIPTION
https://github.com/golang/go/blob/release-branch.go1.16/src/database/sql/sql.go#L1205
![image](https://user-images.githubusercontent.com/1203957/185194777-16678115-88c5-4813-8e35-b46eddc1ad1e.png)
https://github.com/gin-gonic/gin/blob/v1.8.1/context.go#L1168
![image](https://user-images.githubusercontent.com/1203957/185194900-c6313073-a598-410c-b5f0-4bfdbbde3a9c.png)
https://github.com/gin-gonic/gin/blob/v1.7.1/context.go#L1157
![image](https://user-images.githubusercontent.com/1203957/185194970-6f6c577d-5fd9-4281-967c-a66ae22a2be5.png)

use gin.Context{} to database conn ctx param,  if use v1.8.1  c.engine =nil  panic then recover,  un free lock conn; next time to conn  lock, always wait lock to free; if use v1.7.*  is ok;
so  gin cxt.Done() to check e.engine=nil,   Compatible with this case.
