### PR TITLE
test(path): Optimize unit test execution results

### DIFF
--- a/path_test.go
+++ b/path_test.go
@@ -83,7 +83,6 @@ func TestPathCleanMallocs(t *testing.T) {
 
 	if runtime.GOMAXPROCS(0) > 1 {
 		t.Skip("skipping malloc count; GOMAXPROCS>1")
-		return
 	}
 
 	for _, test := range cleanTests {

--- a/path_test.go
+++ b/path_test.go
@@ -6,6 +6,7 @@
 package gin
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -79,6 +80,8 @@ func TestPathCleanMallocs(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping malloc count in short mode")
 	}
+
+	runtime.GC()
 
 	for _, test := range cleanTests {
 		allocs := testing.AllocsPerRun(100, func() { cleanPath(test.result) })

--- a/path_test.go
+++ b/path_test.go
@@ -81,7 +81,10 @@ func TestPathCleanMallocs(t *testing.T) {
 		t.Skip("skipping malloc count in short mode")
 	}
 
-	runtime.GC()
+	if runtime.GOMAXPROCS(0) > 1 {
+		t.Skip("skipping malloc count; GOMAXPROCS>1")
+		return
+	}
 
 	for _, test := range cleanTests {
 		allocs := testing.AllocsPerRun(100, func() { cleanPath(test.result) })


### PR DESCRIPTION
I found an official example, I see the official example for the number of CPU cores for comparison, so I made a reference to the official adjustment.

**References:**

- https://github.com/golang/go/blob/master/src/path/path_test.go#L82-L85
- https://github.com/golang/go/issues/5000
- https://codereview.appspot.com/7545043