### PR TITLE
refactor(slice): simplify SliceValidationError Error method

### DIFF
--- a/binding/default_validator.go
+++ b/binding/default_validator.go
@@ -5,8 +5,8 @@
 package binding
 
 import (
-	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -22,13 +22,17 @@ type SliceValidationError []error
 
 // Error concatenates all error elements in SliceValidationError into a single string separated by \n.
 func (err SliceValidationError) Error() string {
+	if len(err) == 0 {
+		return ""
+	}
+
 	var b strings.Builder
-	for i := range err {
+	for i := 0; i < len(err); i++ {
 		if err[i] != nil {
 			if b.Len() > 0 {
 				b.WriteString("\n")
 			}
-			fmt.Fprintf(&b, "[%d]: %s", i, err[i].Error())
+			b.WriteString("[" + strconv.Itoa(i) + "]: " + err[i].Error())
 		}
 	}
 	return b.String()

--- a/binding/default_validator.go
+++ b/binding/default_validator.go
@@ -22,25 +22,16 @@ type SliceValidationError []error
 
 // Error concatenates all error elements in SliceValidationError into a single string separated by \n.
 func (err SliceValidationError) Error() string {
-	n := len(err)
-	switch n {
-	case 0:
-		return ""
-	default:
-		var b strings.Builder
-		if err[0] != nil {
-			fmt.Fprintf(&b, "[%d]: %s", 0, err[0].Error())
-		}
-		if n > 1 {
-			for i := 1; i < n; i++ {
-				if err[i] != nil {
-					b.WriteString("\n")
-					fmt.Fprintf(&b, "[%d]: %s", i, err[i].Error())
-				}
+	var b strings.Builder
+	for i := range err {
+		if err[i] != nil {
+			if b.Len() > 0 {
+				b.WriteString("\n")
 			}
+			fmt.Fprintf(&b, "[%d]: %s", i, err[i].Error())
 		}
-		return b.String()
 	}
+	return b.String()
 }
 
 var _ StructValidator = (*defaultValidator)(nil)

--- a/binding/default_validator_benchmark_test.go
+++ b/binding/default_validator_benchmark_test.go
@@ -12,11 +12,15 @@ import (
 
 func BenchmarkSliceValidationError(b *testing.B) {
 	const size int = 100
+	e := make(SliceValidationError, size)
+	for j := 0; j < size; j++ {
+		e[j] = errors.New(strconv.Itoa(j))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
-		e := make(SliceValidationError, size)
-		for j := 0; j < size; j++ {
-			e[j] = errors.New(strconv.Itoa(j))
-		}
 		if len(e.Error()) == 0 {
 			b.Errorf("error")
 		}


### PR DESCRIPTION
Enhance code readability by replacing the original "switch statement and if conditionals" with a simple "for loop" to iterate over the error slice.

Below is my local test code:

default_validator.go
```go
type SliceValidationError []error

// Error concatenates all error elements in SliceValidationError into a single string separated by \n.
func (err SliceValidationError) Error() string {
	n := len(err)
	switch n {
	case 0:
		return ""
	default:
		var b strings.Builder
		if err[0] != nil {
			fmt.Fprintf(&b, "[%d]: %s", 0, err[0].Error())
		}
		if n > 1 {
			for i := 1; i < n; i++ {
				if err[i] != nil {
					b.WriteString("\n")
					fmt.Fprintf(&b, "[%d]: %s", i, err[i].Error())
				}
			}
		}
		return b.String()
	}
}

func (err SliceValidationError) NewError() string {
	if len(err) == 0 {
		return ""
	}

	var b strings.Builder
	for i := 0; i < len(err); i++ {
		if err[i] != nil {
			if b.Len() > 0 {
				b.WriteString("\n")
			}
			b.WriteString("[" + strconv.Itoa(i) + "]: " + err[i].Error())
		}
	}
	return b.String()
}
```

default_validator_benchmark_test.go
```go
package binding

import (
	"errors"
	"strconv"
	"testing"

	"github.com/stretchr/testify/assert"
)

func getSliceValidationError(n int) SliceValidationError {
	e := make(SliceValidationError, n)
	for i := 0; i < n; i++ {
		e[i] = errors.New(strconv.Itoa(i))
	}
	return e
}

func TestSameError(t *testing.T) {
	e0 := getSliceValidationError(0)
	assert.Equal(t, e0.Error(), e0.NewError())

	e1 := getSliceValidationError(1)
	assert.Equal(t, e1.Error(), e1.NewError())

	e10 := getSliceValidationError(10)
	assert.Equal(t, e10.Error(), e10.NewError())
}

func BenchmarkSliceValidationError0(b *testing.B) {
	e := getSliceValidationError(0)

	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_ = e.Error()
	}
}

func BenchmarkSliceValidationNewError0(b *testing.B) {
	e := getSliceValidationError(0)

	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_ = e.NewError()
	}
}

func BenchmarkSliceValidationError1(b *testing.B) {
	e := getSliceValidationError(1)

	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_ = e.Error()
	}
}

func BenchmarkSliceValidationNewError1(b *testing.B) {
	e := getSliceValidationError(1)

	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_ = e.NewError()
	}
}

func BenchmarkSliceValidationError10(b *testing.B) {
	e := getSliceValidationError(10)

	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_ = e.Error()
	}
}

func BenchmarkSliceValidationNewError10(b *testing.B) {
	e := getSliceValidationError(10)

	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_ = e.NewError()
	}
}

```

test output
```text
=== RUN   TestSameError
--- PASS: TestSameError (0.00s)
PASS

Process finished with the exit code 0
```

benchmark output
```text
goos: darwin
goarch: amd64
pkg: github.com/gin-gonic/gin/binding
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
BenchmarkSliceValidationError0
BenchmarkSliceValidationError0-8       	611569416	         1.911 ns/op	       0 B/op	       0 allocs/op
BenchmarkSliceValidationNewError0
BenchmarkSliceValidationNewError0-8    	614464096	         1.909 ns/op	       0 B/op	       0 allocs/op
BenchmarkSliceValidationError1
BenchmarkSliceValidationError1-8       	 5836453	       196.6 ns/op	      56 B/op	       3 allocs/op
BenchmarkSliceValidationNewError1
BenchmarkSliceValidationNewError1-8    	21680595	        51.82 ns/op	       8 B/op	       1 allocs/op
BenchmarkSliceValidationError10
BenchmarkSliceValidationError10-8      	  705206	      1609 ns/op	     440 B/op	      16 allocs/op
BenchmarkSliceValidationNewError10
BenchmarkSliceValidationNewError10-8   	 2226651	       530.6 ns/op	     248 B/op	       5 allocs/op
PASS

Process finished with the exit code 0
```
