### PR TITLE
docs(context): #3369 modify the annotation about Context.Param()

### DIFF
--- a/context.go
+++ b/context.go
@@ -386,7 +386,9 @@ func (c *Context) GetStringMapStringSlice(key string) (smss map[string][]string)
 //
 //	router.GET("/user/:id", func(c *gin.Context) {
 //	    // a GET request to /user/john
-//	    id := c.Param("id") // id == "john"
+//	    id := c.Param("id") // id == "/john"
+//	    // a GET request to /user/john/
+//	    id := c.Param("id") // id == "/john/"
 //	})
 func (c *Context) Param(key string) string {
 	return c.Params.ByName(key)


### PR DESCRIPTION
If you don't want to motify the annotation. Maybe I can fix it in the tree.go (func Get or func ByName).

Please feel free to reach out with any questions.

Thank you very much.
