### PR TITLE
removed the $ which was getting to clipboard while copying this the cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ to your code, and then `go [build|run|test]` will automatically fetch the necess
 Otherwise, run the following Go command to install the `gin` package:
 
 ```sh
-$ go get -u github.com/gin-gonic/gin
+go get -u github.com/gin-gonic/gin
 ```
 
 ### Running Gin


### PR DESCRIPTION
Removed the $ from the go get cmd mentioned on the Readme file. Which was getting copied while clicking on copy buttton.