### PR TITLE
feat(router): not obtain middleware in RouteInfo

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -63,6 +63,7 @@ type RouteInfo struct {
 	Method      string
 	Path        string
 	Handler     string
+	Handlers    HandlersChain
 	HandlerFunc HandlerFunc
 }
 
@@ -360,6 +361,7 @@ func iterate(path, method string, routes RoutesInfo, root *node) RoutesInfo {
 			Method:      method,
 			Path:        path,
 			Handler:     nameOfFunction(handlerFunc),
+			Handlers:    root.handlers,
 			HandlerFunc: handlerFunc,
 		})
 	}


### PR DESCRIPTION
`gin.RoutesInfo` not provide function to obtain all handlerFunc.