### PR TITLE
chore/make initFormCache public #3462

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -377,6 +377,7 @@ People and companies, who have contributed, in alphabetical order.
 - vinhha96 <anhvinha1@gmail.com>
 - voidman <retmain@foxmail.com>
 - vz <vzvway@gmail.com>
+- webstradev <erik@webstra.dev>
 - wei <wei840222@gmail.com>
 - weibaohui <weibaohui@yeah.net>
 - whirosan <whirosan@users.noreply.github.com>

--- a/context.go
+++ b/context.go
@@ -525,7 +525,7 @@ func (c *Context) PostFormArray(key string) (values []string) {
 	return
 }
 
-func (c *Context) initFormCache() {
+func (c *Context) InitFormCache() {
 	if c.formCache == nil {
 		c.formCache = make(url.Values)
 		req := c.Request
@@ -541,7 +541,7 @@ func (c *Context) initFormCache() {
 // GetPostFormArray returns a slice of strings for a given form key, plus
 // a boolean value whether at least one value exists for the given key.
 func (c *Context) GetPostFormArray(key string) (values []string, ok bool) {
-	c.initFormCache()
+	c.InitFormCache()
 	values, ok = c.formCache[key]
 	return
 }
@@ -555,7 +555,7 @@ func (c *Context) PostFormMap(key string) (dicts map[string]string) {
 // GetPostFormMap returns a map for a given form key, plus a boolean value
 // whether at least one value exists for the given key.
 func (c *Context) GetPostFormMap(key string) (map[string]string, bool) {
-	c.initFormCache()
+	c.InitFormCache()
 	return c.get(c.formCache, key)
 }
 


### PR DESCRIPTION

As described in #3462 . The FormCache only gets initialized when calling GetPostForm or GetPostForm Array. There are some use cases for example when wanting to iterate over the entire form, that it would be convenient to be able to initialize the cache directly. 

In this pr, I have simply made initFormCache public so it can be called in such use cases.