### PR TITLE
fixed open redirect

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -699,6 +699,7 @@ func redirectTrailingSlash(c *Context) {
 		p = prefix + "/" + req.URL.Path
 	}
 	req.URL.Path = p + "/"
+	p = regRemoveRepeatedChar.ReplaceAllString(p, "/")
 	if length := len(p); length > 1 && p[length-1] == '/' {
 		req.URL.Path = p[:length-1]
 	}


### PR DESCRIPTION
Hi, 

In the default configuration, Gin enables RedirectTrailingSlash, which allows paths with trailing slashes to work properly even in `/:param1/:param2` pattern, for example `/hostname/evil.com/`. 

This is achieved by redirecting users to `/hostname/evil.com` using the `redirectTrailingSlash` function. However, if the `param1` is empty, users are redirected to `//evil.com`, browsers will automatically prepend the http(s) protocol for url starting with `//`. Below is a simple vulnerable code snippet.

```go
package main

import (
 "net/http"

 "github.com/gin-gonic/gin"
)

func main() {
 router := gin.Default()

 router.GET("/", func(c *gin.Context) {
  c.JSON(http.StatusOK, gin.H{
   "message": "Hello Gin!",
  })
 })

 router.GET("/:param1/:param2", func(c *gin.Context) {
  param1 := c.Param("param1")
  param2 := c.Param("param2")

  c.JSON(http.StatusOK, gin.H{
   "param1":  param1,
   "param2": param2,
  })

 })

 router.Run(":8080")
}
```

You can observe the request being redirected to a malicious website by accessing http://localhost:8080//evil.com/ in your browser or using the curl command `curl -v http://localhost:8080//evil.com/`. This issue affects versions 1.9.1 and earlier.


<img width="866" alt="image" src="https://github.com/gin-gonic/gin/assets/33282478/a813b63f-419b-4497-b78e-aa8b16e94359">

<img width="542" alt="image" src="https://github.com/gin-gonic/gin/assets/33282478/35b2e147-725c-4218-9edf-3eb7c6527935">

Below is the fix code:
```go
func redirectTrailingSlash(c *Context) {
	req := c.Request
	p := req.URL.Path
	if prefix := path.Clean(c.Request.Header.Get("X-Forwarded-Prefix")); prefix != "." {
		prefix = regSafePrefix.ReplaceAllString(prefix, "")
		prefix = regRemoveRepeatedChar.ReplaceAllString(prefix, "/")

		p = prefix + "/" + req.URL.Path
	}
	req.URL.Path = p + "/"
	p = regRemoveRepeatedChar.ReplaceAllString(p, "/") // fix open redirect
	if length := len(p); length > 1 && p[length-1] == '/' {
		req.URL.Path = p[:length-1]
	}
	redirectRequest(c)
}
```

