### PR TITLE
Don't panic when failed to render or write JSON

### DIFF
--- a/render/json.go
+++ b/render/json.go
@@ -54,10 +54,7 @@ var (
 
 // Render (JSON) writes data with custom ContentType.
 func (r JSON) Render(w http.ResponseWriter) (err error) {
-	if err = WriteJSON(w, r.Data); err != nil {
-		panic(err)
-	}
-	return
+	return WriteJSON(w, r.Data)
 }
 
 // WriteContentType (JSON) writes JSON ContentType.


### PR DESCRIPTION
Currently, gin will panic if failed to write JSON to client and it's unnecessary for most scenarios. Because most of them are caused by network error like connection reset or timeout, it'd be better to retrieve an error instead of panic.

This PR can also fix this issue: https://github.com/gin-gonic/gin/issues/3351
