### PR TITLE
Add func `RunHttp3` in gin.go, which support both TLS/TCP and QUIC

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -582,6 +582,23 @@ func (engine *Engine) RunQUIC(addr, certFile, keyFile string) (err error) {
 	return
 }
 
+// RunHttp3 attaches the router to a http.Server and starts listening
+// and serving both TLS/TCP and QUIC requests in parallel.
+// It is a shortcut for http3.ListenAndServe(addr, certFile, keyFile, router)
+// Note: this method will block the calling goroutine indefinitely unless an error happens.
+func (engine *Engine) RunHttp3(addr, certFile, keyFile string) (err error) {
+	debugPrint("Listening and serving both HTTPS and QUIC on %s\n", addr)
+	defer func() { debugPrintError(err) }()
+
+	if engine.isUnsafeTrustedProxies() {
+		debugPrint("[WARNING] You trusted all proxies, this is NOT safe. We recommend you to set a value.\n" +
+			"Please check https://pkg.go.dev/github.com/gin-gonic/gin#readme-don-t-trust-all-proxies for details.")
+	}
+
+	err = http3.ListenAndServe(addr, certFile, keyFile, engine.Handler())
+	return
+}
+
 // RunListener attaches the router to a http.Server and starts listening and serving HTTP requests
 // through the specified net.Listener
 func (engine *Engine) RunListener(listener net.Listener) (err error) {


### PR DESCRIPTION
Add func `RunHttp3` in gin.go, which support both TLS/TCP and QUIC in parallel.
