### PR TITLE
refactor: use bytes.ReplaceAll directly

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -164,7 +164,7 @@ func function(pc uintptr) []byte {
 	if period := bytes.Index(name, dot); period >= 0 {
 		name = name[period+1:]
 	}
-	name = bytes.Replace(name, centerDot, dot, -1)
+	name = bytes.ReplaceAll(name, centerDot, dot)
 	return name
 }
 


### PR DESCRIPTION
Use `bytes.ReplaceAll(name, centerDot, dot)` instead of `bytes.Replace(name, centerDot, dot, -1)`, which looks more concise
