### PR TITLE
use a copy of the body in jsonBinding.Bind()

### DIFF
--- a/binding/json.go
+++ b/binding/json.go
@@ -34,7 +34,11 @@ func (jsonBinding) Bind(req *http.Request, obj any) error {
 	if req == nil || req.Body == nil {
 		return errors.New("invalid request")
 	}
-	return decodeJSON(req.Body, obj)
+	body, err := req.GetBody()
+	if err != nil {
+		return err
+	}
+	return decodeJSON(body, obj)
 }
 
 func (jsonBinding) BindBody(body []byte, obj any) error {


### PR DESCRIPTION
`jsonBinding.Bind(req, obj)` passes `req.Body` to `decodeJSON`, which in turn reads all data from `req.Body`, making it impossible to use the body later as a side effect.