### PR TITLE
feature: Add content-length header where it is possible without reading buffers

### DIFF
--- a/render/data.go
+++ b/render/data.go
@@ -15,6 +15,9 @@ type Data struct {
 // Render (Data) writes data with custom ContentType.
 func (r Data) Render(w http.ResponseWriter) (err error) {
 	r.WriteContentType(w)
+
+	writeContentLength(w, len(r.Data))
+
 	_, err = w.Write(r.Data)
 	return
 }

--- a/render/protobuf.go
+++ b/render/protobuf.go
@@ -26,6 +26,8 @@ func (r ProtoBuf) Render(w http.ResponseWriter) error {
 		return err
 	}
 
+	writeContentLength(w, len(bytes))
+
 	_, err = w.Write(bytes)
 	return err
 }

--- a/render/render.go
+++ b/render/render.go
@@ -4,7 +4,10 @@
 
 package render
 
-import "net/http"
+import (
+	"net/http"
+	"strconv"
+)
 
 // Render interface is to be implemented by JSON, XML, HTML, YAML and so on.
 type Render interface {
@@ -38,4 +41,8 @@ func writeContentType(w http.ResponseWriter, value []string) {
 	if val := header["Content-Type"]; len(val) == 0 {
 		header["Content-Type"] = value
 	}
+}
+
+func writeContentLength(w http.ResponseWriter, value int) {
+	w.Header().Set("Content-Length", strconv.Itoa(value))
 }

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -38,6 +38,8 @@ func TestRenderJSON(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "{\"foo\":\"bar\",\"html\":\"\\u003cb\\u003e\"}", w.Body.String())
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+	assert.Equal(t, "36", w.Header().Get("Content-Length"))
+
 }
 
 func TestRenderJSONError(t *testing.T) {
@@ -60,6 +62,8 @@ func TestRenderIndentedJSON(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "{\n    \"bar\": \"foo\",\n    \"foo\": \"bar\"\n}", w.Body.String())
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+	assert.Equal(t, "38", w.Header().Get("Content-Length"))
+
 }
 
 func TestRenderIndentedJSONPanics(t *testing.T) {
@@ -85,6 +89,7 @@ func TestRenderSecureJSON(t *testing.T) {
 	assert.NoError(t, err1)
 	assert.Equal(t, "{\"foo\":\"bar\"}", w1.Body.String())
 	assert.Equal(t, "application/json; charset=utf-8", w1.Header().Get("Content-Type"))
+	assert.Equal(t, "13", w1.Header().Get("Content-Length"))
 
 	w2 := httptest.NewRecorder()
 	datas := []map[string]any{{
@@ -97,6 +102,7 @@ func TestRenderSecureJSON(t *testing.T) {
 	assert.NoError(t, err2)
 	assert.Equal(t, "while(1);[{\"foo\":\"bar\"},{\"bar\":\"foo\"}]", w2.Body.String())
 	assert.Equal(t, "application/json; charset=utf-8", w2.Header().Get("Content-Type"))
+	assert.Equal(t, "38", w2.Header().Get("Content-Length"))
 }
 
 func TestRenderSecureJSONFail(t *testing.T) {
@@ -122,6 +128,7 @@ func TestRenderJsonpJSON(t *testing.T) {
 	assert.NoError(t, err1)
 	assert.Equal(t, "x({\"foo\":\"bar\"});", w1.Body.String())
 	assert.Equal(t, "application/javascript; charset=utf-8", w1.Header().Get("Content-Type"))
+	assert.Equal(t, "17", w1.Header().Get("Content-Length"))
 
 	w2 := httptest.NewRecorder()
 	datas := []map[string]any{{
@@ -134,6 +141,8 @@ func TestRenderJsonpJSON(t *testing.T) {
 	assert.NoError(t, err2)
 	assert.Equal(t, "x([{\"foo\":\"bar\"},{\"bar\":\"foo\"}]);", w2.Body.String())
 	assert.Equal(t, "application/javascript; charset=utf-8", w2.Header().Get("Content-Type"))
+	assert.Equal(t, "33", w2.Header().Get("Content-Length"))
+
 }
 
 func TestRenderJsonpJSONError2(t *testing.T) {
@@ -149,6 +158,7 @@ func TestRenderJsonpJSONError2(t *testing.T) {
 
 	assert.Equal(t, "{\"foo\":\"bar\"}", w.Body.String())
 	assert.Equal(t, "application/javascript; charset=utf-8", w.Header().Get("Content-Type"))
+	assert.Equal(t, "13", w.Header().Get("Content-Length"))
 }
 
 func TestRenderJsonpJSONFail(t *testing.T) {
@@ -172,6 +182,7 @@ func TestRenderAsciiJSON(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "{\"lang\":\"GO\\u8bed\\u8a00\",\"tag\":\"\\u003cbr\\u003e\"}", w1.Body.String())
 	assert.Equal(t, "application/json", w1.Header().Get("Content-Type"))
+	assert.Equal(t, "48", w1.Header().Get("Content-Length"))
 
 	w2 := httptest.NewRecorder()
 	data2 := 3.1415926
@@ -179,6 +190,8 @@ func TestRenderAsciiJSON(t *testing.T) {
 	err = (AsciiJSON{data2}).Render(w2)
 	assert.NoError(t, err)
 	assert.Equal(t, "3.1415926", w2.Body.String())
+	assert.Equal(t, "9", w2.Header().Get("Content-Length"))
+
 }
 
 func TestRenderAsciiJSONFail(t *testing.T) {
@@ -240,6 +253,8 @@ b:
 	assert.NoError(t, err)
 	assert.Equal(t, "|4-\n    a : Easy!\n    b:\n    \tc: 2\n    \td: [3, 4]\n    \t\n", w.Body.String())
 	assert.Equal(t, "application/x-yaml; charset=utf-8", w.Header().Get("Content-Type"))
+	assert.Equal(t, "56", w.Header().Get("Content-Length"))
+
 }
 
 type fail struct{}
@@ -268,6 +283,8 @@ func TestRenderTOML(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "foo = 'bar'\nhtml = '<b>'\n", w.Body.String())
 	assert.Equal(t, "application/toml; charset=utf-8", w.Header().Get("Content-Type"))
+	assert.Equal(t, "25", w.Header().Get("Content-Length"))
+
 }
 
 func TestRenderTOMLFail(t *testing.T) {
@@ -296,6 +313,8 @@ func TestRenderProtoBuf(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, string(protoData), w.Body.String())
 	assert.Equal(t, "application/x-protobuf", w.Header().Get("Content-Type"))
+	assert.Equal(t, strconv.Itoa(len(string(protoData))), w.Header().Get("Content-Length"))
+
 }
 
 func TestRenderProtoBufFail(t *testing.T) {
@@ -373,6 +392,8 @@ func TestRenderData(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "#!PNG some raw data", w.Body.String())
 	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+	assert.Equal(t, "19", w.Header().Get("Content-Length"))
+
 }
 
 func TestRenderString(t *testing.T) {
@@ -405,6 +426,8 @@ func TestRenderStringLenZero(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "hola %s %d", w.Body.String())
 	assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
+	assert.Equal(t, "10", w.Header().Get("Content-Length"))
+
 }
 
 func TestRenderHTMLTemplate(t *testing.T) {

--- a/render/text.go
+++ b/render/text.go
@@ -36,6 +36,12 @@ func WriteString(w http.ResponseWriter, format string, data []any) (err error) {
 		_, err = fmt.Fprintf(w, format, data...)
 		return
 	}
-	_, err = w.Write(bytesconv.StringToBytes(format))
+
+	bytes := bytesconv.StringToBytes(format)
+
+	writeContentLength(w, len(bytes))
+
+	_, err = w.Write(bytes)
+
 	return
 }

--- a/render/toml.go
+++ b/render/toml.go
@@ -26,6 +26,8 @@ func (r TOML) Render(w http.ResponseWriter) error {
 		return err
 	}
 
+	writeContentLength(w, len(bytes))
+
 	_, err = w.Write(bytes)
 	return err
 }

--- a/render/yaml.go
+++ b/render/yaml.go
@@ -26,6 +26,8 @@ func (r YAML) Render(w http.ResponseWriter) error {
 		return err
 	}
 
+	writeContentLength(w, len(bytes))
+
 	_, err = w.Write(bytes)
 	return err
 }


### PR DESCRIPTION
 The `Content-Length` header is missing for some JSON responses.
After some investigation, I found the following comment in the [net/http](https://pkg.go.dev/net/http#ResponseWriter.Write) documentation that states that
```
...if the total size of all written
data is under a few KB, and there are no Flush calls, the
Content-Length header is added automatically.
```
This led to the conclusion that there is no `Content-Length`  header for longer responses because they are longer than the [2048-byte limit](https://cs.opensource.google/go/go/+/refs/tags/go1.20.2:src/net/http/server.go;l=338). However, in a lot of cases, the renderer knows the length of the response (it's a `[]byte` or `string`)
This PR adds the `Content-Length`  header in those cases.

This investigation was because we noticed gzip compression in our CDN wasn't working (Cloudfront), and we realized this was due to the missing `Content-Length` header. 
https://aws.amazon.com/premiumsupport/knowledge-center/cloudfront-troubleshoot-compressed-files/#:~:text=Check%20your%20CloudFront%20configuration,a%20value%20greater%20than%20zero.

I have added test cases for the renderers with the added `Content-Length` header. There are some inconsistencies in the actual renderers and how the tests are structured, so I adapted my code to the style of the current scope.


- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

