### PR TITLE
refactor: Replace Request.FormFile

### DIFF
--- a/context.go
+++ b/context.go
@@ -581,12 +581,12 @@ func (c *Context) FormFile(name string) (*multipart.FileHeader, error) {
 			return nil, err
 		}
 	}
-	f, fh, err := c.Request.FormFile(name)
-	if err != nil {
-		return nil, err
+	if c.Request.MultipartForm != nil && c.Request.MultipartForm.File != nil {
+		if fhs := c.Request.MultipartForm.File[name]; len(fhs) > 0 {
+			return fhs[0], nil
+		}
 	}
-	f.Close()
-	return fh, err
+	return nil, http.ErrMissingFile
 }
 
 // MultipartForm is the parsed multipart form, including file uploads.


### PR DESCRIPTION
- Write logic to replace request.FormFile
- request.FormFile calls useless logic in code
``` go
if fhs := r.MultipartForm.File[key]; len(fhs) > 0 {
  f, err := fhs[0].Open()  // useless
  return f, fhs[0], err
}
```