### PR TITLE
fix(gin): Do not panic when handling method not allowed on empty tree

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -687,7 +687,7 @@ func (engine *Engine) handleHTTPRequest(c *Context) {
 		break
 	}
 
-	if engine.HandleMethodNotAllowed {
+	if engine.HandleMethodNotAllowed && len(t) > 0 {
 		// According to RFC 7231 section 6.5.5, MUST generate an Allow header field in response
 		// containing a list of the target resource's currently supported methods.
 		allowed := make([]string, 0, len(t)-1)

--- a/gin_test.go
+++ b/gin_test.go
@@ -754,3 +754,14 @@ func TestCustomUnmarshalStruct(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, `"2000/01/01"`, w.Body.String())
 }
+
+// Test the fix for https://github.com/gin-gonic/gin/issues/4002
+func TestMethodNotAllowedNoRoute(t *testing.T) {
+	g := New()
+	g.HandleMethodNotAllowed = true
+
+	req := httptest.NewRequest("GET", "/", nil)
+	resp := httptest.NewRecorder()
+	assert.NotPanics(t, func() { g.ServeHTTP(resp, req) })
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}


### PR DESCRIPTION
Fix #4002 

