### PR TITLE
feat: add Error if the request can't be authorized

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -7,6 +7,7 @@ package gin
 import (
 	"crypto/subtle"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -25,6 +26,11 @@ type authPair struct {
 }
 
 type authPairs []authPair
+
+var (
+	// ErrUnauthorized cannot authorize the request.
+	ErrUnauthorized = errors.New("unauthorized")
+)
 
 func (a authPairs) searchCredential(authValue string) (string, bool) {
 	if authValue == "" {
@@ -53,6 +59,7 @@ func BasicAuthForRealm(accounts Accounts, realm string) HandlerFunc {
 		user, found := pairs.searchCredential(c.requestHeader("Authorization"))
 		if !found {
 			// Credentials doesn't match, we return 401 and abort handlers chain.
+			c.Error(ErrUnauthorized)
 			c.Header("WWW-Authenticate", realm)
 			c.AbortWithStatus(http.StatusUnauthorized)
 			return

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -46,6 +46,7 @@
   - [Redirects](#redirects)
   - [Custom Middleware](#custom-middleware)
   - [Using BasicAuth() middleware](#using-basicauth-middleware)
+  - [Detecting authorization failure in custom middleware](#detecting-authorization-failure-in-custom-middleware)
   - [Goroutines inside a middleware](#goroutines-inside-a-middleware)
   - [Custom HTTP configuration](#custom-http-configuration)
   - [Support Let's Encrypt](#support-lets-encrypt)
@@ -1465,6 +1466,26 @@ func main() {
 
   // Listen and serve on 0.0.0.0:8080
   r.Run(":8080")
+}
+```
+
+#### Detecting authorization failure in custom middleware
+
+When the `BasicAuth` middleware fails authorization, an `Error` is added to the `gin.Context.Errors` slice. You can detect this failure in a custom middleware with code like this:
+
+```go
+func main() {
+  router := New()
+  router.Use(func(c *Context) {
+    c.Next()
+    if c.Errors.Last().Err == ErrUnauthorized {
+      // Unauthorized detected, act accordingly
+    }
+  })
+  router.Use(BasicAuth(Accounts{"admin": "password"}))
+  router.GET("/login", func(c *Context) {
+    c.String(http.StatusOK, c.MustGet(AuthUserKey).(string))
+  })
 }
 ```
 


### PR DESCRIPTION
Add `Error` to `gin.Context` if the `BasicAuth` middleware is unable to successfully authorize the request, such that other custom middleware can detect that the request is unauthorized.

A more scalable approach would be to expose the HTTP `status` set by other middleware, but that requires a bigger change than I was comfortable with. I would love to move this in that direction, though, if I'm provided with a bit of guidance.

Resolves #3576.