### PR TITLE
perf: replace unsafe with the raw method for string to bytes conversion

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -9,8 +9,6 @@ import (
 	"encoding/base64"
 	"net/http"
 	"strconv"
-
-	"github.com/gin-gonic/gin/internal/bytesconv"
 )
 
 // AuthUserKey is the cookie name for user credential in basic auth.
@@ -34,7 +32,7 @@ func (a authPairs) searchCredential(authValue string) (string, bool) {
 		return "", false
 	}
 	for _, pair := range a {
-		if subtle.ConstantTimeCompare(bytesconv.StringToBytes(pair.value), bytesconv.StringToBytes(authValue)) == 1 {
+		if subtle.ConstantTimeCompare([]byte(pair.value), []byte(authValue)) == 1 {
 			return pair.user, true
 		}
 	}
@@ -90,7 +88,7 @@ func processAccounts(accounts Accounts) authPairs {
 
 func authorizationHeader(user, password string) string {
 	base := user + ":" + password
-	return "Basic " + base64.StdEncoding.EncodeToString(bytesconv.StringToBytes(base))
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(base))
 }
 
 // BasicAuthForProxy returns a Basic HTTP Proxy-Authorization middleware.

--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin/internal/bytesconv"
 	"github.com/gin-gonic/gin/internal/json"
 )
 
@@ -239,9 +238,9 @@ func setWithProperType(val string, value reflect.Value, field reflect.StructFiel
 		case multipart.FileHeader:
 			return nil
 		}
-		return json.Unmarshal(bytesconv.StringToBytes(val), value.Addr().Interface())
+		return json.Unmarshal([]byte(val), value.Addr().Interface())
 	case reflect.Map:
-		return json.Unmarshal(bytesconv.StringToBytes(val), value.Addr().Interface())
+		return json.Unmarshal([]byte(val), value.Addr().Interface())
 	case reflect.Ptr:
 		if !value.Elem().IsValid() {
 			value.Set(reflect.New(value.Type().Elem()))

--- a/render/json.go
+++ b/render/json.go
@@ -97,9 +97,9 @@ func (r SecureJSON) Render(w http.ResponseWriter) error {
 		return err
 	}
 	// if the jsonBytes is array values
-	if bytes.HasPrefix(jsonBytes, bytesconv.StringToBytes("[")) && bytes.HasSuffix(jsonBytes,
-		bytesconv.StringToBytes("]")) {
-		if _, err = w.Write(bytesconv.StringToBytes(r.Prefix)); err != nil {
+	if bytes.HasPrefix(jsonBytes, []byte("[")) && bytes.HasSuffix(jsonBytes,
+		[]byte("]")) {
+		if _, err = w.Write([]byte(r.Prefix)); err != nil {
 			return err
 		}
 	}
@@ -126,11 +126,11 @@ func (r JsonpJSON) Render(w http.ResponseWriter) (err error) {
 	}
 
 	callback := template.JSEscapeString(r.Callback)
-	if _, err = w.Write(bytesconv.StringToBytes(callback)); err != nil {
+	if _, err = w.Write([]byte(callback)); err != nil {
 		return err
 	}
 
-	if _, err = w.Write(bytesconv.StringToBytes("(")); err != nil {
+	if _, err = w.Write([]byte("(")); err != nil {
 		return err
 	}
 
@@ -138,7 +138,7 @@ func (r JsonpJSON) Render(w http.ResponseWriter) (err error) {
 		return err
 	}
 
-	if _, err = w.Write(bytesconv.StringToBytes(");")); err != nil {
+	if _, err = w.Write([]byte(");")); err != nil {
 		return err
 	}
 

--- a/render/text.go
+++ b/render/text.go
@@ -7,8 +7,6 @@ package render
 import (
 	"fmt"
 	"net/http"
-
-	"github.com/gin-gonic/gin/internal/bytesconv"
 )
 
 // String contains the given interface object slice and its format.
@@ -36,6 +34,6 @@ func WriteString(w http.ResponseWriter, format string, data []any) (err error) {
 		_, err = fmt.Fprintf(w, format, data...)
 		return
 	}
-	_, err = w.Write(bytesconv.StringToBytes(format))
+	_, err = w.Write([]byte(format))
 	return
 }

--- a/tree.go
+++ b/tree.go
@@ -93,14 +93,14 @@ func (n *node) addChild(child *node) {
 
 func countParams(path string) uint16 {
 	var n uint16
-	s := bytesconv.StringToBytes(path)
+	s := []byte(path)
 	n += uint16(bytes.Count(s, strColon))
 	n += uint16(bytes.Count(s, strStar))
 	return n
 }
 
 func countSections(path string) uint16 {
-	s := bytesconv.StringToBytes(path)
+	s := []byte(path)
 	return uint16(bytes.Count(s, strSlash))
 }
 


### PR DESCRIPTION
Issue references: https://github.com/gin-gonic/gin/issues/3935

For string to bytes conversion
Two points to make this change:

1. The raw method also has 0 memory allocation
2. Unsafe is slightly slower than the raw method. And as the name suggests, it's "unsafe". There's no point to use the unsafe method to convert string to bytes

Benchmark result in: [gin/internal/bytesconv/bytesconv_test.go](https://github.com/gin-gonic/gin/blob/master/internal/bytesconv/bytesconv_test.go):

```
╰─± go test -v -run=none -bench=^BenchmarkBytesConvStr -benchmem=true
goos: darwin
goarch: amd64
pkg: github.com/gin-gonic/gin/internal/bytesconv
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkBytesConvStrToBytesRaw
BenchmarkBytesConvStrToBytesRaw-12      1000000000               0.2542 ns/op          0 B/op          0 allocs/op
BenchmarkBytesConvStrToBytes
BenchmarkBytesConvStrToBytes-12         1000000000               0.5039 ns/op          0 B/op          0 allocs/op
PASS
ok      github.com/gin-gonic/gin/internal/bytesconv     1.163s
```
