### PR TITLE
Only push net error to c.Errors and panic others errors

### DIFF
--- a/context.go
+++ b/context.go
@@ -924,9 +924,13 @@ func (c *Context) Render(code int, r render.Render) {
 	}
 
 	if err := r.Render(c.Writer); err != nil {
-		// Pushing error to c.Errors
-		_ = c.Error(err)
-		c.Abort()
+		// if err is net error, pushing error to c.Errors
+		if _, ok := err.(*net.OpError); ok {
+			_ = c.Error(err)
+			c.Abort()
+		} else {
+			panic(err)
+		}
 	}
 }
 


### PR DESCRIPTION
In pr: https://github.com/gin-gonic/gin/pull/2150, remove the panic in Render function and push all error to c.Errors. 

This is to avoid panic when encountering "broken pipe -> write tcp" errors, in order to improve program performance. 

However, this will also cause the program to ignore errors from json.Marshal(). When an error occurs during json.Marshal(), the client will only receive an empty http body.

Therefore, when it is a non-network error, Render() still needs to panic in order for the client to be aware of this error.
