### PR TITLE
Use magenta color for HTTP 101 status in the log

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -83,6 +83,8 @@ func (p *LogFormatterParams) StatusCodeColor() string {
 	code := p.StatusCode
 
 	switch {
+	case code >= http.StatusContinue && code < http.StatusOK:
+		return magenta
 	case code >= http.StatusOK && code < http.StatusMultipleChoices:
 		return green
 	case code >= http.StatusMultipleChoices && code < http.StatusBadRequest:

--- a/logger_test.go
+++ b/logger_test.go
@@ -310,6 +310,7 @@ func TestColorForStatus(t *testing.T) {
 		return p.StatusCodeColor()
 	}
 
+	assert.Equal(t, magenta, colorForStatus(http.StatusSwitchingProtocols), "1xx should be magenta")
 	assert.Equal(t, green, colorForStatus(http.StatusOK), "2xx should be green")
 	assert.Equal(t, white, colorForStatus(http.StatusMovedPermanently), "3xx should be white")
 	assert.Equal(t, yellow, colorForStatus(http.StatusNotFound), "4xx should be yellow")


### PR DESCRIPTION
When using http.Hijacker, there was a scary looking red log entry.

Color it in a more "neutral" color instead, since it is harmless.


