### PR TITLE
Use the Gin context when doing WrapF or WrapH

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -39,14 +39,14 @@ func Bind(val any) HandlerFunc {
 // WrapF is a helper function for wrapping http.HandlerFunc and returns a Gin middleware.
 func WrapF(f http.HandlerFunc) HandlerFunc {
 	return func(c *Context) {
-		f(c.Writer, c.Request)
+		f(c.Writer, c.Request.WithContext(c))
 	}
 }
 
 // WrapH is a helper function for wrapping http.Handler and returns a Gin middleware.
 func WrapH(h http.Handler) HandlerFunc {
 	return func(c *Context) {
-		h.ServeHTTP(c.Writer, c.Request)
+		h.ServeHTTP(c.Writer, c.Request.WithContext(c))
 	}
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -31,16 +31,23 @@ type testStruct struct {
 func (t *testStruct) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	assert.Equal(t.T, "POST", req.Method)
 	assert.Equal(t.T, "/path", req.URL.Path)
+	assert.Equal(t.T, "yes", req.Context().Value("middleware"))
 	w.WriteHeader(http.StatusInternalServerError)
 	fmt.Fprint(w, "hello")
 }
 
 func TestWrap(t *testing.T) {
 	router := New()
+
+	router.Use(func(c *Context) {
+		c.Set("middleware", "yes")
+	})
+
 	router.POST("/path", WrapH(&testStruct{t}))
 	router.GET("/path2", WrapF(func(w http.ResponseWriter, req *http.Request) {
 		assert.Equal(t, "GET", req.Method)
 		assert.Equal(t, "/path2", req.URL.Path)
+		assert.Equal(t, "yes", req.Context().Value("middleware"))
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, "hola!")
 	}))


### PR DESCRIPTION
Because the signature of an `http.Handler` does not include a `*gin.Context`, an `http.Handler` can only access `req.Context()`. However, this always refers to the request's original context instead of the Gin context. This means that any values set with Gin's `c.Set` are not accessible in those handlers. This means that Gin middleware that sets context values actually can't pass values to third-party handlers!

This PR updates `WrapF` and `WrapH` to make `req.Context()` return the Gin context itself. This makes calls like `c.Value` work as expected.

`c.Request` is unaffected by this change, meaning that the original request (with its original context) can still be accessed via `req.Context().(*gin.Context).Request` if absolutely necessary. This also means that `ContextWithFallback` still works.