### PR TITLE
unmarshal xml array in golang only getting the first element if xml have same and muti root node

### DIFF
--- a/binding/xml.go
+++ b/binding/xml.go
@@ -26,8 +26,13 @@ func (xmlBinding) BindBody(body []byte, obj any) error {
 }
 func decodeXML(r io.Reader, obj any) error {
 	decoder := xml.NewDecoder(r)
-	if err := decoder.Decode(obj); err != nil {
-		return err
+	for  {
+		if err := decoder.Decode(obj); err != nil {
+			if err == io.EOF{
+				break
+			}
+			return err
+		}
 	}
 	return validate(obj)
 }


### PR DESCRIPTION
here is xml.Unmarshal problem if xml have muti-root:

[unmarshal-xml-array-in-golang-only-getting-the-first-element](https://stackoverflow.com/questions/27553274/unmarshal-xml-array-in-golang-only-getting-the-first-element)

[so  gin have same problem](https://stackoverflow.com/questions/74226570/golang-gin-binding-request-body-xml-to-slice):

if gin bind muti-root-xml, it should use for util io.EOF


