### PR TITLE
Remove redundant comments

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -334,7 +334,6 @@ func (engine *Engine) addRoute(method, path string, handlers HandlersChain) {
 	}
 	root.addRoute(path, handlers)
 
-	// Update maxParams
 	if paramsCount := countParams(path); paramsCount > engine.maxParams {
 		engine.maxParams = paramsCount
 	}


### PR DESCRIPTION
I think this comment is redundant.
The code already sufficiently conveys the meaning of `// Update maxParams`.


