### PR TITLE
Convert strings and slices using the officially recommended way

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gin-gonic/gin
 
-go 1.18
+go 1.20
 
 require (
 	github.com/bytedance/sonic v1.4.0

--- a/internal/bytesconv/bytesconv_1.19.go
+++ b/internal/bytesconv/bytesconv_1.19.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !go1.20
-// +build !go1.20
 
 package bytesconv
 

--- a/internal/bytesconv/bytesconv_1.19.go
+++ b/internal/bytesconv/bytesconv_1.19.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
+//go:build !go1.20
+// +build !go1.20
+
 package bytesconv
 
 import (

--- a/internal/bytesconv/bytesconv_1.20.go
+++ b/internal/bytesconv/bytesconv_1.20.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.20
-// +build go1.20
 
 package bytesconv
 

--- a/internal/bytesconv/bytesconv_1.20.go
+++ b/internal/bytesconv/bytesconv_1.20.go
@@ -1,0 +1,22 @@
+// Copyright 2022 Gin Core Team. All rights reserved.
+// Use of this source code is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+//go:build go1.20
+// +build go1.20
+
+package bytesconv
+
+import (
+	"unsafe"
+)
+
+// StringToBytes converts string to byte slice without a memory allocation.
+func StringToBytes(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}
+
+// BytesToString converts byte slice to string without a memory allocation.
+func BytesToString(b []byte) string {
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}

--- a/internal/bytesconv/bytesconv_1.20.go
+++ b/internal/bytesconv/bytesconv_1.20.go
@@ -12,11 +12,13 @@ import (
 )
 
 // StringToBytes converts string to byte slice without a memory allocation.
+// For more details, see https://github.com/golang/go/issues/53003#issuecomment-1140276077.
 func StringToBytes(s string) []byte {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 // BytesToString converts byte slice to string without a memory allocation.
+// For more details, see https://github.com/golang/go/issues/53003#issuecomment-1140276077.
 func BytesToString(b []byte) string {
 	return unsafe.String(unsafe.SliceData(b), len(b))
 }

--- a/internal/bytesconv/bytesconv_1.20.go
+++ b/internal/bytesconv/bytesconv_1.20.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Gin Core Team. All rights reserved.
+// Copyright 2023 Gin Core Team. All rights reserved.
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
Go official is expected to provide unsafe.{SliceData, Slice, StringData, String} series methods in version 1.20 for conversion of strings and slices.

Reference: https://github.com/golang/go/issues/53003