### PR TITLE
fix(binding): form binding error on fields of type any

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -187,45 +187,34 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 	if !ok && !opt.isDefaultExists {
 		return false, nil
 	}
+	if !ok || (ok && len(vs) == 0) { // (ok && len(vs) == 0) should not happen, add for sense of security
+		vs = []string{opt.defaultValue}
+	}
+
+	if setCustomOk, setCustomErr := trySetCustom(vs[0], value); setCustomOk {
+		return true, setCustomErr
+	}
 
 	switch value.Kind() {
 	case reflect.Slice:
-		if !ok {
-			vs = []string{opt.defaultValue}
-		}
-
-		if ok, err = trySetCustom(vs[0], value); ok {
-			return ok, err
-		}
-
 		return true, setSlice(vs, value, field)
 	case reflect.Array:
-		if !ok {
-			vs = []string{opt.defaultValue}
-		}
-
-		if ok, err = trySetCustom(vs[0], value); ok {
-			return ok, err
-		}
-
 		if len(vs) != value.Len() {
 			return false, fmt.Errorf("%q is not valid value for %s", vs, value.Type().String())
 		}
-
 		return true, setArray(vs, value, field)
 	default:
-		var val string
-		if !ok {
-			val = opt.defaultValue
+		switch value.Kind() {
+		case reflect.Interface: // if field is any, we can set vs into it directly
+			if len(vs) == 1 {
+				value.Set(reflect.ValueOf(vs[0]))
+			} else {
+				value.Set(reflect.ValueOf(vs))
+			}
+			return true, nil
+		default:
+			return true, setWithProperType(vs[0], value, field)
 		}
-
-		if len(vs) > 0 {
-			val = vs[0]
-		}
-		if ok, err := trySetCustom(val, value); ok {
-			return ok, err
-		}
-		return true, setWithProperType(val, value, field)
 	}
 }
 
@@ -278,6 +267,9 @@ func setWithProperType(val string, value reflect.Value, field reflect.StructFiel
 			value.Set(reflect.New(value.Type().Elem()))
 		}
 		return setWithProperType(val, value.Elem(), field)
+	case reflect.Interface:
+		value.Set(reflect.ValueOf(val))
+		return nil
 	default:
 		return errUnknownType
 	}


### PR DESCRIPTION
when I want to bind query to `any`, I got a unknown type error. but it works in BindUri(/:name/:v for example) and BindJSON. 
it should be a bug. I fix it.
```go
package main

import (
	"fmt"
	"io"
	"net"
	"net/http"
	"os"
	"time"

	"github.com/gin-gonic/gin"
)

type Req struct {
	Name string `form:"name"`
	V    *any   `form:"v"`
}

func main() {
	// fix(binding): form binding error on fields of type `any`
	stop := newGin() // start server
	time.Sleep(time.Millisecond * 200)
	sendReq("/test?name=234")     // {"Name":"234","V":null}  ok
	sendReq("/test?name=234&v=1") // unknown type !!   want {"Name":"234","V":"1"}. **need fix**
	stop()
}

func newGin() (stopFunc func()) {
	gin.SetMode(gin.ReleaseMode)
	r := gin.New()
	r.GET("/test", func(c *gin.Context) {
		var req Req
		if err := c.ShouldBindQuery(&req); err != nil {
			http.Error(c.Writer, err.Error(), http.StatusBadRequest)
			return
		}
		c.JSON(200, req)
	})
	listen, err := net.Listen("tcp", ":8081")
	if err != nil {
		panic(err)
	}
	var ch = make(chan error, 1)
	go func() {
		ch <- r.RunListener(listen)
	}()
	return func() {
		listen.Close()
		<-ch
	}
}

func sendReq(url string) {
	fmt.Println("send request: ", "http://127.0.0.1:8081"+url)
	req, err := http.NewRequest("GET", "http://127.0.0.1:8081"+url, nil)
	if err != nil {
		fmt.Println(err)
		return
	}
	resp, err := http.DefaultClient.Do(req)
	if err != nil {
		fmt.Println(err)
		return
	}
	defer resp.Body.Close()
	os.Stdout.Write([]byte("resp:"))
	io.Copy(os.Stdout, resp.Body)
	os.Stdout.Write([]byte("\n"))
}

```
