### PR TITLE
console logger HTTP status code bug fixed

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -61,6 +61,7 @@ func (w *responseWriter) WriteHeader(code int) {
 	if code > 0 && w.status != code {
 		if w.Written() {
 			debugPrint("[WARNING] Headers were already written. Wanted to override status code %d with %d", w.status, code)
+			return
 		}
 		w.status = code
 	}

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -132,3 +132,21 @@ func TestResponseWriterFlush(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 }
+
+func TestResponseWriterStatusCode(t *testing.T) {
+	testWriter := httptest.NewRecorder()
+	writer := &responseWriter{}
+	writer.reset(testWriter)
+	w := ResponseWriter(writer)
+
+	w.WriteHeader(http.StatusOK)
+	w.WriteHeaderNow()
+
+	assert.Equal(t, http.StatusOK, w.Status())
+	assert.True(t, w.Written())
+
+	w.WriteHeader(http.StatusUnauthorized)
+
+	// status must be 200 although we tried to change it
+	assert.Equal(t, http.StatusOK, w.Status())
+}


### PR DESCRIPTION
@manucorporat @thinkerou @appleboy 
Hello Dears.
It looks like the console logger HTTP response code is not equal to the client(browser) HTTP status code in the case we set the response status code twice or more by mistake or whatever.
It would make some problems when we want to monitor our network traffic because the status code which we have is not right.
Please consider the following code:
```go
	router := gin.Default()

	router.GET("/", func(c *gin.Context) {
		c.String(http.StatusOK, "Status OK")
		c.String(http.StatusUnauthorized, "Status Unauthorized")
	})

	router.Run()
```
If we make an HTTP request by curl:
```curl
curl -v 127.0.0.1:8080
```
We'll get 200 status by curl, but the console logger prints 401, and its not true.

I fixed this problem by preventing rewriting the HTTP status code in the response writer and It's working fine now.

Regards.