### PR TITLE
docs(context): Added deprecation comments to BindWith

### DIFF
--- a/deprecated.go
+++ b/deprecated.go
@@ -12,6 +12,8 @@ import (
 
 // BindWith binds the passed struct pointer using the specified binding engine.
 // See the binding package.
+//
+// Deprecated: Use MustBindWith or ShouldBindWith.
 func (c *Context) BindWith(obj any, b binding.Binding) error {
 	log.Println(`BindWith(\"any, binding.Binding\") error is going to
 	be deprecated, please check issue #662 and either use MustBindWith() if you


### PR DESCRIPTION
I hope to achieve that the IDE can recognize deprecated methods and guide users with correct prompts.

<img width="814" alt="image" src="https://github.com/gin-gonic/gin/assets/14297703/cdc441f2-97ab-48a4-bb27-c5d0a40982c1">