### PR TITLE
Draft: add X-Forwarded-Proto support

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -112,6 +112,8 @@ type Engine struct {
 	// `(*gin.Context).Request.RemoteAddr`.
 	ForwardedByClientIP bool
 
+	ForwardedByClientProto bool
+
 	// AppEngine was deprecated.
 	// Deprecated: USE `TrustedPlatform` WITH VALUE `gin.PlatformGoogleAppEngine` INSTEAD
 	// #726 #755 If enabled, it will trust some headers starting with
@@ -135,6 +137,8 @@ type Engine struct {
 	// `(*gin.Context).Request.RemoteAddr` is matched by at least one of the
 	// network origins of list defined by `(*gin.Engine).SetTrustedProxies()`.
 	RemoteIPHeaders []string
+
+	RemoteProtoHeaders []string
 
 	// TrustedPlatform if set to a constant of value gin.Platform*, trusts the headers set by
 	// that platform, for example to determine the client IP
@@ -189,7 +193,9 @@ func New() *Engine {
 		RedirectFixedPath:      false,
 		HandleMethodNotAllowed: false,
 		ForwardedByClientIP:    true,
+		ForwardedByClientProto: true,
 		RemoteIPHeaders:        []string{"X-Forwarded-For", "X-Real-IP"},
+		RemoteProtoHeaders:     []string{"X-Forwarded-Proto"},
 		TrustedPlatform:        defaultPlatform,
 		UseRawPath:             false,
 		RemoveExtraSlash:       false,


### PR DESCRIPTION
**This PR is a draft, it's objective is to add a new function that is used to obtain the scheme from remote user's request. I'm not sure if this proposal will be accept by yours, so I haven't added tests and document until we can confirm it.**

As you know, many servers are run behind a proxy server, that's why Gin has the mechanism like `c.ClientIP()` that is used to get client address from HTTP header. 

In addition to the IP address, server's HTTPS certification is always configured in the proxy server too, such as Nginx, Caddy, Cloudflare. [Caddy](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#defaults) and [Cloudflare](https://developers.cloudflare.com/fundamentals/get-started/reference/http-request-headers/#x-forwarded-proto) are both use `X-Forwarded-Proto` to told the web app if the client user visit them by https or not. 

Other web framework like [Django](https://docs.djangoproject.com/en/4.1/ref/settings/#secure-proxy-ssl-header) also have a setting that is able to allow a trusted scheme header.

Currently Gin doesn't have a trusted method to get `X-Forwarded-Proto` like `X-Forwarded-For`. Be similar to `X-Forwarded-For`, we have to check if the remote ip is a trusted proxy server before getting the header. So I create this PR to implement it.

Referring to the `ClientIP` function, the new `ClientProto` function will like that:

```go
func (c *Context) ClientProto() string {
	var isTls = c.Request.TLS != nil
	remoteIP := net.ParseIP(c.RemoteIP())
	if remoteIP == nil {
		return ""
	}
	trusted := c.engine.isTrustedProxy(remoteIP)

	if trusted && c.engine.ForwardedByClientProto && c.engine.RemoteProtoHeaders != nil {
		for _, headerName := range c.engine.RemoteProtoHeaders {
			proto, valid := c.engine.validateHeader(c.requestHeader(headerName))
			if valid {
				return proto
			}
		}
	}

	if isTls {
		return "https"
	} else {
		return "http"
	}
}
```

Looking forward your reply, we can discuss about it.