### PR TITLE
chore: improve linting, testing, and GitHub Actions setup

### DIFF
--- a/.github/workflows/gin.yml
+++ b/.github/workflows/gin.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.48.0
+          version: v1.52.2
           args: --verbose
   test:
     needs: lint
@@ -75,17 +75,3 @@ jobs:
       - name: Format
         if: matrix.go-version == '1.20.x'
         run: diff -u <(echo -n) <(gofmt -d .)
-  notification-gitter:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notification failure message
-        if: failure()
-        run: |
-          PR_OR_COMPARE="$(if [ "${{ github.event.pull_request }}" != "" ]; then echo "${{ github.event.pull_request.html_url }}"; else echo "${{ github.event.compare }}"; fi)"
-          curl -d message="GitHub Actions [$GITHUB_REPOSITORY]($PR_OR_COMPARE) ($GITHUB_REF) [normal]($GITHUB_API_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) ($GITHUB_RUN_NUMBER)" -d level=error https://webhooks.gitter.im/e/7f95bf605c4d356372f4
-      - name: Notification success message
-        if: success()
-        run: |
-          PR_OR_COMPARE="$(if [ "${{ github.event.pull_request }}" != "" ]; then echo "${{ github.event.pull_request.html_url }}"; else echo "${{ github.event.compare }}"; fi)"
-          curl -d message="GitHub Actions [$GITHUB_REPOSITORY]($PR_OR_COMPARE) ($GITHUB_REF) [normal]($GITHUB_API_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) ($GITHUB_RUN_NUMBER)" https://webhooks.gitter.im/e/7f95bf605c4d356372f4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,22 @@ linters:
     - nolintlint
     - revive
     - wastedassign
+
+linters-settings:
+  gosec:
+    # To select a subset of rules to run.
+    # Available rules: https://github.com/securego/gosec#available-rules
+    # Default: [] - means include all rules
+    includes:
+      - G102
+      - G106
+      - G108
+      - G109
+      - G111
+      - G112
+      - G201
+      - G203
+
 issues:
   exclude-rules:
     - linters:
@@ -37,3 +53,6 @@ issues:
     - path: _test\.go
       linters:
         - gosec # security is not make sense in tests
+    - linters:
+        - revive
+      path: _test\.go

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![codecov](https://codecov.io/gh/gin-gonic/gin/branch/master/graph/badge.svg)](https://codecov.io/gh/gin-gonic/gin)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gin-gonic/gin)](https://goreportcard.com/report/github.com/gin-gonic/gin)
 [![GoDoc](https://pkg.go.dev/badge/github.com/gin-gonic/gin?status.svg)](https://pkg.go.dev/github.com/gin-gonic/gin?tab=doc)
-[![Join the chat at https://gitter.im/gin-gonic/gin](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gin-gonic/gin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Sourcegraph](https://sourcegraph.com/github.com/gin-gonic/gin/-/badge.svg)](https://sourcegraph.com/github.com/gin-gonic/gin?badge)
 [![Open Source Helpers](https://www.codetriage.com/gin-gonic/gin/badges/users.svg)](https://www.codetriage.com/gin-gonic/gin)
 [![Release](https://img.shields.io/github/release/gin-gonic/gin.svg?style=flat-square)](https://github.com/gin-gonic/gin/releases)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,0 @@
-coverage:
-  notify:
-    gitter:
-      default:
-        url: https://webhooks.gitter.im/e/d90dcdeeab2f1e357165

--- a/fs.go
+++ b/fs.go
@@ -39,7 +39,7 @@ func (fs onlyFilesFS) Open(name string) (http.File, error) {
 }
 
 // Readdir overrides the http.File default implementation.
-func (f neuteredReaddirFile) Readdir(count int) ([]os.FileInfo, error) {
+func (f neuteredReaddirFile) Readdir(_ int) ([]os.FileInfo, error) {
 	// this disables directory listing
 	return nil, nil
 }

--- a/recovery.go
+++ b/recovery.go
@@ -103,7 +103,7 @@ func CustomRecoveryWithWriter(out io.Writer, handle RecoveryFunc) HandlerFunc {
 	}
 }
 
-func defaultHandleRecovery(c *Context, err any) {
+func defaultHandleRecovery(c *Context, _ any) {
 	c.AbortWithStatus(http.StatusInternalServerError)
 }
 


### PR DESCRIPTION
- Update golangci-lint version from `v1.48.0` to `v1.52.2`
- Remove Gitter notifications from GitHub Actions workflow
- Add gosec linter settings and include specific rules
- Exclude revive linter for test files
- Remove Gitter badge from README.md
- Delete codecov.yml file
- Change function parameter name in fs.go
- Remove unused parameter in defaultHandleRecovery function