### PR TITLE
Replace Index*, SplitN with Cut

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -369,11 +369,8 @@ func setTimeDuration(val string, value reflect.Value) error {
 }
 
 func head(str, sep string) (head string, tail string) {
-	idx := strings.Index(str, sep)
-	if idx < 0 {
-		return str, ""
-	}
-	return str[:idx], str[idx+len(sep):]
+	head, tail, _ = strings.Cut(str, sep)
+	return head, tail
 }
 
 func setFormMap(ptr any, form map[string][]string) error {

--- a/context.go
+++ b/context.go
@@ -562,10 +562,10 @@ func (c *Context) get(m map[string][]string, key string) (map[string]string, boo
 	dicts := make(map[string]string)
 	exist := false
 	for k, v := range m {
-		if i := strings.IndexByte(k, '['); i >= 1 && k[0:i] == key {
-			if j := strings.IndexByte(k[i+1:], ']'); j >= 1 {
+		if before, after, found := strings.Cut(k, "["); found && before == key {
+			if before, _, found := strings.Cut(after, "]"); found && before != "" {
 				exist = true
-				dicts[k[i+1:][:j]] = v[0]
+				dicts[before] = v[0]
 			}
 		}
 	}

--- a/tree.go
+++ b/tree.go
@@ -241,9 +241,10 @@ walk:
 				// Wildcard conflict
 				pathSeg := path
 				if n.nType != catchAll {
-					pathSeg = strings.SplitN(pathSeg, "/", 2)[0]
+					pathSeg, _, _ = strings.Cut(pathSeg, "/")
 				}
-				prefix := fullPath[:strings.Index(fullPath, pathSeg)] + n.path
+				prefix, _, _ := strings.Cut(fullPath, pathSeg)
+				prefix = prefix + n.path
 				panic("'" + pathSeg +
 					"' in new path '" + fullPath +
 					"' conflicts with existing wildcard '" + n.path +
@@ -351,7 +352,7 @@ func (n *node) insertChild(path string, fullPath string, handlers HandlersChain)
 		}
 
 		if len(n.path) > 0 && n.path[len(n.path)-1] == '/' {
-			pathSeg := strings.SplitN(n.children[0].path, "/", 2)[0]
+			pathSeg, _, _ := strings.Cut(n.children[0].path, "/")
 			panic("catch-all wildcard '" + path +
 				"' in new path '" + fullPath +
 				"' conflicts with existing path segment '" + pathSeg +

--- a/utils.go
+++ b/utils.go
@@ -104,8 +104,8 @@ func parseAccept(acceptHeader string) []string {
 	parts := strings.Split(acceptHeader, ",")
 	out := make([]string, 0, len(parts))
 	for _, part := range parts {
-		if i := strings.IndexByte(part, ';'); i > 0 {
-			part = part[:i]
+		if before, _, found := strings.Cut(part, ";"); found {
+			part = before
 		}
 		if part = strings.TrimSpace(part); part != "" {
 			out = append(out, part)


### PR DESCRIPTION
- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

`strings.Cut` and `bytes.Cut`, added in [Go 1.18](https://tip.golang.org/doc/go1.18), make it easier to cut out substrings and make the code more readable than with `strings.Index*` and others.

Therefore, I send a PR to replace them.

Some parts of the code do not replace `strings.Index` because they are used with "strings.LastIndex".