### PR TITLE
feat(form): add custom string slice for form tag unmarshal (#3970)

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -193,14 +193,25 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 		if !ok {
 			vs = []string{opt.defaultValue}
 		}
+
+		if ok, err = trySetCustom(vs[0], value); ok {
+			return ok, err
+		}
+
 		return true, setSlice(vs, value, field)
 	case reflect.Array:
 		if !ok {
 			vs = []string{opt.defaultValue}
 		}
+
+		if ok, err = trySetCustom(vs[0], value); ok {
+			return ok, err
+		}
+
 		if len(vs) != value.Len() {
 			return false, fmt.Errorf("%q is not valid value for %s", vs, value.Type().String())
 		}
+
 		return true, setArray(vs, value, field)
 	default:
 		var val string


### PR DESCRIPTION
Resolves #3970
```golang
package main

import (
	"fmt"
	"net/http"
	"strings"

	"github.com/gin-gonic/gin"
)

type CustomPath []string

func (b *CustomPath) UnmarshalParam(param string) error {
	elems := strings.Split(param, "/")
	n := len(elems)
	if n < 2 {
		return fmt.Errorf("invalid path: %s", param)
	}

	*b = elems
	return nil
}

type PathRequest struct {
	Paths CustomPath `form:"path"`
}

func main() {
	g := gin.Default()
	g.GET("", func(c *gin.Context) {
		var request PathRequest
		if err := c.ShouldBind(&request); err != nil {
			c.String(http.StatusBadRequest, "request parse err: %v", err)
			return
		}

		c.String(200, "Hello %s", request.Paths)
	})
	g.Run(":9000")
}



Calling this server with a string parameters path will get the expected slices.

Example: 
$ curl 'http://127.0.0.1:9000?path=hello/world' 
CustomPath:  [hello world]