### PR TITLE
feat: basic auth without keeping a list of accounts

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -25,6 +25,8 @@ type authPair struct {
 }
 
 type authPairs []authPair
+type authHeaderValidator func(c *Context) (authenticatedUser string, ok bool)
+type UsernamePasswordValidator func(username, password string) bool
 
 func (a authPairs) searchCredential(authValue string) (string, bool) {
 	if authValue == "" {
@@ -38,36 +40,74 @@ func (a authPairs) searchCredential(authValue string) (string, bool) {
 	return "", false
 }
 
-// BasicAuthForRealm returns a Basic HTTP Authorization middleware. It takes as arguments a map[string]string where
-// the key is the user name and the value is the password, as well as the name of the Realm.
+// BasicAuthForRealmWithValidator returns a Basic HTTP Authorization middleware.
+// Its first argument is a function that checks the username and password and returns true if an account matches.
+// The second parameter is the name of the realm. If the realm is empty, "Authorization Required" will be used by default.
 // If the realm is empty, "Authorization Required" will be used by default.
 // (see http://tools.ietf.org/html/rfc2617#section-1.2)
-func BasicAuthForRealm(accounts Accounts, realm string) HandlerFunc {
-	if realm == "" {
-		realm = "Authorization Required"
-	}
-	realm = "Basic realm=" + strconv.Quote(realm)
-	pairs := processAccounts(accounts)
-	return func(c *Context) {
-		// Search user in the slice of allowed credentials
-		user, found := pairs.searchCredential(c.requestHeader("Authorization"))
-		if !found {
-			// Credentials doesn't match, we return 401 and abort handlers chain.
-			c.Header("WWW-Authenticate", realm)
-			c.AbortWithStatus(http.StatusUnauthorized)
-			return
+func BasicAuthForRealmWithValidator(validator UsernamePasswordValidator, realm string) HandlerFunc {
+	headerValidator := func(c *Context) (string, bool) {
+		username, password, ok := c.Request.BasicAuth()
+		if !ok {
+			return username, false
 		}
 
-		// The user credentials was found, set user's id to key AuthUserKey in this context, the user's id can be read later using
-		// c.MustGet(gin.AuthUserKey).
-		c.Set(AuthUserKey, user)
+		ok = validator(username, password)
+		if ok {
+			return username, true
+		}
+		return "", false
 	}
+
+	return basicAuthForRealmWithValidator(headerValidator, realm)
 }
 
 // BasicAuth returns a Basic HTTP Authorization middleware. It takes as argument a map[string]string where
 // the key is the user name and the value is the password.
 func BasicAuth(accounts Accounts) HandlerFunc {
 	return BasicAuthForRealm(accounts, "")
+}
+
+// basicAuthForRealmWithValidator returns a Basic HTTP Authorization middleware. It takes as arguments a function and the realm.
+// The function takes the context and returns the user if found and a boolean indicating whether or not authentication was successful.
+// the second parameter is the name of the realm. If the realm is empty, "Authorization Required" will be used by default.
+// (see http://tools.ietf.org/html/rfc2617#section-1.2)
+func basicAuthForRealmWithValidator(validateUser authHeaderValidator, realm string) HandlerFunc {
+	if realm == "" {
+		realm = "Authorization Required"
+	}
+	realm = "Basic realm=" + strconv.Quote(realm)
+
+	return func(c *Context) {
+		// Search user in the slice of allowed credentials
+		user, ok := validateUser(c)
+
+		if !ok {
+			// Credentials doesn't match, we return 401 and abort handlers chain.
+			c.Header("WWW-Authenticate", realm)
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		// The user credentials was found, set user's id to key AuthUserKey in this context, the user's id can be read later using
+		// c.MustGet(gin.AuthUserKey).
+		c.Set(AuthUserKey, user)
+	}
+}
+
+// BasicAuthForRealm returns a Basic HTTP Authorization middleware. It takes as arguments a map[string]string where
+// the key is the user name and the value is the password, as well as the name of the Realm.
+// If the realm is empty, "Authorization Required" will be used by default.
+// (see http://tools.ietf.org/html/rfc2617#section-1.2)
+func BasicAuthForRealm(accounts Accounts, realm string) HandlerFunc {
+	return basicAuthForRealmWithValidator(accountsValidator(accounts), realm)
+}
+
+// accountsValidator returns a validator that searches for the right account using the given authorization header
+func accountsValidator(accounts Accounts) authHeaderValidator {
+	pairs := processAccounts(accounts)
+	return func(c *Context) (string, bool) {
+		return pairs.searchCredential(c.requestHeader("Authorization"))
+	}
 }
 
 func processAccounts(accounts Accounts) authPairs {


### PR DESCRIPTION
Hi,
while using gin I often wanted to use basic authentication that does not require me to save all available accounts to a map (Currently it is handled that way).

I wanted to be able to pass a username and password validator that directly "plugs into" gin. 

Example:

I have a function that checks if a user and password combination is right.

```
func isValidUser(username string, password string) (valid bool) {
    // e.g. LDAP authentication is done here 
    // if user and password match, return true
}
```

It does not include any basic authentication specific code. Realm and authentication headers are hidden from the user of the library.
This function (of type UsernamePasswordValidator) can now be converted to a gin basic authentication middleware like so:

```
middleware := BasicAuthForRealmWithValidator(isValidUser, "")
```

I added tests and refactored the current code so that it integrates seamlessly with this new behavior.

I hope you like it.

Thank you for this great library. It is a joy to use.
