### PR TITLE
refactor: Use stackBufSize as a global vars instead of a local vars

### DIFF
--- a/path.go
+++ b/path.go
@@ -5,6 +5,8 @@
 
 package gin
 
+const stackBufSize = 128
+
 // cleanPath is the URL version of path.Clean, it returns a canonical URL path
 // for p, eliminating . and .. elements.
 //
@@ -19,7 +21,6 @@ package gin
 //
 // If the result of this process is an empty string, "/" is returned.
 func cleanPath(p string) string {
-	const stackBufSize = 128
 	// Turn empty string into "/"
 	if p == "" {
 		return "/"

--- a/tree.go
+++ b/tree.go
@@ -657,8 +657,6 @@ walk: // Outer loop for walking the tree
 // It returns the case-corrected path and a bool indicating whether the lookup
 // was successful.
 func (n *node) findCaseInsensitivePath(path string, fixTrailingSlash bool) ([]byte, bool) {
-	const stackBufSize = 128
-
 	// Use a static sized buffer on the stack in the common case.
 	// If the path is too long, allocate a buffer on the heap instead.
 	buf := make([]byte, 0, stackBufSize)


### PR DESCRIPTION
Hello👋
I think it's better to use global variables instead of local variables.
What do you think?