### PR TITLE
chore(docs): Remove the Brigade project, because the Gin is no longer used in the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2366,5 +2366,4 @@ Awesome project lists using [Gin](https://github.com/gin-gonic/gin) web framewor
 * [photoprism](https://github.com/photoprism/photoprism): Personal photo management powered by Go and Google TensorFlow.
 * [krakend](https://github.com/devopsfaith/krakend): Ultra performant API Gateway with middlewares.
 * [picfit](https://github.com/thoas/picfit): An image resizing server written in Go.
-* [brigade](https://github.com/brigadecore/brigade): Event-based Scripting for Kubernetes.
 * [dkron](https://github.com/distribworks/dkron): Distributed, fault tolerant job scheduling system.


### PR DESCRIPTION
And the [Brigade](https://github.com/brigadecore/brigade) is an archived CNCF project now.