### PR TITLE
Wrap the context render panic.

### DIFF
--- a/context.go
+++ b/context.go
@@ -922,7 +922,10 @@ func (c *Context) Render(code int, r render.Render) {
 	}
 
 	if err := r.Render(c.Writer); err != nil {
-		panic(err)
+		panic(Error{
+			Err:  err,
+			Type: ErrorTypeRender,
+		})
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -655,6 +655,16 @@ func TestContextRenderPanicIfErr(t *testing.T) {
 	defer func() {
 		r := recover()
 		assert.Equal(t, "TestPanicRender", fmt.Sprint(r))
+
+		// confirm the recovered object is an error
+		err, ok := r.(error)
+		assert.True(t, ok)
+
+		// the error returned should be a gin render Error
+		e := Error{}
+		assert.True(t, errors.As(err, &e))
+		assert.ErrorContains(t, e.Unwrap(), "TestPanicRender")
+		assert.True(t, e.IsType(ErrorTypeRender))
 	}()
 	w := httptest.NewRecorder()
 	c, _ := CreateTestContext(w)


### PR DESCRIPTION
The utility of the `c.JSON` helper or other `context.Render` methods not returning an error simplifies client code.

There are rare errors during rendering that result in a panic, which most production systems will handle in middleware.

This introduces the ability to detect that it is a gin rendering error in the panic handler as opposed to other handler logic panics.

To be able to trap c.JSON render panics this PR will also need https://github.com/gin-gonic/gin/pull/3390 - which changes the JSON renderer to be more consistent, until that is also merged this context Render panic will not fire.


- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

