### PR TITLE
gin.Context: check key type on calling Value when key is 0

### DIFF
--- a/context.go
+++ b/context.go
@@ -1200,7 +1200,7 @@ func (c *Context) Err() error {
 // if no value is associated with key. Successive calls to Value with
 // the same key returns the same result.
 func (c *Context) Value(key any) any {
-	if key == 0 {
+	if _, ok := key.(int); ok && key == 0 {
 		return c.Request
 	}
 	if key == ContextKey {


### PR DESCRIPTION
The type of context key is part of the key used in the context.Context type. 
Many packages use zero and an unexported type to inject values into context.Context.
An example is [Go-OpenTelemetry](https://github.com/open-telemetry/opentelemetry-go/blob/main/trace/context.go#L25), where it uses `traceContextKeyType` and value `0` as the key.

Since we have added `ContextWithFallback` option, it is now crucial to avoid interrupting other packages' procedures by checking the type of value before blindly assuming it is `int(0)` and returning `context.Request`.

This change will guarantee that `context.Value(0)` still returns `context.Request` while it will allow other packages to continue working as expected.