### PR TITLE
feat(form): add array collection format in form binding

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -182,6 +182,34 @@ func trySetCustom(val string, value reflect.Value) (isSet bool, err error) {
 	return false, nil
 }
 
+func trySplit(vs []string, field reflect.StructField) (newVs []string, err error) {
+	cfTag := field.Tag.Get("collection_format")
+	if cfTag == "" || cfTag == "multi" {
+		return vs, nil
+	}
+
+	var sep string
+	switch cfTag {
+	case "csv":
+		sep = ","
+	case "ssv":
+		sep = " "
+	case "tsv":
+		sep = "\t"
+	case "pipes":
+		sep = "|"
+	default:
+		return vs, fmt.Errorf("%s is not supported in the collection_format. (csv, ssv, pipes)", cfTag)
+	}
+
+	newVs = make([]string, 0)
+	for _, v := range vs {
+		newVs = append(newVs, strings.Split(v, sep)...)
+	}
+
+	return newVs, nil
+}
+
 func setByForm(value reflect.Value, field reflect.StructField, form map[string][]string, tagValue string, opt setOptions) (isSet bool, err error) {
 	vs, ok := form[tagValue]
 	if !ok && !opt.isDefaultExists {
@@ -198,6 +226,10 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 			return ok, err
 		}
 
+		if vs, err = trySplit(vs, field); err != nil {
+			return false, err
+		}
+
 		return true, setSlice(vs, value, field)
 	case reflect.Array:
 		if !ok {
@@ -206,6 +238,10 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 
 		if ok, err = trySetCustom(vs[0], value); ok {
 			return ok, err
+		}
+
+		if vs, err = trySplit(vs, field); err != nil {
+			return false, err
 		}
 
 		if len(vs) != value.Len() {

--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -202,7 +202,11 @@ func trySplit(vs []string, field reflect.StructField) (newVs []string, err error
 		return vs, fmt.Errorf("%s is not supported in the collection_format. (csv, ssv, pipes)", cfTag)
 	}
 
-	newVs = make([]string, 0)
+	totalLength := 0
+	for _, v := range vs {
+		totalLength += strings.Count(v, sep) + 1
+	}
+	newVs = make([]string, 0, totalLength)
 	for _, v := range vs {
 		newVs = append(newVs, strings.Split(v, sep)...)
 	}

--- a/binding/form_mapping_test.go
+++ b/binding/form_mapping_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMappingBaseTypes(t *testing.T) {
@@ -288,7 +289,7 @@ func TestMappingCollectionFormat(t *testing.T) {
 		"array_tsv":   {"1	2"},
 		"array_pipes": {"1|2"},
 	}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, []int{1, 2}, s.SliceMulti)
 	assert.Equal(t, []int{1, 2}, s.SliceCsv)

--- a/binding/form_mapping_test.go
+++ b/binding/form_mapping_test.go
@@ -263,6 +263,45 @@ func TestMappingArray(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestMappingCollectionFormat(t *testing.T) {
+	var s struct {
+		SliceMulti []int  `form:"slice_multi" collection_format:"multi"`
+		SliceCsv   []int  `form:"slice_csv" collection_format:"csv"`
+		SliceSsv   []int  `form:"slice_ssv" collection_format:"ssv"`
+		SliceTsv   []int  `form:"slice_tsv" collection_format:"tsv"`
+		SlicePipes []int  `form:"slice_pipes" collection_format:"pipes"`
+		ArrayMulti [2]int `form:"array_multi" collection_format:"multi"`
+		ArrayCsv   [2]int `form:"array_csv" collection_format:"csv"`
+		ArraySsv   [2]int `form:"array_ssv" collection_format:"ssv"`
+		ArrayTsv   [2]int `form:"array_tsv" collection_format:"tsv"`
+		ArrayPipes [2]int `form:"array_pipes" collection_format:"pipes"`
+	}
+	err := mappingByPtr(&s, formSource{
+		"slice_multi": {"1", "2"},
+		"slice_csv":   {"1,2"},
+		"slice_ssv":   {"1 2"},
+		"slice_tsv":   {"1	2"},
+		"slice_pipes": {"1|2"},
+		"array_multi": {"1", "2"},
+		"array_csv":   {"1,2"},
+		"array_ssv":   {"1 2"},
+		"array_tsv":   {"1	2"},
+		"array_pipes": {"1|2"},
+	}, "form")
+	assert.NoError(t, err)
+
+	assert.Equal(t, []int{1, 2}, s.SliceMulti)
+	assert.Equal(t, []int{1, 2}, s.SliceCsv)
+	assert.Equal(t, []int{1, 2}, s.SliceSsv)
+	assert.Equal(t, []int{1, 2}, s.SliceTsv)
+	assert.Equal(t, []int{1, 2}, s.SlicePipes)
+	assert.Equal(t, [2]int{1, 2}, s.ArrayMulti)
+	assert.Equal(t, [2]int{1, 2}, s.ArrayCsv)
+	assert.Equal(t, [2]int{1, 2}, s.ArraySsv)
+	assert.Equal(t, [2]int{1, 2}, s.ArrayTsv)
+	assert.Equal(t, [2]int{1, 2}, s.ArrayPipes)
+}
+
 func TestMappingStructField(t *testing.T) {
 	var s struct {
 		J struct {


### PR DESCRIPTION
Enables the possibility of collecting array data from queries or form data by specifying the collection_format tag in structs.

Several people are waiting for this feature to be updated.

cc @Simon-Saaw

Related PR: https://github.com/gin-gonic/gin/pull/2750
Close https://github.com/gin-gonic/gin/pull/2750