### PR TITLE
fix(form):add max iteration to avoid stack overflow

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -26,6 +26,8 @@ var (
 	ErrConvertToMapString = errors.New("can not convert to map of strings")
 )
 
+const maxIterDepth = 255
+
 func mapURI(ptr any, m map[string][]string) error {
 	return mapFormByTag(ptr, m, "uri")
 }
@@ -74,15 +76,17 @@ func (form formSource) TrySet(value reflect.Value, field reflect.StructField, ta
 }
 
 func mappingByPtr(ptr any, setter setter, tag string) error {
-	_, err := mapping(reflect.ValueOf(ptr), emptyField, setter, tag)
+	_, err := mapping(reflect.ValueOf(ptr), emptyField, setter, tag, 0)
 	return err
 }
 
-func mapping(value reflect.Value, field reflect.StructField, setter setter, tag string) (bool, error) {
+func mapping(value reflect.Value, field reflect.StructField, setter setter, tag string, depth int) (bool, error) {
 	if field.Tag.Get(tag) == "-" { // just ignoring this field
 		return false, nil
 	}
-
+	if depth > maxIterDepth {
+		return false, fmt.Errorf("deep of nesting is too high > %d", maxIterDepth)
+	}
 	vKind := value.Kind()
 
 	if vKind == reflect.Ptr {
@@ -92,7 +96,7 @@ func mapping(value reflect.Value, field reflect.StructField, setter setter, tag 
 			isNew = true
 			vPtr = reflect.New(value.Type().Elem())
 		}
-		isSet, err := mapping(vPtr.Elem(), field, setter, tag)
+		isSet, err := mapping(vPtr.Elem(), field, setter, tag, depth+1)
 		if err != nil {
 			return false, err
 		}
@@ -121,7 +125,7 @@ func mapping(value reflect.Value, field reflect.StructField, setter setter, tag 
 			if sf.PkgPath != "" && !sf.Anonymous { // unexported
 				continue
 			}
-			ok, err := mapping(value.Field(i), sf, setter, tag)
+			ok, err := mapping(value.Field(i), sf, setter, tag, depth+1)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
example code:
```go
type People struct {
	Name    string  `form:"name"`
	Teacher Teacher `form:"teacher"`
}

type Teacher struct {
	Owner *People `form:"owner"`
}

router := gin.Default()
router.GET("/search", func(c *gin.Context) {
	var req People
	if err := c.ShouldBindQuery(&req); err != nil {
		c.String(http.StatusBadRequest, "bad request")
		return
	}
	c.String(http.StatusOK, "Welcome Gin Server")
})
``` 

if param to  be parsed contains nested field ,goroutine will crash 

runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc020460418 stack=[0xc020460000, 0xc040460000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x13bad15?, 0x16315c0?})
        /usr/local/go/src/runtime/panic.go:1047 +0x5d fp=0x700007c93da0 sp=0x700007c93d70 pc=0x10345bd
runtime.newstack()
        /usr/local/go/src/runtime/stack.go:1104 +0x5cc fp=0x700007c93f58 sp=0x700007c93da0 pc=0x104dcec
runtime.morestack()
        /usr/local/go/src/runtime/asm_amd64.s:570 +0x8b fp=0x700007c93f60 sp=0x700007c93f58 pc=0x10636cb

goroutine 7 [running]:
runtime.heapBitsSetType(0xc001c7f350?, 0x18?, 0x18?, 0x1377180?)
        /usr/local/go/src/runtime/mbitmap.go:844 +0xbac fp=0xc020460428 sp=0xc020460420 pc=0x101556c
runtime.mallocgc(0x18, 0x1377180, 0x1)
        /usr/local/go/src/runtime/malloc.go:1050 +0x64d fp=0xc0204604a0 sp=0xc020460428 pc=0x100cb6d
reflect.unsafe_New(0x7?)
        /usr/local/go/src/runtime/malloc.go:1197 +0x27 fp=0xc0204604c8 sp=0xc0204604a0 pc=0x105eba7
reflect.New({0x1465920?, 0x1377180})
        /usr/local/go/src/reflect/value.go:3139 +0x5d fp=0xc0204604f8 sp=0xc0204604c8 pc=0x10aaffd
github.com/gin-gonic/gin/binding.mapping({0x1341520?, 0xc001c7f348?, 0xc001c80a20?}, {{0x133308c, 0x5}, {0x0, 0x0}, {0x1465920, 0x1341520}, {0x1333092, ...}, ...}, ...)
        /Users/gaochong/GoProjects/gin/binding/form_mapping.go:81 +0x27d fp=0xc0204606e0 sp=0xc0204604f8 pc=0x131429d
github.com/gin-gonic/gin/binding.mapping({0x136d4c0?, 0xc001c7f348?, 0x0?}, {{0x13362f0, 0x7}, {0x0, 0x0}, {0x1465920, 0x136d4c0}, {0x13362f8, ...}, ...}, ...)
        /Users/gaochong/GoProjects/gin/binding/form_mapping.go:112 +0x550 fp=0xc0204608c8 sp=0xc0204606e0 pc=0x1314570
github.com/gin-gonic/gin/binding.mapping({0x1377180?, 0xc001c7f338?, 0xc001c80a00?}, {{0x133308c, 0x5}, {0x0, 0x0}, {0x1465920, 0x1341520}, {0x1333092, ...}, ...}, ...)
        /Users/gaochong/GoProjects/gin/binding/form_mapping.go:112 +0x550 fp=0xc020460ab0 sp=0xc0204608c8 pc=0x1314570
github.com/gin-gonic/gin/binding.mapping({0x1341520?, 0xc001c7f330?, 0xc001c809f0?}, {{0x133308c, 0x5}, {0x0, 0x0}, {0x1465920, 0x1341520}, {0x1333092, ...}, ...}, ...)
        /Users/gaochong/GoProjects/gin/binding/form_mapping.go:83 +0x318 fp=0xc020460c98 sp=0xc020460ab0 pc=0x1314338
github.com/gin-gonic/gin/binding.mapping({0x136d4c0?, 0xc001c7f330?, 0x0?}, {{0x13362f0, 0x7}, {0x0, 0x0}, {0x1465920, 0x136d4c0}, {0x13362f8, ...}, ...}, ...)
        /Users/gaochong/GoProjects/gin/binding/form_mapping.go:112 +0x550 fp=0xc020460e80 sp=0xc020460c98 pc=0x1314570
github.com/gin-gonic/gin/binding.mapping({0x1377180?, 0xc001c7f320?, 0xc001c809d0?}, {{0x133308c, 0x5}, {0x0, 0x0}, {0x1465920, 0x1341520}, {0x1333092, ...}, ...}, ...)
