### PR TITLE
use a copy of the body in jsonBinding.Bind()

### DIFF
--- a/binding/json.go
+++ b/binding/json.go
@@ -34,6 +34,12 @@ func (jsonBinding) Bind(req *http.Request, obj any) error {
 	if req == nil || req.Body == nil {
 		return errors.New("invalid request")
 	}
+	if req.GetBody == nil {
+		req.GetBody = func()(io.ReadCloser, error) {
+			var readerCopy io.ReadCloser = req.Body
+			return readerCopy, nil
+		}
+	}
 	body, err := req.GetBody()
 	if err != nil {
 		return err

--- a/binding/json.go
+++ b/binding/json.go
@@ -34,6 +34,10 @@ func (jsonBinding) Bind(req *http.Request, obj any) error {
 	if req == nil || req.Body == nil {
 		return errors.New("invalid request")
 	}
+	body, err := req.GetBody()
+	if err != nil {
+		return err
+	}
 	return decodeJSON(req.Body, obj)
 }
 

--- a/binding/json.go
+++ b/binding/json.go
@@ -38,7 +38,7 @@ func (jsonBinding) Bind(req *http.Request, obj any) error {
 	if err != nil {
 		return err
 	}
-	return decodeJSON(req.Body, obj)
+	return decodeJSON(body, obj)
 }
 
 func (jsonBinding) BindBody(body []byte, obj any) error {


### PR DESCRIPTION
jsonBinding.Bind(req, obj) passes req.Body to decodeJSON, which in turn reads all data from req.Body, making it impossible to use the body later as a side effect.