### PR TITLE
docs(gin): update link to dont-trust-all-proxies section (#3938)

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -391,7 +391,7 @@ func (engine *Engine) Run(addr ...string) (err error) {
 
 	if engine.isUnsafeTrustedProxies() {
 		debugPrint("[WARNING] You trusted all proxies, this is NOT safe. We recommend you to set a value.\n" +
-			"Please check https://pkg.go.dev/github.com/gin-gonic/gin#readme-don-t-trust-all-proxies for details.")
+			"Please check https://github.com/gin-gonic/gin/blob/master/docs/doc.md#dont-trust-all-proxies for details.")
 	}
 
 	address := resolveAddress(addr)
@@ -512,7 +512,7 @@ func (engine *Engine) RunTLS(addr, certFile, keyFile string) (err error) {
 
 	if engine.isUnsafeTrustedProxies() {
 		debugPrint("[WARNING] You trusted all proxies, this is NOT safe. We recommend you to set a value.\n" +
-			"Please check https://pkg.go.dev/github.com/gin-gonic/gin#readme-don-t-trust-all-proxies for details.")
+			"Please check https://github.com/gin-gonic/gin/blob/master/docs/doc.md#dont-trust-all-proxies for details.")
 	}
 
 	err = http.ListenAndServeTLS(addr, certFile, keyFile, engine.Handler())


### PR DESCRIPTION
Update link [1] to [2] after PR #3449 was merged.

[1] https://pkg.go.dev/github.com/gin-gonic/gin#readme-don-t-trust-all-proxies
[2] https://github.com/gin-gonic/gin/blob/master/docs/doc.md#dont-trust-all-proxies

Closes #3938
