### PR TITLE
Optimize the ShouldBindUri method of the Context struct

### DIFF
--- a/context.go
+++ b/context.go
@@ -739,7 +739,7 @@ func (c *Context) ShouldBindHeader(obj any) error {
 
 // ShouldBindUri binds the passed struct pointer using the specified binding engine.
 func (c *Context) ShouldBindUri(obj any) error {
-	m := make(map[string][]string)
+	m := make(map[string][]string, len(c.Params))
 	for _, v := range c.Params {
 		m[v.Key] = []string{v.Value}
 	}


### PR DESCRIPTION
Initialize the m map with a length of len(c.Params)