### PR TITLE
improve the context.MultipartForm method

### DIFF
--- a/context.go
+++ b/context.go
@@ -591,8 +591,12 @@ func (c *Context) FormFile(name string) (*multipart.FileHeader, error) {
 
 // MultipartForm is the parsed multipart form, including file uploads.
 func (c *Context) MultipartForm() (*multipart.Form, error) {
-	err := c.Request.ParseMultipartForm(c.engine.MaxMultipartMemory)
-	return c.Request.MultipartForm, err
+	if c.Request.MultipartForm == nil {
+		if err := c.Request.ParseMultipartForm(c.engine.MaxMultipartMemory); err != nil {
+			return nil, err
+		}
+	}
+	return c.Request.MultipartForm, nil
 }
 
 // SaveUploadedFile uploads the form file to specific dst.

--- a/context_test.go
+++ b/context_test.go
@@ -107,7 +107,7 @@ func TestContextMultipartForm(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.NotNil(t, f)
 	}
-
+	assert.Equal(t, c.PostForm("foo"), "bar")
 	assert.NoError(t, c.SaveUploadedFile(f.File["file"][0], "test"))
 }
 


### PR DESCRIPTION
Return `c.Request.MultipartForm` directly if it has been parsed.