### PR TITLE
refactor: Ignore the error which never occur

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -59,9 +59,8 @@ func (h H) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		Space: "",
 		Local: "map",
 	}
-	if err := e.EncodeToken(start); err != nil {
-		return err
-	}
+	_ = e.EncodeToken(start)
+
 	for key, value := range h {
 		elem := xml.StartElement{
 			Name: xml.Name{Space: "", Local: key},


### PR DESCRIPTION
- ignore the error which is never occur
```
	start.Name = xml.Name{
		Space: "",
		Local: "map",
	}
```
```
	if start.Name.Local == "" {
		return fmt.Errorf("xml: start tag with no name")
	}
```