### PR TITLE
fix(context): make context Value method adhere to Go standards

### DIFF
--- a/context.go
+++ b/context.go
@@ -1226,6 +1226,10 @@ func (c *Context) Err() error {
 // the same key returns the same result.
 func (c *Context) Value(key any) any {
 	if key == 0 {
+		val := c.Request.Context().Value(key)
+		if val != nil {
+			return val
+		}
 		return c.Request
 	}
 	if key == ContextKey {


### PR DESCRIPTION
This PR modifies the `Value` method in the `Context` struct of `context.go`. The purpose of this change is to make the `Value` method more in line with Go language standards.
