### PR TITLE
bugfix: SliceValidationError has two elements, but the first one is nil

### DIFF
--- a/binding/default_validator.go
+++ b/binding/default_validator.go
@@ -28,15 +28,12 @@ func (err SliceValidationError) Error() string {
 		return ""
 	default:
 		var b strings.Builder
-		if err[0] != nil {
-			fmt.Fprintf(&b, "[%d]: %s", 0, err[0].Error())
-		}
-		if n > 1 {
-			for i := 1; i < n; i++ {
-				if err[i] != nil {
+		for i := 0; i < n; i++ {
+			if err[i] != nil {
+				if b.Len() > 0 {
 					b.WriteString("\n")
-					fmt.Fprintf(&b, "[%d]: %s", i, err[i].Error())
 				}
+				fmt.Fprintf(&b, "[%d]: %s", i, err[i].Error())
 			}
 		}
 		return b.String()

--- a/binding/default_validator_test.go
+++ b/binding/default_validator_test.go
@@ -25,6 +25,13 @@ func TestSliceValidationError(t *testing.T) {
 			},
 			"[0]: first error\n[1]: second error",
 		},
+		{"has two elements, but the first one is nil",
+			SliceValidationError{
+				nil,
+				errors.New("first error at second place"),
+			},
+			"[1]: first error at second place",
+		},
 		{"has many elements",
 			SliceValidationError{
 				errors.New("first error"),


### PR DESCRIPTION
I add a test case
```
{"has two elements, but the first one is nil",
	SliceValidationError{
		nil,
		errors.New("first error at second place"),
	},
	"[1]: first error at second place",
},
```
it fails
```
--- FAIL: TestSliceValidationError (0.00s)
    --- FAIL: TestSliceValidationError/has_two_elements,_but_the_first_one_is_nil (0.00s)
        /Users/xinrui/Documents/unilake/gin/binding/default_validator_test.go:50: SliceValidationError.Error() = 
            [1]: first error at second place, want [1]: first error at second place
FAIL
FAIL	github.com/gin-gonic/gin/binding	0.546s
FAIL
```
so I changed the func (err SliceValidationError) Error() string