### PR TITLE
Do not QueryEscape cookies (#1717)

### DIFF
--- a/context.go
+++ b/context.go
@@ -890,7 +890,7 @@ func (c *Context) SetCookie(name, value string, maxAge int, path, domain string,
 	}
 	http.SetCookie(c.Writer, &http.Cookie{
 		Name:     name,
-		Value:    url.QueryEscape(value),
+		Value:    value,
 		MaxAge:   maxAge,
 		Path:     path,
 		Domain:   domain,

--- a/context_test.go
+++ b/context_test.go
@@ -627,6 +627,13 @@ func TestContextSetCookiePathEmpty(t *testing.T) {
 	assert.Equal(t, "user=gin; Path=/; Domain=localhost; Max-Age=1; HttpOnly; Secure; SameSite=Lax", c.Writer.Header().Get("Set-Cookie"))
 }
 
+func TestContextSetCookieWithSpace(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie("user", "gin test", 1, "/", "localhost", true, true)
+	assert.Equal(t, "user=\"gin test\"; Path=/; Domain=localhost; Max-Age=1; HttpOnly; Secure; SameSite=Lax", c.Writer.Header().Get("Set-Cookie"))
+}
+
 func TestContextGetCookie(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Request, _ = http.NewRequest("GET", "/get", nil)


### PR DESCRIPTION
Cookies values are already sanitized by the Go http library, so there is no need to invoke QueryEscape() on them.
Furthermore, QueryEscape() has the undesirable effect of replacing spaces wiith "+" characters.