### PR TITLE
fix bug in validateHeader

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -463,17 +463,20 @@ func (engine *Engine) validateHeader(header string) (clientIP string, valid bool
 	for i := len(items) - 1; i >= 0; i-- {
 		ipStr := strings.TrimSpace(items[i])
 		ip := net.ParseIP(ipStr)
+		valid = true
+
 		if ip == nil {
-			break
+			ipStr = ""
+			valid = false
 		}
 
 		// X-Forwarded-For is appended by proxy
 		// Check IPs in reverse order and stop when find untrusted proxy
-		if (i == 0) || (!engine.isTrustedProxy(ip)) {
-			return ipStr, true
+		if valid && (!engine.isTrustedProxy(ip)) {
+			return ipStr, valid
 		}
 	}
-	return "", false
+	return "", valid
 }
 
 // parseIP parse a string representation of an IP and returns a net.IP with the


### PR DESCRIPTION
Improved IP header logic. We have a problem getting a client IP if it has "X-Forwarded-For: xxx.xxx.xxx.xxx,"
Example:
X-Forwarded-For client header mask: CDN-IP, NAT-IP, any IP, space character
After checking this header, we have an IP from Header.RemoteAddr Docker Swarm IP or CDN-IP