### PR TITLE
Removed unnecessary shell symbol from installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ to your code, and then `go [build|run|test]` will automatically fetch the necess
 Otherwise, run the following Go command to install the `gin` package:
 
 ```sh
-$ go get -u github.com/gin-gonic/gin
+go get -u github.com/gin-gonic/gin
 ```
 
 ### Running Gin


### PR DESCRIPTION
I've made a small modification to the code snippet in the documentation. The "$" symbol was removed from the installation command to enhance user-friendliness. When users copy and paste the command into the terminal, they won't need to delete the "$" symbol.

