### PR TITLE
chore(router): match method added to routergroup for multiple HTTP methods supporting

### DIFF
--- a/routergroup.go
+++ b/routergroup.go
@@ -42,6 +42,7 @@ type IRoutes interface {
 	PUT(string, ...HandlerFunc) IRoutes
 	OPTIONS(string, ...HandlerFunc) IRoutes
 	HEAD(string, ...HandlerFunc) IRoutes
+	Match([]string, string, ...HandlerFunc) IRoutes
 
 	StaticFile(string, string) IRoutes
 	StaticFileFS(string, string, http.FileSystem) IRoutes
@@ -145,6 +146,15 @@ func (group *RouterGroup) HEAD(relativePath string, handlers ...HandlerFunc) IRo
 // GET, POST, PUT, PATCH, HEAD, OPTIONS, DELETE, CONNECT, TRACE.
 func (group *RouterGroup) Any(relativePath string, handlers ...HandlerFunc) IRoutes {
 	for _, method := range anyMethods {
+		group.handle(method, relativePath, handlers)
+	}
+
+	return group.returnObj()
+}
+
+// Match registers a route that matches the specified methods that you declared.
+func (group *RouterGroup) Match(methods []string, relativePath string, handlers ...HandlerFunc) IRoutes {
+	for _, method := range methods {
 		group.handle(method, relativePath, handlers)
 	}
 

--- a/routergroup_test.go
+++ b/routergroup_test.go
@@ -186,6 +186,7 @@ func testRoutesInterface(t *testing.T, r IRoutes) {
 	assert.Equal(t, r, r.PUT("/", handler))
 	assert.Equal(t, r, r.OPTIONS("/", handler))
 	assert.Equal(t, r, r.HEAD("/", handler))
+	assert.Equal(t, r, r.Match([]string{http.MethodPut, http.MethodPatch}, "/match", handler))
 
 	assert.Equal(t, r, r.StaticFile("/file", "."))
 	assert.Equal(t, r, r.StaticFileFS("/static2", ".", Dir(".", false)))


### PR DESCRIPTION
I added the Match method to the IRoutes interface and RouterGroup struct for supporting multiple HTTP methods with single functionality and handler.

For example, this is common to use both PUT and PATCH methods when developing RESTful APIs for updating models.
Without this method, we should repeat ourselves to handle this.

With the Match method our routing signature is like this:

```go
r.Match([]string{http.MethodPut, http.MethodPatch}, "/", func(c *gin.Context) {
    c.String(http.StatusOK, "This handler will support both PUT and PATCH methods.")
})
```