### PR TITLE
chore(perf): Optimize the Copy method of the Context struct

### DIFF
--- a/context.go
+++ b/context.go
@@ -115,17 +115,22 @@ func (c *Context) Copy() *Context {
 		Request:   c.Request,
 		engine:    c.engine,
 	}
+
 	cp.writermem.ResponseWriter = nil
 	cp.Writer = &cp.writermem
 	cp.index = abortIndex
 	cp.handlers = nil
-	cp.Keys = make(map[string]any, len(c.Keys))
-	for k, v := range c.Keys {
+
+	cKeys := c.Keys
+	cp.Keys = make(map[string]any, len(cKeys))
+	for k, v := range cKeys {
 		cp.Keys[k] = v
 	}
-	paramsCopy := make([]Param, len(c.Params))
-	copy(paramsCopy, c.Params)
-	cp.Params = paramsCopy
+
+	cParams := c.Params
+	cp.Params = make([]Param, len(cParams))
+	copy(cp.Params, cParams)
+
 	return &cp
 }
 

--- a/context.go
+++ b/context.go
@@ -113,20 +113,19 @@ func (c *Context) Copy() *Context {
 	cp := Context{
 		writermem: c.writermem,
 		Request:   c.Request,
-		Params:    c.Params,
 		engine:    c.engine,
 	}
 	cp.writermem.ResponseWriter = nil
 	cp.Writer = &cp.writermem
 	cp.index = abortIndex
 	cp.handlers = nil
-	cp.Keys = map[string]any{}
+	cp.Keys = make(map[string]any, len(c.Keys))
 	for k, v := range c.Keys {
 		cp.Keys[k] = v
 	}
-	paramCopy := make([]Param, len(cp.Params))
-	copy(paramCopy, cp.Params)
-	cp.Params = paramCopy
+	paramsCopy := make([]Param, len(c.Params))
+	copy(paramsCopy, c.Params)
+	cp.Params = paramsCopy
 	return &cp
 }
 


### PR DESCRIPTION
Using 'make' to initialize the map('cp.Keys') with a length of 'c.Keys'.  
Avoiding repeatedly assiging the 'params' to 'context'.

Below is my local test code:

context.go
```golang
func (c *Context) Copy() *Context {
	cp := Context{
		writermem: c.writermem,
		Request:   c.Request,
		Params:    c.Params,
		engine:    c.engine,
	}
	cp.writermem.ResponseWriter = nil
	cp.Writer = &cp.writermem
	cp.index = abortIndex
	cp.handlers = nil
	cp.Keys = map[string]any{}
	for k, v := range c.Keys {
		cp.Keys[k] = v
	}
	paramCopy := make([]Param, len(cp.Params))
	copy(paramCopy, cp.Params)
	cp.Params = paramCopy
	return &cp
}

func (c *Context) NewCopy() *Context {
	cp := Context{
		writermem: c.writermem,
		Request:   c.Request,
		engine:    c.engine,
	}

	cp.writermem.ResponseWriter = nil
	cp.Writer = &cp.writermem
	cp.index = abortIndex
	cp.handlers = nil

	cKeys := c.Keys
	cp.Keys = make(map[string]any, len(cKeys))
	for k, v := range cKeys {
		cp.Keys[k] = v
	}

	cParams := c.Params
	cp.Params = make([]Param, len(cParams))
	copy(cp.Params, cParams)

	return &cp
}
```

context_test.go
```golang
func getTestContext() *Context {
    return &Context{
        Keys:   map[string]any{
            "k0" :   "v0" ,
            "k1" : 1,
            "k2" : 2.0,
            "k3" : true,
            "k4" :   "v4" ,
        },
        Params: []Param{
            {
                Key:     "k0" ,
                Value:   "v0" ,
            },
            {
                Key:     "k1" ,
                Value:   "v1" ,
            },
            {
                Key:     "k2" ,
                Value:   "v2" ,
            },
        },
    }
}
 
func TestCopySame(t *testing.T) {
    testCtx := getTestContext()
 
    copyCtx := testCtx.Copy()
    newCopyCtx := testCtx.NewCopy()
 
    if !reflect.DeepEqual(copyCtx, newCopyCtx) {
        t.Error("Got different contexts!")
    }
}
 
func BenchmarkContextCopy(b *testing.B) {
    testCtx := getTestContext()
    b.ReportAllocs()
    b.ResetTimer()
 
    for i := 0; i < b.N; i++ {
        _ = testCtx.Copy()
    }
}
 
func BenchmarkContextNewCopy(b *testing.B) {
    testCtx := getTestContext()
    b.ReportAllocs()
    b.ResetTimer()
 
    for i := 0; i < b.N; i++ {
        _ = testCtx.NewCopy()
    }
}
```

test output
```planText
=== RUN   TestCopySame
--- PASS: TestCopySame (0.00s)
PASS

Process finished with the exit code 0
```

bench output
```planText
goos: linux
goarch: amd64
pkg: github.com/gin-gonic/gin
cpu: Intel(R) Core(TM) i5-8400 CPU @ 2.80GHz
BenchmarkContextCopy
BenchmarkContextCopy-6             	 2506035	       519.9 ns/op	     688 B/op	       4 allocs/op
BenchmarkContextNewCopy
BenchmarkContextNewCopy-6          	 4579729	       255.8 ns/op	      96 B/op	       1 allocs/op
PASS

Process finished with the exit code 0
```

