### PR TITLE
Remove redundant code

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -205,7 +205,7 @@ func New() *Engine {
 		trustedProxies:         []string{"0.0.0.0/0", "::/0"},
 		trustedCIDRs:           defaultTrustedCIDRs,
 	}
-	engine.RouterGroup.engine = engine
+	engine.engine = engine
 	engine.pool.New = func() any {
 		return engine.allocateContext(engine.maxParams)
 	}


### PR DESCRIPTION
Remove redundant code

`engine.RouterGroup.engine = engine`

the `RouterGroup` can remove. 
