### PR TITLE
build(codecov): Added a codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  require_ci_to_pass: true
+
+  status:
+    project:
+      default:
+        target: 99%
+        threshold: 99%
+
+    patch:
+      default:
+        target: 99%
+        threshold: 95%


### PR DESCRIPTION
```yml
coverage:
  require_ci_to_pass: true # This indicates that the code coverage must meet the specified targets in order for the CI (Continuous Integration) process to pass.

  status:
    project:
      default:
        target: 99% # This sets the code coverage target for the project to 99%. It means that at least 99% of the code needs to be covered by tests.
        threshold: 99% # This sets the code coverage threshold for the project to 99% If the code coverage falls below 99%, the CI will be marked as failed.

    patch:
      default:
        target: 99% # This sets the code coverage target for patches to 99%. It means that at least 99% of the patch code needs to be covered by tests.
        threshold: 95% # This sets the code coverage threshold for patches to 95%. If the code coverage of a patch falls below 95%, the CI will be marked as failed.
```

**If there is a need to adjust the thresholds, please provide a comment to explain.**