### PR TITLE
change function type to pointer receivers error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -81,7 +81,7 @@ func (msg *Error) MarshalJSON() ([]byte, error) {
 }
 
 // Error implements the error interface.
-func (msg Error) Error() string {
+func (msg *Error) Error() string {
 	return msg.Err.Error()
 }
 


### PR DESCRIPTION
Struct Error has methods on both value and pointer receivers. Such usage is not recommended by the Go Documentation. 