### PR TITLE
Refactor: Update examples using `Git Submodules` instead

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples"]
+	path = examples
+	url = https://github.com/gin-gonic/examples

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,0 @@
-# Gin Examples
-
-⚠️  **NOTICE:** All gin examples have been moved as standalone repository to [here](https://github.com/gin-gonic/examples).


### PR DESCRIPTION
Instead of telling in README.md that examples has been move to new repository, maybe use `Git SubModules` is helpful?

