### PR TITLE
feat(binding): Support custom BindUnmarshaler for binding.

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -165,6 +165,23 @@ func tryToSetValue(value reflect.Value, field reflect.StructField, setter setter
 	return setter.TrySet(value, field, tagValue, setOpt)
 }
 
+// BindUnmarshaler is the interface used to wrap the UnmarshalParam method.
+type BindUnmarshaler interface {
+	// UnmarshalParam decodes and assigns a value from an form or query param.
+	UnmarshalParam(param string) error
+}
+
+// trySetCustom tries to set a custom type value
+// If the value implements the BindUnmarshaler interface, it will be used to set the value, we will return `true`
+// to skip the default value setting.
+func trySetCustom(val string, value reflect.Value) (isSet bool, err error) {
+	switch v := value.Addr().Interface().(type) {
+	case BindUnmarshaler:
+		return true, v.UnmarshalParam(val)
+	}
+	return false, nil
+}
+
 func setByForm(value reflect.Value, field reflect.StructField, form map[string][]string, tagValue string, opt setOptions) (isSet bool, err error) {
 	vs, ok := form[tagValue]
 	if !ok && !opt.isDefaultExists {
@@ -193,6 +210,9 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 
 		if len(vs) > 0 {
 			val = vs[0]
+		}
+		if ok, err := trySetCustom(val, value); ok {
+			return ok, err
 		}
 		return true, setWithProperType(val, value, field)
 	}

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -27,6 +27,7 @@
   - [Only Bind Query String](#only-bind-query-string)
   - [Bind Query String or Post Data](#bind-query-string-or-post-data)
   - [Bind Uri](#bind-uri)
+  - [Bind custom unmarshaler](#bind-custom-unmarshaler)
   - [Bind Header](#bind-header)
   - [Bind HTML checkboxes](#bind-html-checkboxes)
   - [Multipart/Urlencoded binding](#multiparturlencoded-binding)
@@ -897,6 +898,46 @@ Test it with:
 ```sh
 curl -v localhost:8088/thinkerou/987fbc97-4bed-5078-9f07-9141ba07c9f3
 curl -v localhost:8088/thinkerou/not-uuid
+```
+
+### Bind custom unmarshaler
+
+```go
+package main
+
+import (
+  "github.com/gin-gonic/gin"
+  "strings"
+)
+
+type Birthday string
+
+func (b *Birthday) UnmarshalParam(param string) error {
+  *b = Birthday(strings.Replace(param, "-", "/", -1))
+  return nil
+}
+
+func main() {
+  route := gin.Default()
+  var request struct {
+    Birthday Birthday `form:"birthday"`
+  }
+  route.GET("/test", func(ctx *gin.Context) {
+    _ = ctx.BindQuery(&request)
+    ctx.JSON(200, request.Birthday)
+  })
+  route.Run(":8088")
+}
+```
+
+Test it with:
+
+```sh
+curl 'localhost:8088/test?birthday=2000-01-01'
+```
+Result
+```sh
+"2000/01/01"
 ```
 
 ### Bind Header

--- a/gin_test.go
+++ b/gin_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -729,4 +730,27 @@ func TestWithOptionFunc(t *testing.T) {
 	routes := r.Routes()
 	assertRoutePresent(t, routes, RouteInfo{Path: "/test1", Method: "GET", Handler: "github.com/gin-gonic/gin.handlerTest1"})
 	assertRoutePresent(t, routes, RouteInfo{Path: "/test2", Method: "GET", Handler: "github.com/gin-gonic/gin.handlerTest2"})
+}
+
+type Birthday string
+
+func (b *Birthday) UnmarshalParam(param string) error {
+	*b = Birthday(strings.Replace(param, "-", "/", -1))
+	return nil
+}
+
+func TestCustomUnmarshalStruct(t *testing.T) {
+	route := Default()
+	var request struct {
+		Birthday Birthday `form:"birthday"`
+	}
+	route.GET("/test", func(ctx *Context) {
+		_ = ctx.BindQuery(&request)
+		ctx.JSON(200, request.Birthday)
+	})
+	req := httptest.NewRequest("GET", "/test?birthday=2000-01-01", nil)
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, `"2000/01/01"`, w.Body.String())
 }


### PR DESCRIPTION
## Feature
Add `binding.BindUnmarshaler` interface to support custom unmarshaling (from the suggestion in https://github.com/gin-gonic/gin/issues/2673)

## Description
This PR is inspired by the information provided on the following page: [labstack/echo/v4#BindUnmarshaler ](https://pkg.go.dev/github.com/labstack/echo/v4#BindUnmarshaler) and  [PR-3045](https://github.com/gin-gonic/gin/pull/3045).

As [ssoroka](https://github.com/ssoroka) (the author of [PR-3045](https://github.com/gin-gonic/gin/pull/3045)) mentioned:
> This is way off my radar (it's been 2 years and I've switched to huma). Feel free to take over the change and apply it in a new PR."

Therefore, I would like to open a new pull request to implement this feature. However, I have identified two potential issues with PR-3045:

1. PR-3045 also introduces support for the `encoding.TextUnmarshaler` interface. I believe there might be compatibility issues with this approach. Instead, I suggest that users implement the new interface binding.BindUnmarshaler to achieve the desired custom unmarshaler functionality.

2. In order to support arrays and slices, PR-3045 uses `vs[0]` to retrieve the first item. This approach may be susceptible to boundary issues. Upon closer examination of the implementation, I found that addressing this complexity might be challenging. As a temporary solution, I have decided not to support this functionality for arrays and slices. If there is a future demand from other users, we can consider implementing it at that time.


```go
if ok, err := trySetCustom(vs[0], value); ok || err != nil {
    return ok, err
}
```
## Usage
```go
package main

import (
  "github.com/gin-gonic/gin"
  "strings"
)

type Birthday string

func (b *Birthday) UnmarshalParam(param string) error {
  *b = Birthday(strings.Replace(param, "-", "/", -1))
  return nil
}

func main() {
  route := gin.Default()
  var request struct {
    Birthday Birthday `form:"birthday"`
  }
  route.GET("/test", func(ctx *gin.Context) {
    _ = ctx.BindQuery(&request)
    ctx.JSON(200, request.Birthday)
  })
  route.Run(":8088")
}
```

Test it with:

```sh
curl 'localhost:8088/test?birthday=2000-01-01'
```
Result
```sh
"2000/01/01"
```

## Testing
1. Unit testing, see `binding/form_mapping_test.go`
2. Integration testing, see `gin_test.go`

## References
- Close https://github.com/gin-gonic/gin/issues/2673
- Close https://github.com/gin-gonic/gin/issues/2631
- Related to https://github.com/gin-gonic/gin/pull/3045