### PR TITLE
Treat http.ErrAbortHandler as broken pipe

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -69,6 +69,9 @@ func CustomRecoveryWithWriter(out io.Writer, handle RecoveryFunc) HandlerFunc {
 						}
 					}
 				}
+				if errors.Is(err, http.ErrAbortHandler) {
+					brokenPipe = true
+				}
 				if logger != nil {
 					stack := stack(3)
 					httpRequest, _ := httputil.DumpRequest(c.Request, false)


### PR DESCRIPTION
```
ErrAbortHandler is a sentinel panic value to abort a handler.
While any panic from ServeHTTP aborts the response to the client, panicking with ErrAbortHandler also suppresses logging of a stack trace to the server's error log.
```

- CC - #1714
- similar to https://github.com/gorilla/handlers/pull/159/files
- Other PR: https://github.com/gin-gonic/gin/pull/2590

- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

