### PR TITLE
chore(http): add support for go1.20 http.rwUnwrapper to gin.responseWriter

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -51,6 +51,10 @@ type responseWriter struct {
 
 var _ ResponseWriter = (*responseWriter)(nil)
 
+func (w *responseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
 func (w *responseWriter) reset(writer http.ResponseWriter) {
 	w.ResponseWriter = writer
 	w.size = noWritten

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -30,6 +30,12 @@ func init() {
 	SetMode(TestMode)
 }
 
+func TestResponseWriterUnwrap(t *testing.T) {
+	testWriter := httptest.NewRecorder()
+	writer := &responseWriter{ResponseWriter: testWriter}
+	assert.Same(t, testWriter, writer.Unwrap())
+}
+
 func TestResponseWriterReset(t *testing.T) {
 	testWriter := httptest.NewRecorder()
 	writer := &responseWriter{}


### PR DESCRIPTION
This PR implements the go1.20 `http.rwUnwrapper` interface on the private gin.responseWriter type:
```go
type rwUnwrapper interface {
	Unwrap() ResponseWriter
}
```

This will allow code using go1.20 to use the http.ResponseController utility type added in go1.20.

```go
engine.GET("/path", func (c *gin.Context) {
  controller := http.NewResponseController(c.Writer)
  controller.SetWriteDeadline(time.Second)
  // ...
}
```

