### PR TITLE
Replace bytes.Buffer with strings.Builder where appropriate

### DIFF
--- a/debug_test.go
+++ b/debug_test.go
@@ -5,7 +5,6 @@
 package gin
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"html/template"
@@ -13,6 +12,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 
@@ -138,7 +138,7 @@ func captureOutput(t *testing.T, f func()) string {
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
 	go func() {
-		var buf bytes.Buffer
+		var buf strings.Builder
 		wg.Done()
 		_, err := io.Copy(&buf, reader)
 		assert.NoError(t, err)

--- a/githubapi_test.go
+++ b/githubapi_test.go
@@ -5,12 +5,12 @@
 package gin
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -401,7 +401,7 @@ func TestGithubAPI(t *testing.T) {
 }
 
 func exampleFromPath(path string) (string, Params) {
-	output := new(bytes.Buffer)
+	output := new(strings.Builder)
 	params := make(Params, 0, 6)
 	start := -1
 	for i, c := range path {

--- a/logger_test.go
+++ b/logger_test.go
@@ -5,10 +5,10 @@
 package gin
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,7 +20,7 @@ func init() {
 }
 
 func TestLogger(t *testing.T) {
-	buffer := new(bytes.Buffer)
+	buffer := new(strings.Builder)
 	router := New()
 	router.Use(LoggerWithWriter(buffer))
 	router.GET("/example", func(c *Context) {})
@@ -84,7 +84,7 @@ func TestLogger(t *testing.T) {
 }
 
 func TestLoggerWithConfig(t *testing.T) {
-	buffer := new(bytes.Buffer)
+	buffer := new(strings.Builder)
 	router := New()
 	router.Use(LoggerWithConfig(LoggerConfig{Output: buffer}))
 	router.GET("/example", func(c *Context) {})
@@ -148,7 +148,7 @@ func TestLoggerWithConfig(t *testing.T) {
 }
 
 func TestLoggerWithFormatter(t *testing.T) {
-	buffer := new(bytes.Buffer)
+	buffer := new(strings.Builder)
 
 	d := DefaultWriter
 	DefaultWriter = buffer
@@ -182,7 +182,7 @@ func TestLoggerWithFormatter(t *testing.T) {
 func TestLoggerWithConfigFormatting(t *testing.T) {
 	var gotParam LogFormatterParams
 	var gotKeys map[string]any
-	buffer := new(bytes.Buffer)
+	buffer := new(strings.Builder)
 
 	router := New()
 	router.engine.trustedCIDRs, _ = router.engine.prepareTrustedCIDRs()
@@ -382,7 +382,7 @@ func TestErrorLogger(t *testing.T) {
 }
 
 func TestLoggerWithWriterSkippingPaths(t *testing.T) {
-	buffer := new(bytes.Buffer)
+	buffer := new(strings.Builder)
 	router := New()
 	router.Use(LoggerWithWriter(buffer, "/skipped"))
 	router.GET("/logged", func(c *Context) {})
@@ -397,7 +397,7 @@ func TestLoggerWithWriterSkippingPaths(t *testing.T) {
 }
 
 func TestLoggerWithConfigSkippingPaths(t *testing.T) {
-	buffer := new(bytes.Buffer)
+	buffer := new(strings.Builder)
 	router := New()
 	router.Use(LoggerWithConfig(LoggerConfig{
 		Output:    buffer,

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -5,7 +5,6 @@
 package gin
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 	"net/http"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestPanicClean(t *testing.T) {
-	buffer := new(bytes.Buffer)
+	buffer := new(strings.Builder)
 	router := New()
 	password := "my-super-secret-password"
 	router.Use(RecoveryWithWriter(buffer))
@@ -50,7 +49,7 @@ func TestPanicClean(t *testing.T) {
 
 // TestPanicInHandler assert that panic has been recovered.
 func TestPanicInHandler(t *testing.T) {
-	buffer := new(bytes.Buffer)
+	buffer := new(strings.Builder)
 	router := New()
 	router.Use(RecoveryWithWriter(buffer))
 	router.GET("/recovery", func(_ *Context) {
@@ -122,7 +121,7 @@ func TestPanicWithBrokenPipe(t *testing.T) {
 
 	for errno, expectMsg := range expectMsgs {
 		t.Run(expectMsg, func(t *testing.T) {
-			var buf bytes.Buffer
+			var buf strings.Builder
 
 			router := New()
 			router.Use(RecoveryWithWriter(&buf))
@@ -145,8 +144,8 @@ func TestPanicWithBrokenPipe(t *testing.T) {
 }
 
 func TestCustomRecoveryWithWriter(t *testing.T) {
-	errBuffer := new(bytes.Buffer)
-	buffer := new(bytes.Buffer)
+	errBuffer := new(strings.Builder)
+	buffer := new(strings.Builder)
 	router := New()
 	handleRecovery := func(c *Context, err any) {
 		errBuffer.WriteString(err.(string))
@@ -179,8 +178,8 @@ func TestCustomRecoveryWithWriter(t *testing.T) {
 }
 
 func TestCustomRecovery(t *testing.T) {
-	errBuffer := new(bytes.Buffer)
-	buffer := new(bytes.Buffer)
+	errBuffer := new(strings.Builder)
+	buffer := new(strings.Builder)
 	router := New()
 	DefaultErrorWriter = buffer
 	handleRecovery := func(c *Context, err any) {
@@ -214,8 +213,8 @@ func TestCustomRecovery(t *testing.T) {
 }
 
 func TestRecoveryWithWriterWithCustomRecovery(t *testing.T) {
-	errBuffer := new(bytes.Buffer)
-	buffer := new(bytes.Buffer)
+	errBuffer := new(strings.Builder)
+	buffer := new(strings.Builder)
 	router := New()
 	DefaultErrorWriter = buffer
 	handleRecovery := func(c *Context, err any) {


### PR DESCRIPTION
To build strings more efficiently, use strings.Builder instead.
