### PR TITLE
Create a way to transform net/http requests into Contexts

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -562,16 +562,39 @@ func (engine *Engine) RunListener(listener net.Listener) (err error) {
 	return
 }
 
-// ServeHTTP conforms to the http.Handler interface.
-func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+// GetContext transforms a http.ResponseWriter and *http.Request into a new
+// *Context without handling the request. This new context can then be passed
+// to *Engine.HandleContext for handling.
+//
+// Any contexts created with this method are not automatically returned to the
+// pool, so it is recommended that you call *Engine.ReleaseContext when you are
+// done with it, though this is not required.
+func (engine *Engine) GetContext(w http.ResponseWriter, req *http.Request) *Context {
 	c := engine.pool.Get().(*Context)
 	c.writermem.reset(w)
 	c.Request = req
 	c.reset()
 
+	return c
+}
+
+// ReleaseContext releases a context created with *Engine.GetContext back into
+// the pool. Releasing a context marks it as available for reuse and therefore
+// must only be called once the context is no longer in use. Releasing a context
+// is not required, but it is recommended to improve performance. Calling this
+// method on a context that is not created with *Engine.GetContext will result
+// in undefined behavior.
+func (engine *Engine) ReleaseContext(c *Context) {
+	engine.pool.Put(c)
+}
+
+// ServeHTTP conforms to the http.Handler interface.
+func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	c := engine.GetContext(w, req)
+
 	engine.handleHTTPRequest(c)
 
-	engine.pool.Put(c)
+	engine.ReleaseContext(c)
 }
 
 // HandleContext re-enters a context that has been rewritten.


### PR DESCRIPTION
- Add a method for retrieving a new *Context given an http.ResponseWriter and *http.Request.
- Add a method for returning to the pool *Contexts which were provided by *Engine.GetRequest to the pool

This allows contexts to be manipulated prior to handling whereas ServeHTTP does not provide the caller with access to the context.

---

ReleaseContext does have some potential issues if, for example, a context from one engine was released to another. One option is to check all of the fields on the Context are set to expected values. Alternatively, the ReleaseContext method could be removed entirely, however that would make pooling impossible since there is no way for an outside package to set up a Context for reuse.