### PR TITLE
docs: fix typo in Gin Quick Start

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -524,7 +524,7 @@ func main() {
       return c.Writer.Status() < http.StatusInternalServerError
   }
   
-  engine.Use(gin.LoggerWithConfig(loggerConfig))
+  router.Use(gin.LoggerWithConfig(loggerConfig))
   router.Use(gin.Recovery())
   
   // skipped


### PR DESCRIPTION
Fixed a typo in "Gin Quick Start".