### PR TITLE
Draft: added `FromTrustProxy` function to `gin.Context`

### DIFF
--- a/context.go
+++ b/context.go
@@ -814,6 +814,15 @@ func (c *Context) RemoteIP() string {
 	return ip
 }
 
+// FromTrustProxy check if the request is from a trusted proxy server
+func (c *Context) FromTrustProxy() bool {
+	remoteIP := net.ParseIP(c.RemoteIP())
+	if remoteIP == nil {
+		return false
+	}
+	return c.engine.isTrustedProxy(remoteIP)
+}
+
 // ContentType returns the Content-Type header of the request.
 func (c *Context) ContentType() string {
 	return filterFlags(c.requestHeader("Content-Type"))


### PR DESCRIPTION
**This PR is a draft, it's objective is to add a new function that is used to check if the request is from a trusted proxy server. I'm not sure if this proposal will be accept by yous, so I haven't added tests and document until we can confirm it.**

Sometimes we want to get some useful headers like `X-Forwarded-Proto` from reverse proxy. Currently Gin have a checking mechanism that is used to obtain `X-Forwarded-For` header safely, but it is not exposed.

This PR is aimed at exposing `isTrustedProxy` to developer. And it also is an alternative for <https://github.com/gin-gonic/gin/pull/3447>, is a painless resolution.
