### PR TITLE
ci(release): refactor changelog regex patterns and exclusions

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,7 @@ builds:
 changelog:
   # Set it to true if you wish to skip the changelog generation.
   # This may result in an empty release notes on GitHub/GitLab/Gitea.
-  skip: false
+  disable: true
 
   # Changelog generation implementation to use.
   #

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,7 @@ builds:
 changelog:
   # Set it to true if you wish to skip the changelog generation.
   # This may result in an empty release notes on GitHub/GitLab/Gitea.
-  disable: true
+  disable: false
 
   # Changelog generation implementation to use.
   #

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,17 +35,17 @@ changelog:
   # Default is no groups.
   groups:
     - title: Features
-      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      regexp: "^.*feat[(\\w)]*:+.*$"
       order: 0
     - title: "Bug fixes"
-      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      regexp: "^.*fix[(\\w)]*:+.*$"
       order: 1
-    - title: "Refactor"
-      regexp: '^.*?refactor(\([[:word:]]+\))??!?:.+$'
-      order: 2
     - title: "Enhancements"
-      regexp: '^.*?chore(\([[:word:]]+\))??!?:.+$'
+      regexp: "^.*chore[(\\w)]*:+.*$"
       order: 2
+    - title: "Refactor"
+      regexp: "^.*refactor[(\\w)]*:+.*$"
+      order: 3
     - title: Others
       order: 999
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,7 @@
 project_name: gin
 
 builds:
-  -
-    # If true, skip the build.
+  - # If true, skip the build.
     # Useful for library projects.
     # Default is false
     skip: true
@@ -21,7 +20,7 @@ changelog:
   # - `github-native`: uses the GitHub release notes generation API, disables the groups feature.
   #
   # Defaults to `git`.
-  use: git
+  use: github
 
   # Sorts the changelog by the commit's messages.
   # Could either be asc, desc or empty
@@ -36,13 +35,16 @@ changelog:
   # Default is no groups.
   groups:
     - title: Features
-      regexp: "^.*feat[(\\w)]*:+.*$"
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
       order: 0
-    - title: 'Bug fixes'
-      regexp: "^.*fix[(\\w)]*:+.*$"
+    - title: "Bug fixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
       order: 1
-    - title: 'Enhancements'
-      regexp: "^.*chore[(\\w)]*:+.*$"
+    - title: "Refactor"
+      regexp: '^.*?refactor(\([[:word:]]+\))??!?:.+$'
+      order: 2
+    - title: "Enhancements"
+      regexp: '^.*?chore(\([[:word:]]+\))??!?:.+$'
       order: 2
     - title: Others
       order: 999
@@ -52,6 +54,6 @@ changelog:
     # the changelog
     # Default is empty
     exclude:
-      - '^docs'
-      - 'CICD'
+      - "^docs"
+      - "CICD"
       - typo


### PR DESCRIPTION
- Update the build configuration to skip the build using a comment
- Change the `changelog` use from `git` to `github`
- Modify the regex patterns for `Features`, `Bug fixes`, and `Enhancements` titles in the changelog
- Add a new regex pattern for the `Refactor` title in the changelog
- Update the excluded items in the changelog to include `docs` and `CICD` with corrected quotes


