### PR TITLE
feat: gin.Context GetXxx added support for more go native types

### DIFF
--- a/context.go
+++ b/context.go
@@ -297,7 +297,31 @@ func (c *Context) GetInt(key string) (i int) {
 	return
 }
 
-// GetInt64 returns the value associated with the key as an integer.
+// GetInt8 returns the value associated with the key as an integer 8.
+func (c *Context) GetInt8(key string) (i8 int8) {
+	if val, ok := c.Get(key); ok && val != nil {
+		i8, _ = val.(int8)
+	}
+	return
+}
+
+// GetInt16 returns the value associated with the key as an integer 16.
+func (c *Context) GetInt16(key string) (i16 int16) {
+	if val, ok := c.Get(key); ok && val != nil {
+		i16, _ = val.(int16)
+	}
+	return
+}
+
+// GetInt32 returns the value associated with the key as an integer 32.
+func (c *Context) GetInt32(key string) (i32 int32) {
+	if val, ok := c.Get(key); ok && val != nil {
+		i32, _ = val.(int32)
+	}
+	return
+}
+
+// GetInt64 returns the value associated with the key as an integer 64.
 func (c *Context) GetInt64(key string) (i64 int64) {
 	if val, ok := c.Get(key); ok && val != nil {
 		i64, _ = val.(int64)
@@ -313,10 +337,42 @@ func (c *Context) GetUint(key string) (ui uint) {
 	return
 }
 
-// GetUint64 returns the value associated with the key as an unsigned integer.
+// GetUint8 returns the value associated with the key as an unsigned integer 8.
+func (c *Context) GetUint8(key string) (ui8 uint8) {
+	if val, ok := c.Get(key); ok && val != nil {
+		ui8, _ = val.(uint8)
+	}
+	return
+}
+
+// GetUint16 returns the value associated with the key as an unsigned integer 16.
+func (c *Context) GetUint16(key string) (ui16 uint16) {
+	if val, ok := c.Get(key); ok && val != nil {
+		ui16, _ = val.(uint16)
+	}
+	return
+}
+
+// GetUint32 returns the value associated with the key as an unsigned integer 32.
+func (c *Context) GetUint32(key string) (ui32 uint32) {
+	if val, ok := c.Get(key); ok && val != nil {
+		ui32, _ = val.(uint32)
+	}
+	return
+}
+
+// GetUint64 returns the value associated with the key as an unsigned integer 64.
 func (c *Context) GetUint64(key string) (ui64 uint64) {
 	if val, ok := c.Get(key); ok && val != nil {
 		ui64, _ = val.(uint64)
+	}
+	return
+}
+
+// GetFloat32 returns the value associated with the key as a float32.
+func (c *Context) GetFloat32(key string) (f32 float32) {
+	if val, ok := c.Get(key); ok && val != nil {
+		f32, _ = val.(float32)
 	}
 	return
 }
@@ -341,6 +397,90 @@ func (c *Context) GetTime(key string) (t time.Time) {
 func (c *Context) GetDuration(key string) (d time.Duration) {
 	if val, ok := c.Get(key); ok && val != nil {
 		d, _ = val.(time.Duration)
+	}
+	return
+}
+
+func (c *Context) GetIntSlice(key string) (is []int) {
+	if val, ok := c.Get(key); ok && val != nil {
+		is, _ = val.([]int)
+	}
+	return
+}
+
+func (c *Context) GetInt8Slice(key string) (i8s []int8) {
+	if val, ok := c.Get(key); ok && val != nil {
+		i8s, _ = val.([]int8)
+	}
+	return
+}
+
+func (c *Context) GetInt16Slice(key string) (i16s []int16) {
+	if val, ok := c.Get(key); ok && val != nil {
+		i16s, _ = val.([]int16)
+	}
+	return
+}
+
+func (c *Context) GetInt32Slice(key string) (i32s []int32) {
+	if val, ok := c.Get(key); ok && val != nil {
+		i32s, _ = val.([]int32)
+	}
+	return
+}
+
+func (c *Context) GetInt64Slice(key string) (i64s []int64) {
+	if val, ok := c.Get(key); ok && val != nil {
+		i64s, _ = val.([]int64)
+	}
+	return
+}
+
+func (c *Context) GetUintSlice(key string) (uis []uint) {
+	if val, ok := c.Get(key); ok && val != nil {
+		uis, _ = val.([]uint)
+	}
+	return
+}
+
+func (c *Context) GetUint8Slice(key string) (ui8s []uint8) {
+	if val, ok := c.Get(key); ok && val != nil {
+		ui8s, _ = val.([]uint8)
+	}
+	return
+}
+
+func (c *Context) GetUint16Slice(key string) (ui16s []uint16) {
+	if val, ok := c.Get(key); ok && val != nil {
+		ui16s, _ = val.([]uint16)
+	}
+	return
+}
+
+func (c *Context) GetUint32Slice(key string) (ui32s []uint32) {
+	if val, ok := c.Get(key); ok && val != nil {
+		ui32s, _ = val.([]uint32)
+	}
+	return
+}
+
+func (c *Context) GetUint64Slice(key string) (ui64s []uint64) {
+	if val, ok := c.Get(key); ok && val != nil {
+		ui64s, _ = val.([]uint64)
+	}
+	return
+}
+
+func (c *Context) GetFloat32Slice(key string) (f32s []float32) {
+	if val, ok := c.Get(key); ok && val != nil {
+		f32s, _ = val.([]float32)
+	}
+	return
+}
+
+func (c *Context) GetFloat64Slice(key string) (f64s []float64) {
+	if val, ok := c.Get(key); ok && val != nil {
+		f64s, _ = val.([]float64)
 	}
 	return
 }

--- a/context_test.go
+++ b/context_test.go
@@ -244,6 +244,30 @@ func TestContextGetInt(t *testing.T) {
 	assert.Equal(t, 1, c.GetInt("int"))
 }
 
+func TestContextGetInt8(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "int8"
+	value := int8(0x7F)
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetInt8(key))
+}
+
+func TestContextGetInt16(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "int16"
+	value := int16(0x7FFF)
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetInt16(key))
+}
+
+func TestContextGetInt32(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "int32"
+	value := int32(0x7FFFFFFF)
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetInt32(key))
+}
+
 func TestContextGetInt64(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Set("int64", int64(42424242424242))
@@ -256,10 +280,42 @@ func TestContextGetUint(t *testing.T) {
 	assert.Equal(t, uint(1), c.GetUint("uint"))
 }
 
+func TestContextGetUint8(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "uint8"
+	value := uint8(0xFF)
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetUint8(key))
+}
+
+func TestContextGetUint16(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "uint16"
+	value := uint16(0xFFFF)
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetUint16(key))
+}
+
+func TestContextGetUint32(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "uint32"
+	value := uint32(0xFFFFFFFF)
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetUint32(key))
+}
+
 func TestContextGetUint64(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Set("uint64", uint64(18446744073709551615))
 	assert.Equal(t, uint64(18446744073709551615), c.GetUint64("uint64"))
+}
+
+func TestContextGetFloat32(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "float32"
+	value := float32(3.14)
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetFloat32(key))
 }
 
 func TestContextGetFloat64(t *testing.T) {
@@ -279,6 +335,102 @@ func TestContextGetDuration(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Set("duration", time.Second)
 	assert.Equal(t, time.Second, c.GetDuration("duration"))
+}
+
+func TestContextGetIntSlice(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "int-slice"
+	value := []int{1, 2}
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetIntSlice(key))
+}
+
+func TestContextGetInt8Slice(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "int8-slice"
+	value := []int8{1, 2}
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetInt8Slice(key))
+}
+
+func TestContextGetInt16Slice(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "int16-slice"
+	value := []int16{1, 2}
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetInt16Slice(key))
+}
+
+func TestContextGetInt32Slice(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "int32-slice"
+	value := []int32{1, 2}
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetInt32Slice(key))
+}
+
+func TestContextGetInt64Slice(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "int64-slice"
+	value := []int64{1, 2}
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetInt64Slice(key))
+}
+
+func TestContextGetUintSlice(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "uint-slice"
+	value := []uint{1, 2}
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetUintSlice(key))
+}
+
+func TestContextGetUint8Slice(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "uint8-slice"
+	value := []uint8{1, 2}
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetUint8Slice(key))
+}
+
+func TestContextGetUint16Slice(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "uint16-slice"
+	value := []uint16{1, 2}
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetUint16Slice(key))
+}
+
+func TestContextGetUint32Slice(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "uint32-slice"
+	value := []uint32{1, 2}
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetUint32Slice(key))
+}
+
+func TestContextGetUint64Slice(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "uint64-slice"
+	value := []uint64{1, 2}
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetUint64Slice(key))
+}
+
+func TestContextGetFloat32Slice(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "float32-slice"
+	value := []float32{1, 2}
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetFloat32Slice(key))
+}
+
+func TestContextGetFloat64Slice(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "float64-slice"
+	value := []float64{1, 2}
+	c.Set(key, value)
+	assert.Equal(t, value, c.GetFloat64Slice(key))
 }
 
 func TestContextGetStringSlice(t *testing.T) {


### PR DESCRIPTION
Thanks for such a nice open-source web framework, when I was using gin middleware today I found that the support for go native types when getting the data from gin. I put in a uint8 type, for example I put in a uint8 type, which when I get it doesn't provide a quick method but requires me to type it myself. I added some get methods of go native type, please review and merge to help more people, thank you very much

gin.Context new add methods: 
- GetInt8
- GetInt16
- GetInt32
- GetUint8
- GetUint16
- GetUint32
- GetFloat32
- GetIntSlice
- GetInt8Slice
- GetInt16Slice
- GetInt32Slice
- GetInt64Slice
- GetUintSlice
- GetUint8Slice
- GetUint16Slice
- GetUint32Slice
- GetUint64Slice
- GetFloat32Slice
- GetFloat64Slice

 