### PR TITLE
Do not QueryEscape cookies

### DIFF
--- a/context.go
+++ b/context.go
@@ -946,7 +946,7 @@ func (c *Context) SetCookie(name, value string, maxAge int, path, domain string,
 	}
 	http.SetCookie(c.Writer, &http.Cookie{
 		Name:     name,
-		Value:    url.QueryEscape(value),
+		Value:    value,
 		MaxAge:   maxAge,
 		Path:     path,
 		Domain:   domain,
@@ -965,8 +965,7 @@ func (c *Context) Cookie(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	val, _ := url.QueryUnescape(cookie.Value)
-	return val, nil
+	return cookie.Value, nil
 }
 
 // Render writes the response headers and calls render.Render to render data.

--- a/context_test.go
+++ b/context_test.go
@@ -685,6 +685,13 @@ func TestContextSetCookiePathEmpty(t *testing.T) {
 	assert.Equal(t, "user=gin; Path=/; Domain=localhost; Max-Age=1; HttpOnly; Secure; SameSite=Lax", c.Writer.Header().Get("Set-Cookie"))
 }
 
+func TestContextSetCookieWithSpace(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie("user", "gin test", 1, "/", "localhost", true, true)
+	assert.Equal(t, "user=\"gin test\"; Path=/; Domain=localhost; Max-Age=1; HttpOnly; Secure; SameSite=Lax", c.Writer.Header().Get("Set-Cookie"))
+}
+
 func TestContextGetCookie(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Request, _ = http.NewRequest("GET", "/get", nil)


### PR DESCRIPTION
Cookies values are already sanitized by the Go http library, so there is no need to invoke QueryEscape() on them.
The action of getting the value is similar.