### PR TITLE
refactor: replace a panic with an error when walking too deep on form mapping

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -80,8 +80,12 @@ func mappingByPtr(ptr any, setter setter, tag string) error {
 }
 
 func mapping(value reflect.Value, field reflect.StructField, setter setter, tag string, deepth int) (bool, error) {
-	if field.Tag.Get(tag) == "-" { // just ignoring this field
-		return false, nil
+	if field.Name != "" {
+		// ignore the field that not owned by the given tag,
+		// or declared with a "-" symbol.
+		if v, exist := field.Tag.Lookup(tag); !exist || v == "-" {
+			return false, nil
+		}
 	}
 	if deepth >= 1000 {
 		// avoid causing stackoverflow.

--- a/binding/form_mapping_test.go
+++ b/binding/form_mapping_test.go
@@ -52,7 +52,7 @@ func TestMappingBaseTypes(t *testing.T) {
 
 		field := val.Elem().Type().Field(0)
 
-		_, err := mapping(val, emptyField, formSource{field.Name: {tt.form}}, "form")
+		_, err := mapping(val, emptyField, formSource{field.Name: {tt.form}}, "form", 0)
 		assert.NoError(t, err, testName)
 
 		actual := val.Elem().Field(0).Interface()
@@ -277,6 +277,16 @@ func TestMappingMapField(t *testing.T) {
 	err := mappingByPtr(&s, formSource{"M": {`{"one": 1}`}}, "form")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]int{"one": 1}, s.M)
+}
+
+func TestMappingCircularRef(t *testing.T) {
+	type S struct {
+		S *S `form:"s"`
+	}
+	var s S
+
+	err := mappingByPtr(&s, formSource{}, "form")
+	assert.ErrorIs(t, err, errRecursionTooDeep)
 }
 
 func TestMappingIgnoredCircularRef(t *testing.T) {

--- a/binding/form_mapping_test.go
+++ b/binding/form_mapping_test.go
@@ -298,3 +298,15 @@ func TestMappingIgnoredCircularRef(t *testing.T) {
 	err := mappingByPtr(&s, formSource{}, "form")
 	assert.NoError(t, err)
 }
+
+func TestMappingCircularRefOnOtherTag(t *testing.T) {
+	type S struct {
+		S *S     `json:"s"`
+		O string `uri:"o"`
+	}
+	var s S
+
+	err := mappingByPtr(&s, formSource{"o": []string{"x"}}, "uri")
+	assert.Equal(t, "x", s.O)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
this PR is going to report an error rather than panic with stack overflow when walking too deep on form(or customized tag) mapping.

this PR also uses another commit to solve the scenario where multiple binders work on the same struct together.

mitigate some cases like #2203, #1978, and guide users to use `json binder` in a tree-like struct.


