### PR TITLE
 Improved Error Handling in mode.go and fs.go

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -5,6 +5,7 @@
 package gin
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 )
@@ -29,11 +30,12 @@ func Dir(root string, listDirectory bool) http.FileSystem {
 	return &onlyFilesFS{fs}
 }
 
-// Open conforms to http.Filesystem.
+// Open opens a file excluding directories.
+// It conforms to http.Filesystem.
 func (fs onlyFilesFS) Open(name string) (http.File, error) {
 	f, err := fs.fs.Open(name)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
 	return neuteredReaddirFile{f}, nil
 }

--- a/mode.go
+++ b/mode.go
@@ -6,6 +6,7 @@ package gin
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"os"
 
@@ -53,8 +54,16 @@ func init() {
 	SetMode(mode)
 }
 
+func init() {
+	mode := os.Getenv(EnvGinMode)
+	err := SetMode(mode)
+	if err != nil {
+		panic(err)
+	}
+}
+
 // SetMode sets gin mode according to input string.
-func SetMode(value string) {
+func SetMode(value string) error {
 	if value == "" {
 		if flag.Lookup("test.v") != nil {
 			value = TestMode
@@ -71,10 +80,11 @@ func SetMode(value string) {
 	case TestMode:
 		ginMode = testCode
 	default:
-		panic("gin mode unknown: " + value + " (available mode: debug release test)")
+		return fmt.Errorf("gin mode unknown: %s (available mode: debug release test)", value)
 	}
 
 	modeName = value
+	return nil
 }
 
 // DisableBindValidation closes the default validator.

--- a/mode_test.go
+++ b/mode_test.go
@@ -22,30 +22,36 @@ func TestSetMode(t *testing.T) {
 	assert.Equal(t, TestMode, Mode())
 	os.Unsetenv(EnvGinMode)
 
-	SetMode("")
+	err := SetMode("")
+	assert.NoError(t, err)
 	assert.Equal(t, testCode, ginMode)
 	assert.Equal(t, TestMode, Mode())
 
 	tmp := flag.CommandLine
 	flag.CommandLine = flag.NewFlagSet("", flag.ContinueOnError)
-	SetMode("")
+	err = SetMode("")
+	assert.NoError(t, err)
 	assert.Equal(t, debugCode, ginMode)
 	assert.Equal(t, DebugMode, Mode())
 	flag.CommandLine = tmp
 
-	SetMode(DebugMode)
+	err = SetMode(DebugMode)
+	assert.NoError(t, err)
 	assert.Equal(t, debugCode, ginMode)
 	assert.Equal(t, DebugMode, Mode())
 
-	SetMode(ReleaseMode)
+	err = SetMode(ReleaseMode)
+	assert.NoError(t, err)
 	assert.Equal(t, releaseCode, ginMode)
 	assert.Equal(t, ReleaseMode, Mode())
 
-	SetMode(TestMode)
+	err = SetMode(TestMode)
+	assert.NoError(t, err)
 	assert.Equal(t, testCode, ginMode)
 	assert.Equal(t, TestMode, Mode())
 
-	assert.Panics(t, func() { SetMode("unknown") })
+	err = SetMode("unknown")
+	assert.Error(t, err)
 }
 
 func TestDisableBindValidation(t *testing.T) {


### PR DESCRIPTION


**Description:**

This pull request includes improvements to error handling in `mode.go` and `fs.go`:

**SetMode** function in `mode.go`: Previously, the **SetMode** function would panic when an unknown mode was provided. This behavior has been modified to return an error instead of causing a panic, allowing for more graceful error handling. The corresponding tests have also been updated to reflect this change.

Open function in` fs.go`: The error message returned when opening a file has been enhanced to provide better context, similar to the error handling in Python.

These changes aim to improve the robustness of the code and provide clearer, more informative error messages to users.