### PR TITLE
fix(context): verify URL is Non-nil in initQueryCache()

### DIFF
--- a/context.go
+++ b/context.go
@@ -475,7 +475,7 @@ func (c *Context) QueryArray(key string) (values []string) {
 
 func (c *Context) initQueryCache() {
 	if c.queryCache == nil {
-		if c.Request != nil {
+		if c.Request != nil && c.Request.URL != nil {
 			c.queryCache = c.Request.URL.Query()
 		} else {
 			c.queryCache = url.Values{}


### PR DESCRIPTION
## Verify URL is Non-nil in initQueryCache()

When using a test context (as returned by `gin.CreateTestContext(w)`) it is possible that not only the Request object is nil, but also the URL object may be nil.

Ran into this in the wild in unit tests. Stack trace:

```
1. --- FAIL: Test_ListOrgs (1.09s)
2. panic: runtime error: invalid memory address or nil pointer dereference [recovered]
3.     panic: runtime error: invalid memory address or nil pointer dereference
4. [signal SIGSEGV: segmentation violation code=0x1 addr=0x60 pc=0x6e51ce]
5.  
6. goroutine 124 [running]:
7. testing.tRunner.func1.2({0x206ad60, 0x3dd8c30})
8.     /opt/hostedtoolcache/go/1.22.2/x64/src/testing/testing.go:1631 +0x24a
9. testing.tRunner.func1()
10.     /opt/hostedtoolcache/go/1.22.2/x64/src/testing/testing.go:1634 +0x377
11. panic({0x206ad60?, 0x3dd8c30?})
12.     /opt/hostedtoolcache/go/1.22.2/x64/src/runtime/panic.go:770 +0x132
13. net/url.(*URL).Query(0x1000?)
14.     /opt/hostedtoolcache/go/1.22.2/x64/src/net/url/url.go:1122 +0xe
15. github.com/gin-gonic/gin.(*Context).initQueryCache(...)
16.     /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:461
17. github.com/gin-gonic/gin.(*Context).GetQueryArray(0xc000126a00, {0x2392c3d, 0xf})
18.     /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:471 +0x47
19. github.com/gin-gonic/gin.(*Context).GetQuery(...)
20.     /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:445
21. github.com/gin-gonic/gin.(*Context).Query(0x2b5c688?, {0x2392c3d?, 0x2b6f428?})
22.     /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:416 +0x18
23. github.com/HIDDEN_GH_ORG_NAME/api/internal/app/api/handlers/v1.OrganizationAPI.ListOrgsHandler({{0x2b5b880, 0xc0002b6150}, {{0x2b5c688, 0xc000cde910}, {0x2b6f428, 0xc000cde920}, {0x2b565b0, 0xc000cde930}, {0x2b666e0, 0xc000cde940}, ...}, ...}, ...)
24.     /home/runner/work/api/api/internal/app/api/handlers/v1/organizations.go:217 +0x2fe
25. github.com/HIDDEN_GH_ORG_NAME/api/internal/app/api/handlers/v1.Test_ListOrgs(0xc00101ab60)
26.     /home/runner/work/api/api/internal/app/api/handlers/v1/organizations_test.go:88 +0x95b
27. testing.tRunner(0xc00101ab60, 0x24f1320)
28.     /opt/hostedtoolcache/go/1.22.2/x64/src/testing/testing.go:1689 +0xfb
29. created by testing.(*T).Run in goroutine 1
30.     /opt/hostedtoolcache/go/1.22.2/x64/src/testing/testing.go:1742 +0x390
31. FAIL    github.com/HIDDEN_GH_ORG_NAME/api/internal/app/api/handlers/v1  10.886s
```
