### PR TITLE
build: update Gin minimum Go version to 1.21

### DIFF
--- a/.github/workflows/gin.yml
+++ b/.github/workflows/gin.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ["1.20", "1.21", "1.22"]
+        go: ["1.21", "1.22"]
         test-tags:
           ["", "-tags nomsgpack", '-tags "sonic avx"', "-tags go_json", "-race"]
         include:

--- a/README.md
+++ b/README.md
@@ -25,18 +25,17 @@ Gin is a web framework written in [Go](https://go.dev/). It features a martini-l
 - Rendering built-in
 - Extendable
 
-
 ## Getting started
 
 ### Prerequisites
 
-- **[Go](https://go.dev/)**: any one of the **three latest major** [releases](https://go.dev/doc/devel/release) (we test it with these).
+The required version of [Go](https://go.dev/) language is [1.21](https://go.dev/doc/devel/release#go1.21.0) or above.
 
 ### Getting Gin
 
 With [Go module](https://github.com/golang/go/wiki/Modules) support, simply add the following import
 
-```
+```sh
 import "github.com/gin-gonic/gin"
 ```
 
@@ -45,7 +44,7 @@ to your code, and then `go [build|run|test]` will automatically fetch the necess
 Otherwise, run the following Go command to install the `gin` package:
 
 ```sh
-$ go get -u github.com/gin-gonic/gin
+go get -u github.com/gin-gonic/gin
 ```
 
 ### Running Gin
@@ -74,7 +73,7 @@ func main() {
 
 And use the Go command to run the demo:
 
-```
+```sh
 # run example.go and visit 0.0.0.0:8080/ping on browser
 $ go run example.go
 ```
@@ -88,7 +87,6 @@ Learn and practice more examples, please read the [Gin Quick Start](docs/doc.md)
 #### Examples
 
 A number of ready-to-run examples demonstrating various use cases of Gin on the [Gin examples](https://github.com/gin-gonic/examples) repository.
-
 
 ## Documentation
 
@@ -153,23 +151,20 @@ Gin uses a custom version of [HttpRouter](https://github.com/julienschmidt/httpr
 - (3): Heap Memory (B/op), lower is better
 - (4): Average Allocations per Repetition (allocs/op), lower is better
 
-
 ## Middlewares
 
 You can find many useful Gin middlewares at [gin-contrib](https://github.com/gin-contrib).
-
 
 ## Users
 
 Awesome project lists using [Gin](https://github.com/gin-gonic/gin) web framework.
 
-* [gorush](https://github.com/appleboy/gorush): A push notification server written in Go.
-* [fnproject](https://github.com/fnproject/fn): The container native, cloud agnostic serverless platform.
-* [photoprism](https://github.com/photoprism/photoprism): Personal photo management powered by Go and Google TensorFlow.
-* [lura](https://github.com/luraproject/lura): Ultra performant API Gateway with middlewares.
-* [picfit](https://github.com/thoas/picfit): An image resizing server written in Go.
-* [dkron](https://github.com/distribworks/dkron): Distributed, fault tolerant job scheduling system.
-
+- [gorush](https://github.com/appleboy/gorush): A push notification server written in Go.
+- [fnproject](https://github.com/fnproject/fn): The container native, cloud agnostic serverless platform.
+- [photoprism](https://github.com/photoprism/photoprism): Personal photo management powered by Go and Google TensorFlow.
+- [lura](https://github.com/luraproject/lura): Ultra performant API Gateway with middlewares.
+- [picfit](https://github.com/thoas/picfit): An image resizing server written in Go.
+- [dkron](https://github.com/distribworks/dkron): Distributed, fault tolerant job scheduling system.
 
 ## Contributing
 

--- a/debug.go
+++ b/debug.go
@@ -13,7 +13,7 @@ import (
 	"sync/atomic"
 )
 
-const ginSupportMinGoVer = 18
+const ginSupportMinGoVer = 21
 
 // IsDebugging returns true if the framework is running in debug mode.
 // Use SetMode(gin.ReleaseMode) to disable debug mode.
@@ -78,7 +78,7 @@ func getMinVer(v string) (uint64, error) {
 
 func debugPrintWARNINGDefault() {
 	if v, e := getMinVer(runtime.Version()); e == nil && v < ginSupportMinGoVer {
-		debugPrint(`[WARNING] Now Gin requires Go 1.20+.
+		debugPrint(`[WARNING] Now Gin requires Go 1.21+.
 
 `)
 	}

--- a/debug_test.go
+++ b/debug_test.go
@@ -104,7 +104,7 @@ func TestDebugPrintWARNINGDefault(t *testing.T) {
 	})
 	m, e := getMinVer(runtime.Version())
 	if e == nil && m < ginSupportMinGoVer {
-		assert.Equal(t, "[GIN-debug] [WARNING] Now Gin requires Go 1.20+.\n\n[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.\n\n", re)
+		assert.Equal(t, "[GIN-debug] [WARNING] Now Gin requires Go 1.21+.\n\n[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.\n\n", re)
 	} else {
 		assert.Equal(t, "[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.\n\n", re)
 	}


### PR DESCRIPTION
- Update the minimum Go version requirement for Gin from `1.20` to `1.21` in both `debug.go` and `debug_test.go`
- Modify the warning message to reflect the new minimum Go version requirement in `debug.go`
- Adjust the test assertion to match the updated warning message in `debug_test.go`

since https://github.com/gin-gonic/gin/pull/3210 PR import [quic-go/quic-go](https://github.com/quic-go/quic-go) package which require go v1.21 above.

