### PR TITLE
Security Optimization string to byte slice

### DIFF
--- a/internal/bytesconv/bytesconv.go
+++ b/internal/bytesconv/bytesconv.go
@@ -4,21 +4,12 @@
 
 package bytesconv
 
-import (
-	"unsafe"
-)
-
-// StringToBytes converts string to byte slice without a memory allocation.
+// StringToBytes converts string to byte slice
 func StringToBytes(s string) []byte {
-	return *(*[]byte)(unsafe.Pointer(
-		&struct {
-			string
-			Cap int
-		}{s, len(s)},
-	))
+	return []byte(s)
 }
 
-// BytesToString converts byte slice to string without a memory allocation.
+// BytesToString converts byte slice to string
 func BytesToString(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
+	return string(b)
 }


### PR DESCRIPTION
Security Optimization string to byte slice
golang's security mechanism should not be bypassed
