### PR TITLE
ci(lint): enable testifylint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - nilerr
     - nolintlint
     - revive
+    - testifylint
     - wastedassign
 
 linters-settings:
@@ -33,6 +34,8 @@ linters-settings:
       - G112
       - G201
       - G203
+  testifylint:
+    enable-all: true
 
 issues:
   exclude-rules:

--- a/binding/binding_msgpack_test.go
+++ b/binding/binding_msgpack_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/ugorji/go/codec"
 )
 
@@ -24,7 +25,7 @@ func TestBindingMsgPack(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	assert.NotNil(t, buf)
 	err := codec.NewEncoder(buf, h).Encode(test)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	data := buf.Bytes()
 
@@ -41,14 +42,14 @@ func testMsgPackBodyBinding(t *testing.T, b Binding, name, path, badPath, body, 
 	req := requestWithBody("POST", path, body)
 	req.Header.Add("Content-Type", MIMEMSGPACK)
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "bar", obj.Foo)
 
 	obj = FooStruct{}
 	req = requestWithBody("POST", badPath, badBody)
 	req.Header.Add("Content-Type", MIMEMSGPACK)
 	err = MsgPack.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestBindingDefaultMsgPack(t *testing.T) {

--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gin-gonic/gin/testdata/protoexample"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -175,7 +176,7 @@ func TestBindingJSONNilBody(t *testing.T) {
 	var obj FooStruct
 	req, _ := http.NewRequest(http.MethodPost, "/", nil)
 	err := JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestBindingJSON(t *testing.T) {
@@ -376,7 +377,7 @@ func TestBindingFormStringSliceMap(t *testing.T) {
 	req := requestWithBody("POST", "/", "foo=something&foo=bar&hello=world")
 	req.Header.Add("Content-Type", MIMEPOSTForm)
 	err := Form.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, obj)
 	assert.Len(t, obj, 2)
 	target := map[string][]string{
@@ -389,7 +390,7 @@ func TestBindingFormStringSliceMap(t *testing.T) {
 	req = requestWithBody("POST", "/", "foo=something&foo=bar&hello=world")
 	req.Header.Add("Content-Type", MIMEPOSTForm)
 	err = Form.Bind(req, &objInvalid)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestBindingQuery(t *testing.T) {
@@ -428,7 +429,7 @@ func TestBindingQueryStringMap(t *testing.T) {
 	obj := make(map[string]string)
 	req := requestWithBody("GET", "/?foo=bar&hello=world", "")
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, obj)
 	assert.Len(t, obj, 2)
 	assert.Equal(t, "bar", obj["foo"])
@@ -437,7 +438,7 @@ func TestBindingQueryStringMap(t *testing.T) {
 	obj = make(map[string]string)
 	req = requestWithBody("GET", "/?foo=bar&foo=2&hello=world", "") // should pick last
 	err = b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, obj)
 	assert.Len(t, obj, 2)
 	assert.Equal(t, "2", obj["foo"])
@@ -495,28 +496,28 @@ func TestBindingYAMLFail(t *testing.T) {
 
 func createFormPostRequest(t *testing.T) *http.Request {
 	req, err := http.NewRequest("POST", "/?foo=getfoo&bar=getbar", bytes.NewBufferString("foo=bar&bar=foo"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEPOSTForm)
 	return req
 }
 
 func createDefaultFormPostRequest(t *testing.T) *http.Request {
 	req, err := http.NewRequest("POST", "/?foo=getfoo&bar=getbar", bytes.NewBufferString("foo=bar"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEPOSTForm)
 	return req
 }
 
 func createFormPostRequestForMap(t *testing.T) *http.Request {
 	req, err := http.NewRequest("POST", "/?map_foo=getfoo", bytes.NewBufferString("map_foo={\"bar\":123}"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEPOSTForm)
 	return req
 }
 
 func createFormPostRequestForMapFail(t *testing.T) *http.Request {
 	req, err := http.NewRequest("POST", "/?map_foo=getfoo", bytes.NewBufferString("map_foo=hello"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEPOSTForm)
 	return req
 }
@@ -527,20 +528,20 @@ func createFormFilesMultipartRequest(t *testing.T) *http.Request {
 	mw := multipart.NewWriter(body)
 	defer mw.Close()
 
-	assert.NoError(t, mw.SetBoundary(boundary))
-	assert.NoError(t, mw.WriteField("foo", "bar"))
-	assert.NoError(t, mw.WriteField("bar", "foo"))
+	require.NoError(t, mw.SetBoundary(boundary))
+	require.NoError(t, mw.WriteField("foo", "bar"))
+	require.NoError(t, mw.WriteField("bar", "foo"))
 
 	f, err := os.Open("form.go")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer f.Close()
 	fw, err1 := mw.CreateFormFile("file", "form.go")
-	assert.NoError(t, err1)
+	require.NoError(t, err1)
 	_, err = io.Copy(fw, f)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	req, err2 := http.NewRequest("POST", "/?foo=getfoo&bar=getbar", body)
-	assert.NoError(t, err2)
+	require.NoError(t, err2)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+boundary)
 
 	return req
@@ -552,20 +553,20 @@ func createFormFilesMultipartRequestFail(t *testing.T) *http.Request {
 	mw := multipart.NewWriter(body)
 	defer mw.Close()
 
-	assert.NoError(t, mw.SetBoundary(boundary))
-	assert.NoError(t, mw.WriteField("foo", "bar"))
-	assert.NoError(t, mw.WriteField("bar", "foo"))
+	require.NoError(t, mw.SetBoundary(boundary))
+	require.NoError(t, mw.WriteField("foo", "bar"))
+	require.NoError(t, mw.WriteField("bar", "foo"))
 
 	f, err := os.Open("form.go")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer f.Close()
 	fw, err1 := mw.CreateFormFile("file_foo", "form_foo.go")
-	assert.NoError(t, err1)
+	require.NoError(t, err1)
 	_, err = io.Copy(fw, f)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	req, err2 := http.NewRequest("POST", "/?foo=getfoo&bar=getbar", body)
-	assert.NoError(t, err2)
+	require.NoError(t, err2)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+boundary)
 
 	return req
@@ -577,11 +578,11 @@ func createFormMultipartRequest(t *testing.T) *http.Request {
 	mw := multipart.NewWriter(body)
 	defer mw.Close()
 
-	assert.NoError(t, mw.SetBoundary(boundary))
-	assert.NoError(t, mw.WriteField("foo", "bar"))
-	assert.NoError(t, mw.WriteField("bar", "foo"))
+	require.NoError(t, mw.SetBoundary(boundary))
+	require.NoError(t, mw.WriteField("foo", "bar"))
+	require.NoError(t, mw.WriteField("bar", "foo"))
 	req, err := http.NewRequest("POST", "/?foo=getfoo&bar=getbar", body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+boundary)
 	return req
 }
@@ -592,10 +593,10 @@ func createFormMultipartRequestForMap(t *testing.T) *http.Request {
 	mw := multipart.NewWriter(body)
 	defer mw.Close()
 
-	assert.NoError(t, mw.SetBoundary(boundary))
-	assert.NoError(t, mw.WriteField("map_foo", "{\"bar\":123, \"name\":\"thinkerou\", \"pai\": 3.14}"))
+	require.NoError(t, mw.SetBoundary(boundary))
+	require.NoError(t, mw.WriteField("map_foo", "{\"bar\":123, \"name\":\"thinkerou\", \"pai\": 3.14}"))
 	req, err := http.NewRequest("POST", "/?map_foo=getfoo", body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+boundary)
 	return req
 }
@@ -606,10 +607,10 @@ func createFormMultipartRequestForMapFail(t *testing.T) *http.Request {
 	mw := multipart.NewWriter(body)
 	defer mw.Close()
 
-	assert.NoError(t, mw.SetBoundary(boundary))
-	assert.NoError(t, mw.WriteField("map_foo", "3.14"))
+	require.NoError(t, mw.SetBoundary(boundary))
+	require.NoError(t, mw.WriteField("map_foo", "3.14"))
 	req, err := http.NewRequest("POST", "/?map_foo=getfoo", body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+boundary)
 	return req
 }
@@ -617,7 +618,7 @@ func createFormMultipartRequestForMapFail(t *testing.T) *http.Request {
 func TestBindingFormPost(t *testing.T) {
 	req := createFormPostRequest(t)
 	var obj FooBarStruct
-	assert.NoError(t, FormPost.Bind(req, &obj))
+	require.NoError(t, FormPost.Bind(req, &obj))
 
 	assert.Equal(t, "form-urlencoded", FormPost.Name())
 	assert.Equal(t, "bar", obj.Foo)
@@ -627,7 +628,7 @@ func TestBindingFormPost(t *testing.T) {
 func TestBindingDefaultValueFormPost(t *testing.T) {
 	req := createDefaultFormPostRequest(t)
 	var obj FooDefaultBarStruct
-	assert.NoError(t, FormPost.Bind(req, &obj))
+	require.NoError(t, FormPost.Bind(req, &obj))
 
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, "hello", obj.Bar)
@@ -637,22 +638,22 @@ func TestBindingFormPostForMap(t *testing.T) {
 	req := createFormPostRequestForMap(t)
 	var obj FooStructForMapType
 	err := FormPost.Bind(req, &obj)
-	assert.NoError(t, err)
-	assert.Equal(t, float64(123), obj.MapFoo["bar"].(float64))
+	require.NoError(t, err)
+	assert.InDelta(t, float64(123), obj.MapFoo["bar"].(float64), 0.01)
 }
 
 func TestBindingFormPostForMapFail(t *testing.T) {
 	req := createFormPostRequestForMapFail(t)
 	var obj FooStructForMapType
 	err := FormPost.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestBindingFormFilesMultipart(t *testing.T) {
 	req := createFormFilesMultipartRequest(t)
 	var obj FooBarFileStruct
 	err := FormMultipart.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// file from os
 	f, _ := os.Open("form.go")
@@ -664,9 +665,9 @@ func TestBindingFormFilesMultipart(t *testing.T) {
 	defer mf.Close()
 	fileExpect, _ := io.ReadAll(mf)
 
-	assert.Equal(t, FormMultipart.Name(), "multipart/form-data")
-	assert.Equal(t, obj.Foo, "bar")
-	assert.Equal(t, obj.Bar, "foo")
+	assert.Equal(t, "multipart/form-data", FormMultipart.Name())
+	assert.Equal(t, "bar", obj.Foo)
+	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, fileExpect, fileActual)
 }
 
@@ -674,13 +675,13 @@ func TestBindingFormFilesMultipartFail(t *testing.T) {
 	req := createFormFilesMultipartRequestFail(t)
 	var obj FooBarFileFailStruct
 	err := FormMultipart.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestBindingFormMultipart(t *testing.T) {
 	req := createFormMultipartRequest(t)
 	var obj FooBarStruct
-	assert.NoError(t, FormMultipart.Bind(req, &obj))
+	require.NoError(t, FormMultipart.Bind(req, &obj))
 
 	assert.Equal(t, "multipart/form-data", FormMultipart.Name())
 	assert.Equal(t, "bar", obj.Foo)
@@ -691,17 +692,17 @@ func TestBindingFormMultipartForMap(t *testing.T) {
 	req := createFormMultipartRequestForMap(t)
 	var obj FooStructForMapType
 	err := FormMultipart.Bind(req, &obj)
-	assert.NoError(t, err)
-	assert.Equal(t, float64(123), obj.MapFoo["bar"].(float64))
+	require.NoError(t, err)
+	assert.InDelta(t, float64(123), obj.MapFoo["bar"].(float64), 0.01)
 	assert.Equal(t, "thinkerou", obj.MapFoo["name"].(string))
-	assert.Equal(t, float64(3.14), obj.MapFoo["pai"].(float64))
+	assert.InDelta(t, float64(3.14), obj.MapFoo["pai"].(float64), 0.01)
 }
 
 func TestBindingFormMultipartForMapFail(t *testing.T) {
 	req := createFormMultipartRequestForMapFail(t)
 	var obj FooStructForMapType
 	err := FormMultipart.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestBindingProtoBuf(t *testing.T) {
@@ -732,7 +733,7 @@ func TestValidationFails(t *testing.T) {
 	var obj FooStruct
 	req := requestWithBody("POST", "/", `{"bar": "foo"}`)
 	err := JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestValidationDisabled(t *testing.T) {
@@ -743,7 +744,7 @@ func TestValidationDisabled(t *testing.T) {
 	var obj FooStruct
 	req := requestWithBody("POST", "/", `{"bar": "foo"}`)
 	err := JSON.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestRequiredSucceeds(t *testing.T) {
@@ -754,7 +755,7 @@ func TestRequiredSucceeds(t *testing.T) {
 	var obj HogeStruct
 	req := requestWithBody("POST", "/", `{"hoge": 0}`)
 	err := JSON.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestRequiredFails(t *testing.T) {
@@ -765,7 +766,7 @@ func TestRequiredFails(t *testing.T) {
 	var obj HogeStruct
 	req := requestWithBody("POST", "/", `{"boen": 0}`)
 	err := JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestHeaderBinding(t *testing.T) {
@@ -779,7 +780,7 @@ func TestHeaderBinding(t *testing.T) {
 	var theader tHeader
 	req := requestWithBody("GET", "/", "")
 	req.Header.Add("limit", "1000")
-	assert.NoError(t, h.Bind(req, &theader))
+	require.NoError(t, h.Bind(req, &theader))
 	assert.Equal(t, 1000, theader.Limit)
 
 	req = requestWithBody("GET", "/", "")
@@ -790,7 +791,7 @@ func TestHeaderBinding(t *testing.T) {
 	}
 
 	err := h.Bind(req, &failStruct{})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestUriBinding(t *testing.T) {
@@ -803,14 +804,14 @@ func TestUriBinding(t *testing.T) {
 	var tag Tag
 	m := make(map[string][]string)
 	m["name"] = []string{"thinkerou"}
-	assert.NoError(t, b.BindUri(m, &tag))
+	require.NoError(t, b.BindUri(m, &tag))
 	assert.Equal(t, "thinkerou", tag.Name)
 
 	type NotSupportStruct struct {
 		Name map[string]any `uri:"name"`
 	}
 	var not NotSupportStruct
-	assert.Error(t, b.BindUri(m, &not))
+	require.Error(t, b.BindUri(m, &not))
 	assert.Equal(t, map[string]any(nil), not.Name)
 }
 
@@ -831,9 +832,9 @@ func TestUriInnerBinding(t *testing.T) {
 	}
 
 	var tag Tag
-	assert.NoError(t, Uri.BindUri(m, &tag))
-	assert.Equal(t, tag.Name, expectedName)
-	assert.Equal(t, tag.S.Age, expectedAge)
+	require.NoError(t, Uri.BindUri(m, &tag))
+	assert.Equal(t, expectedName, tag.Name)
+	assert.Equal(t, expectedAge, tag.S.Age)
 }
 
 func testFormBindingEmbeddedStruct(t *testing.T, method, path, badPath, body, badBody string) {
@@ -846,7 +847,7 @@ func testFormBindingEmbeddedStruct(t *testing.T, method, path, badPath, body, ba
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, obj.Page)
 	assert.Equal(t, 2, obj.Size)
 	assert.Equal(t, "test-appkey", obj.Appkey)
@@ -862,14 +863,14 @@ func testFormBinding(t *testing.T, method, path, badPath, body, badBody string) 
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, "foo", obj.Bar)
 
 	obj = FooBarStruct{}
 	req = requestWithBody(method, badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testFormBindingDefaultValue(t *testing.T, method, path, badPath, body, badBody string) {
@@ -882,14 +883,14 @@ func testFormBindingDefaultValue(t *testing.T, method, path, badPath, body, badB
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, "hello", obj.Bar)
 
 	obj = FooDefaultBarStruct{}
 	req = requestWithBody(method, badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestFormBindingFail(t *testing.T) {
@@ -899,18 +900,18 @@ func TestFormBindingFail(t *testing.T) {
 	obj := FooBarStruct{}
 	req, _ := http.NewRequest("POST", "/", nil)
 	err := b.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestFormBindingMultipartFail(t *testing.T) {
 	obj := FooBarStruct{}
 	req, err := http.NewRequest("POST", "/", strings.NewReader("foo=bar"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+";boundary=testboundary")
 	_, err = req.MultipartReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = Form.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestFormPostBindingFail(t *testing.T) {
@@ -920,7 +921,7 @@ func TestFormPostBindingFail(t *testing.T) {
 	obj := FooBarStruct{}
 	req, _ := http.NewRequest("POST", "/", nil)
 	err := b.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestFormMultipartBindingFail(t *testing.T) {
@@ -930,7 +931,7 @@ func TestFormMultipartBindingFail(t *testing.T) {
 	obj := FooBarStruct{}
 	req, _ := http.NewRequest("POST", "/", nil)
 	err := b.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testFormBindingForTime(t *testing.T, method, path, badPath, body, badBody string) {
@@ -944,7 +945,7 @@ func testFormBindingForTime(t *testing.T, method, path, badPath, body, badBody s
 	}
 	err := b.Bind(req, &obj)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(1510675200), obj.TimeFoo.Unix())
 	assert.Equal(t, "Asia/Chongqing", obj.TimeFoo.Location().String())
 	assert.Equal(t, int64(-62135596800), obj.TimeBar.Unix())
@@ -955,7 +956,7 @@ func testFormBindingForTime(t *testing.T, method, path, badPath, body, badBody s
 	obj = FooBarStructForTimeType{}
 	req = requestWithBody(method, badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testFormBindingForTimeNotUnixFormat(t *testing.T, method, path, badPath, body, badBody string) {
@@ -968,12 +969,12 @@ func testFormBindingForTimeNotUnixFormat(t *testing.T, method, path, badPath, bo
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	obj = FooStructForTimeTypeNotUnixFormat{}
 	req = requestWithBody(method, badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testFormBindingForTimeNotFormat(t *testing.T, method, path, badPath, body, badBody string) {
@@ -986,12 +987,12 @@ func testFormBindingForTimeNotFormat(t *testing.T, method, path, badPath, body, 
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	obj = FooStructForTimeTypeNotFormat{}
 	req = requestWithBody(method, badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testFormBindingForTimeFailFormat(t *testing.T, method, path, badPath, body, badBody string) {
@@ -1004,12 +1005,12 @@ func testFormBindingForTimeFailFormat(t *testing.T, method, path, badPath, body,
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	obj = FooStructForTimeTypeFailFormat{}
 	req = requestWithBody(method, badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testFormBindingForTimeFailLocation(t *testing.T, method, path, badPath, body, badBody string) {
@@ -1022,12 +1023,12 @@ func testFormBindingForTimeFailLocation(t *testing.T, method, path, badPath, bod
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	obj = FooStructForTimeTypeFailLocation{}
 	req = requestWithBody(method, badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testFormBindingIgnoreField(t *testing.T, method, path, badPath, body, badBody string) {
@@ -1040,7 +1041,7 @@ func testFormBindingIgnoreField(t *testing.T, method, path, badPath, body, badBo
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Nil(t, obj.Foo)
 }
@@ -1055,13 +1056,13 @@ func testFormBindingInvalidName(t *testing.T, method, path, badPath, body, badBo
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "", obj.TestName)
 
 	obj = InvalidNameType{}
 	req = requestWithBody(method, badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testFormBindingInvalidName2(t *testing.T, method, path, badPath, body, badBody string) {
@@ -1074,12 +1075,12 @@ func testFormBindingInvalidName2(t *testing.T, method, path, badPath, body, badB
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	obj = InvalidNameMapType{}
 	req = requestWithBody(method, badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testFormBindingForType(t *testing.T, method, path, badPath, body, badBody string, typ string) {
@@ -1094,17 +1095,17 @@ func testFormBindingForType(t *testing.T, method, path, badPath, body, badBody s
 	case "Slice":
 		obj := FooStructForSliceType{}
 		err := b.Bind(req, &obj)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, []int{1, 2}, obj.SliceFoo)
 
 		obj = FooStructForSliceType{}
 		req = requestWithBody(method, badPath, badBody)
 		err = JSON.Bind(req, &obj)
-		assert.Error(t, err)
+		require.Error(t, err)
 	case "Struct":
 		obj := FooStructForStructType{}
 		err := b.Bind(req, &obj)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t,
 			struct {
 				Idx int "form:\"idx\""
@@ -1113,7 +1114,7 @@ func testFormBindingForType(t *testing.T, method, path, badPath, body, badBody s
 	case "StructPointer":
 		obj := FooStructForStructPointerType{}
 		err := b.Bind(req, &obj)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t,
 			struct {
 				Name string "form:\"name\""
@@ -1122,33 +1123,33 @@ func testFormBindingForType(t *testing.T, method, path, badPath, body, badBody s
 	case "Map":
 		obj := FooStructForMapType{}
 		err := b.Bind(req, &obj)
-		assert.NoError(t, err)
-		assert.Equal(t, float64(123), obj.MapFoo["bar"].(float64))
+		require.NoError(t, err)
+		assert.InDelta(t, float64(123), obj.MapFoo["bar"].(float64), 0.01)
 	case "SliceMap":
 		obj := FooStructForSliceMapType{}
 		err := b.Bind(req, &obj)
-		assert.Error(t, err)
+		require.Error(t, err)
 	case "Ptr":
 		obj := FooStructForStringPtrType{}
 		err := b.Bind(req, &obj)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Nil(t, obj.PtrFoo)
 		assert.Equal(t, "test", *obj.PtrBar)
 
 		obj = FooStructForStringPtrType{}
 		obj.PtrBar = new(string)
 		err = b.Bind(req, &obj)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "test", *obj.PtrBar)
 
 		objErr := FooStructForMapPtrType{}
 		err = b.Bind(req, &objErr)
-		assert.Error(t, err)
+		require.Error(t, err)
 
 		obj = FooStructForStringPtrType{}
 		req = requestWithBody(method, badPath, badBody)
 		err = b.Bind(req, &obj)
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 }
 
@@ -1162,7 +1163,7 @@ func testQueryBinding(t *testing.T, method, path, badPath, body, badBody string)
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, "foo", obj.Bar)
 }
@@ -1177,7 +1178,7 @@ func testQueryBindingFail(t *testing.T, method, path, badPath, body, badBody str
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testQueryBindingBoolFail(t *testing.T, method, path, badPath, body, badBody string) {
@@ -1190,7 +1191,7 @@ func testQueryBindingBoolFail(t *testing.T, method, path, badPath, body, badBody
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testBodyBinding(t *testing.T, b Binding, name, path, badPath, body, badBody string) {
@@ -1199,13 +1200,13 @@ func testBodyBinding(t *testing.T, b Binding, name, path, badPath, body, badBody
 	obj := FooStruct{}
 	req := requestWithBody("POST", path, body)
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "bar", obj.Foo)
 
 	obj = FooStruct{}
 	req = requestWithBody("POST", badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testBodyBindingSlice(t *testing.T, b Binding, name, path, badPath, body, badBody string) {
@@ -1214,12 +1215,12 @@ func testBodyBindingSlice(t *testing.T, b Binding, name, path, badPath, body, ba
 	var obj1 []FooStruct
 	req := requestWithBody("POST", path, body)
 	err := b.Bind(req, &obj1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var obj2 []FooStruct
 	req = requestWithBody("POST", badPath, badBody)
 	err = JSON.Bind(req, &obj2)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testBodyBindingStringMap(t *testing.T, b Binding, path, badPath, body, badBody string) {
@@ -1229,7 +1230,7 @@ func testBodyBindingStringMap(t *testing.T, b Binding, path, badPath, body, badB
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, obj)
 	assert.Len(t, obj, 2)
 	assert.Equal(t, "bar", obj["foo"])
@@ -1239,13 +1240,13 @@ func testBodyBindingStringMap(t *testing.T, b Binding, path, badPath, body, badB
 		obj = make(map[string]string)
 		req = requestWithBody("POST", badPath, badBody)
 		err = b.Bind(req, &obj)
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 
 	objInt := make(map[string]int)
 	req = requestWithBody("POST", path, body)
 	err = b.Bind(req, &objInt)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testBodyBindingUseNumber(t *testing.T, b Binding, name, path, badPath, body, badBody string) {
@@ -1255,16 +1256,16 @@ func testBodyBindingUseNumber(t *testing.T, b Binding, name, path, badPath, body
 	req := requestWithBody("POST", path, body)
 	EnableDecoderUseNumber = true
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// we hope it is int64(123)
 	v, e := obj.Foo.(json.Number).Int64()
-	assert.NoError(t, e)
+	require.NoError(t, e)
 	assert.Equal(t, int64(123), v)
 
 	obj = FooStructUseNumber{}
 	req = requestWithBody("POST", badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testBodyBindingUseNumber2(t *testing.T, b Binding, name, path, badPath, body, badBody string) {
@@ -1274,15 +1275,15 @@ func testBodyBindingUseNumber2(t *testing.T, b Binding, name, path, badPath, bod
 	req := requestWithBody("POST", path, body)
 	EnableDecoderUseNumber = false
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// it will return float64(123) if not use EnableDecoderUseNumber
 	// maybe it is not hoped
-	assert.Equal(t, float64(123), obj.Foo)
+	assert.InDelta(t, float64(123), obj.Foo, 0.01)
 
 	obj = FooStructUseNumber{}
 	req = requestWithBody("POST", badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testBodyBindingDisallowUnknownFields(t *testing.T, b Binding, path, badPath, body, badBody string) {
@@ -1294,13 +1295,13 @@ func testBodyBindingDisallowUnknownFields(t *testing.T, b Binding, path, badPath
 	obj := FooStructDisallowUnknownFields{}
 	req := requestWithBody("POST", path, body)
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "bar", obj.Foo)
 
 	obj = FooStructDisallowUnknownFields{}
 	req = requestWithBody("POST", badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "what")
 }
 
@@ -1310,13 +1311,13 @@ func testBodyBindingFail(t *testing.T, b Binding, name, path, badPath, body, bad
 	obj := FooStruct{}
 	req := requestWithBody("POST", path, body)
 	err := b.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "", obj.Foo)
 
 	obj = FooStruct{}
 	req = requestWithBody("POST", badPath, badBody)
 	err = JSON.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testProtoBodyBinding(t *testing.T, b Binding, name, path, badPath, body, badBody string) {
@@ -1326,14 +1327,14 @@ func testProtoBodyBinding(t *testing.T, b Binding, name, path, badPath, body, ba
 	req := requestWithBody("POST", path, body)
 	req.Header.Add("Content-Type", MIMEPROTOBUF)
 	err := b.Bind(req, &obj)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "yes", *obj.Label)
 
 	obj = protoexample.Test{}
 	req = requestWithBody("POST", badPath, badBody)
 	req.Header.Add("Content-Type", MIMEPROTOBUF)
 	err = ProtoBuf.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 type hook struct{}
@@ -1358,28 +1359,28 @@ func TestPlainBinding(t *testing.T) {
 
 	var s string
 	req := requestWithBody("POST", "/", "test string")
-	assert.NoError(t, p.Bind(req, &s))
-	assert.Equal(t, s, "test string")
+	require.NoError(t, p.Bind(req, &s))
+	assert.Equal(t, "test string", s)
 
 	var bs []byte
 	req = requestWithBody("POST", "/", "test []byte")
-	assert.NoError(t, p.Bind(req, &bs))
+	require.NoError(t, p.Bind(req, &bs))
 	assert.Equal(t, bs, []byte("test []byte"))
 
 	var i int
 	req = requestWithBody("POST", "/", "test fail")
-	assert.Error(t, p.Bind(req, &i))
+	require.Error(t, p.Bind(req, &i))
 
 	req = requestWithBody("POST", "/", "")
 	req.Body = &failRead{}
-	assert.Error(t, p.Bind(req, &s))
+	require.Error(t, p.Bind(req, &s))
 
 	req = requestWithBody("POST", "/", "")
-	assert.Nil(t, p.Bind(req, nil))
+	require.NoError(t, p.Bind(req, nil))
 
 	var ptr *string
 	req = requestWithBody("POST", "/", "")
-	assert.Nil(t, p.Bind(req, ptr))
+	require.NoError(t, p.Bind(req, ptr))
 }
 
 func testProtoBodyBindingFail(t *testing.T, b Binding, name, path, badPath, body, badBody string) {
@@ -1391,20 +1392,20 @@ func testProtoBodyBindingFail(t *testing.T, b Binding, name, path, badPath, body
 	req.Body = io.NopCloser(&hook{})
 	req.Header.Add("Content-Type", MIMEPROTOBUF)
 	err := b.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	invalidobj := FooStruct{}
 	req.Body = io.NopCloser(strings.NewReader(`{"msg":"hello"}`))
 	req.Header.Add("Content-Type", MIMEPROTOBUF)
 	err = b.Bind(req, &invalidobj)
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "obj is not ProtoMessage")
+	require.Error(t, err)
+	assert.Equal(t, "obj is not ProtoMessage", err.Error())
 
 	obj = protoexample.Test{}
 	req = requestWithBody("POST", badPath, badBody)
 	req.Header.Add("Content-Type", MIMEPROTOBUF)
 	err = ProtoBuf.Bind(req, &obj)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func requestWithBody(method, path, body string) (req *http.Request) {

--- a/binding/form_mapping_test.go
+++ b/binding/form_mapping_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMappingBaseTypes(t *testing.T) {
@@ -59,7 +60,7 @@ func TestMappingBaseTypes(t *testing.T) {
 		field := val.Elem().Type().Field(0)
 
 		_, err := mapping(val, emptyField, formSource{field.Name: {tt.form}}, "form")
-		assert.NoError(t, err, testName)
+		require.NoError(t, err, testName)
 
 		actual := val.Elem().Field(0).Interface()
 		assert.Equal(t, tt.expect, actual, testName)
@@ -73,7 +74,7 @@ func TestMappingDefault(t *testing.T) {
 		Array [1]int `form:",default=9"`
 	}
 	err := mappingByPtr(&s, formSource{}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 9, s.Int)
 	assert.Equal(t, []int{9}, s.Slice)
@@ -85,7 +86,7 @@ func TestMappingSkipField(t *testing.T) {
 		A int
 	}
 	err := mappingByPtr(&s, formSource{}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 0, s.A)
 }
@@ -96,7 +97,7 @@ func TestMappingIgnoreField(t *testing.T) {
 		B int `form:"-"`
 	}
 	err := mappingByPtr(&s, formSource{"A": {"9"}, "B": {"9"}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 9, s.A)
 	assert.Equal(t, 0, s.B)
@@ -108,7 +109,7 @@ func TestMappingUnexportedField(t *testing.T) {
 		b int `form:"b"`
 	}
 	err := mappingByPtr(&s, formSource{"a": {"9"}, "b": {"9"}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 9, s.A)
 	assert.Equal(t, 0, s.b)
@@ -119,7 +120,7 @@ func TestMappingPrivateField(t *testing.T) {
 		f int `form:"field"`
 	}
 	err := mappingByPtr(&s, formSource{"field": {"6"}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 0, s.f)
 }
 
@@ -129,7 +130,7 @@ func TestMappingUnknownFieldType(t *testing.T) {
 	}
 
 	err := mappingByPtr(&s, formSource{"U": {"unknown"}}, "form")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, errUnknownType, err)
 }
 
@@ -138,7 +139,7 @@ func TestMappingURI(t *testing.T) {
 		F int `uri:"field"`
 	}
 	err := mapURI(&s, map[string][]string{"field": {"6"}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 6, s.F)
 }
 
@@ -147,7 +148,7 @@ func TestMappingForm(t *testing.T) {
 		F int `form:"field"`
 	}
 	err := mapForm(&s, map[string][]string{"field": {"6"}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 6, s.F)
 }
 
@@ -156,7 +157,7 @@ func TestMapFormWithTag(t *testing.T) {
 		F int `externalTag:"field"`
 	}
 	err := MapFormWithTag(&s, map[string][]string{"field": {"6"}}, "externalTag")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 6, s.F)
 }
 
@@ -171,7 +172,7 @@ func TestMappingTime(t *testing.T) {
 
 	var err error
 	time.Local, err = time.LoadLocation("Europe/Berlin")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = mapForm(&s, map[string][]string{
 		"Time":      {"2019-01-20T16:02:58Z"},
@@ -180,7 +181,7 @@ func TestMappingTime(t *testing.T) {
 		"CSTTime":   {"2019-01-20"},
 		"UTCTime":   {"2019-01-20"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "2019-01-20 16:02:58 +0000 UTC", s.Time.String())
 	assert.Equal(t, "2019-01-20 00:00:00 +0100 CET", s.LocalTime.String())
@@ -195,14 +196,14 @@ func TestMappingTime(t *testing.T) {
 		Time time.Time `time_location:"wrong"`
 	}
 	err = mapForm(&wrongLoc, map[string][]string{"Time": {"2019-01-20T16:02:58Z"}})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// wrong time value
 	var wrongTime struct {
 		Time time.Time
 	}
 	err = mapForm(&wrongTime, map[string][]string{"Time": {"wrong"}})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestMappingTimeDuration(t *testing.T) {
@@ -212,12 +213,12 @@ func TestMappingTimeDuration(t *testing.T) {
 
 	// ok
 	err := mappingByPtr(&s, formSource{"D": {"5s"}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 5*time.Second, s.D)
 
 	// error
 	err = mappingByPtr(&s, formSource{"D": {"wrong"}}, "form")
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestMappingSlice(t *testing.T) {
@@ -227,17 +228,17 @@ func TestMappingSlice(t *testing.T) {
 
 	// default value
 	err := mappingByPtr(&s, formSource{}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []int{9}, s.Slice)
 
 	// ok
 	err = mappingByPtr(&s, formSource{"slice": {"3", "4"}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []int{3, 4}, s.Slice)
 
 	// error
 	err = mappingByPtr(&s, formSource{"slice": {"wrong"}}, "form")
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestMappingArray(t *testing.T) {
@@ -247,20 +248,20 @@ func TestMappingArray(t *testing.T) {
 
 	// wrong default
 	err := mappingByPtr(&s, formSource{}, "form")
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// ok
 	err = mappingByPtr(&s, formSource{"array": {"3", "4"}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, [2]int{3, 4}, s.Array)
 
 	// error - not enough vals
 	err = mappingByPtr(&s, formSource{"array": {"3"}}, "form")
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// error - wrong value
 	err = mappingByPtr(&s, formSource{"array": {"wrong"}}, "form")
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestMappingStructField(t *testing.T) {
@@ -271,7 +272,7 @@ func TestMappingStructField(t *testing.T) {
 	}
 
 	err := mappingByPtr(&s, formSource{"J": {`{"I": 9}`}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 9, s.J.I)
 }
 
@@ -289,20 +290,20 @@ func TestMappingPtrField(t *testing.T) {
 	// With 0 items.
 	var req0 ptrRequest
 	err = mappingByPtr(&req0, formSource{}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, req0.Items)
 
 	// With 1 item.
 	var req1 ptrRequest
 	err = mappingByPtr(&req1, formSource{"items": {`{"key": 1}`}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, req1.Items, 1)
 	assert.EqualValues(t, 1, req1.Items[0].Key)
 
 	// With 2 items.
 	var req2 ptrRequest
 	err = mappingByPtr(&req2, formSource{"items": {`{"key": 1}`, `{"key": 2}`}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, req2.Items, 2)
 	assert.EqualValues(t, 1, req2.Items[0].Key)
 	assert.EqualValues(t, 2, req2.Items[1].Key)
@@ -314,7 +315,7 @@ func TestMappingMapField(t *testing.T) {
 	}
 
 	err := mappingByPtr(&s, formSource{"M": {`{"one": 1}`}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]int{"one": 1}, s.M)
 }
 
@@ -325,7 +326,7 @@ func TestMappingIgnoredCircularRef(t *testing.T) {
 	var s S
 
 	err := mappingByPtr(&s, formSource{}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 type customUnmarshalParamHex int
@@ -344,7 +345,7 @@ func TestMappingCustomUnmarshalParamHexWithFormTag(t *testing.T) {
 		Foo customUnmarshalParamHex `form:"foo"`
 	}
 	err := mappingByPtr(&s, formSource{"foo": {`f5`}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, 245, s.Foo)
 }
@@ -354,7 +355,7 @@ func TestMappingCustomUnmarshalParamHexWithURITag(t *testing.T) {
 		Foo customUnmarshalParamHex `uri:"foo"`
 	}
 	err := mappingByPtr(&s, formSource{"foo": {`f5`}}, "uri")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, 245, s.Foo)
 }
@@ -381,7 +382,7 @@ func TestMappingCustomStructTypeWithFormTag(t *testing.T) {
 		FileData customUnmarshalParamType `form:"data"`
 	}
 	err := mappingByPtr(&s, formSource{"data": {`file:/foo:happiness`}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, "file", s.FileData.Protocol)
 	assert.EqualValues(t, "/foo", s.FileData.Path)
@@ -393,7 +394,7 @@ func TestMappingCustomStructTypeWithURITag(t *testing.T) {
 		FileData customUnmarshalParamType `uri:"data"`
 	}
 	err := mappingByPtr(&s, formSource{"data": {`file:/foo:happiness`}}, "uri")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, "file", s.FileData.Protocol)
 	assert.EqualValues(t, "/foo", s.FileData.Path)
@@ -405,7 +406,7 @@ func TestMappingCustomPointerStructTypeWithFormTag(t *testing.T) {
 		FileData *customUnmarshalParamType `form:"data"`
 	}
 	err := mappingByPtr(&s, formSource{"data": {`file:/foo:happiness`}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, "file", s.FileData.Protocol)
 	assert.EqualValues(t, "/foo", s.FileData.Path)
@@ -417,7 +418,7 @@ func TestMappingCustomPointerStructTypeWithURITag(t *testing.T) {
 		FileData *customUnmarshalParamType `uri:"data"`
 	}
 	err := mappingByPtr(&s, formSource{"data": {`file:/foo:happiness`}}, "uri")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, "file", s.FileData.Protocol)
 	assert.EqualValues(t, "/foo", s.FileData.Path)
@@ -442,7 +443,7 @@ func TestMappingCustomSliceUri(t *testing.T) {
 		FileData customPath `uri:"path"`
 	}
 	err := mappingByPtr(&s, formSource{"path": {`bar/foo`}}, "uri")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, "bar", s.FileData[0])
 	assert.EqualValues(t, "foo", s.FileData[1])
@@ -453,7 +454,7 @@ func TestMappingCustomSliceForm(t *testing.T) {
 		FileData customPath `form:"path"`
 	}
 	err := mappingByPtr(&s, formSource{"path": {`bar/foo`}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, "bar", s.FileData[0])
 	assert.EqualValues(t, "foo", s.FileData[1])
@@ -492,7 +493,7 @@ func TestMappingCustomArrayUri(t *testing.T) {
 	}
 	val := `664a062ac74a8ad104e0e80f`
 	err := mappingByPtr(&s, formSource{"id": {val}}, "uri")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected, _ := convertTo(val)
 	assert.EqualValues(t, expected, s.FileData)
@@ -504,7 +505,7 @@ func TestMappingCustomArrayForm(t *testing.T) {
 	}
 	val := `664a062ac74a8ad104e0e80f`
 	err := mappingByPtr(&s, formSource{"id": {val}}, "form")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected, _ := convertTo(val)
 	assert.EqualValues(t, expected, s.FileData)

--- a/binding/multipart_form_mapping_test.go
+++ b/binding/multipart_form_mapping_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormMultipartBindingBindOneFile(t *testing.T) {
@@ -27,7 +28,7 @@ func TestFormMultipartBindingBindOneFile(t *testing.T) {
 
 	req := createRequestMultipartFiles(t, file)
 	err := FormMultipart.Bind(req, &s)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assertMultipartFileHeader(t, &s.FileValue, file)
 	assertMultipartFileHeader(t, s.FilePtr, file)
@@ -53,7 +54,7 @@ func TestFormMultipartBindingBindTwoFiles(t *testing.T) {
 
 	req := createRequestMultipartFiles(t, files...)
 	err := FormMultipart.Bind(req, &s)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, s.SliceValues, len(files))
 	assert.Len(t, s.SlicePtrs, len(files))
@@ -90,7 +91,7 @@ func TestFormMultipartBindingBindError(t *testing.T) {
 	} {
 		req := createRequestMultipartFiles(t, files...)
 		err := FormMultipart.Bind(req, tt.s)
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 }
 
@@ -106,17 +107,17 @@ func createRequestMultipartFiles(t *testing.T, files ...testFile) *http.Request 
 	mw := multipart.NewWriter(&body)
 	for _, file := range files {
 		fw, err := mw.CreateFormFile(file.Fieldname, file.Filename)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		n, err := fw.Write(file.Content)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, len(file.Content), n)
 	}
 	err := mw.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest("POST", "/", &body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+mw.Boundary())
 	return req
@@ -127,12 +128,12 @@ func assertMultipartFileHeader(t *testing.T, fh *multipart.FileHeader, file test
 	assert.Equal(t, int64(len(file.Content)), fh.Size)
 
 	fl, err := fh.Open()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	body, err := io.ReadAll(fl)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, string(file.Content), string(body))
 
 	err = fl.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/binding/validate_test.go
+++ b/binding/validate_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testInterface interface {
@@ -113,10 +114,10 @@ func TestValidateNoValidationValues(t *testing.T) {
 	test := createNoValidationValues()
 	empty := structNoValidationValues{}
 
-	assert.Nil(t, validate(test))
-	assert.Nil(t, validate(&test))
-	assert.Nil(t, validate(empty))
-	assert.Nil(t, validate(&empty))
+	require.NoError(t, validate(test))
+	require.NoError(t, validate(&test))
+	require.NoError(t, validate(empty))
+	require.NoError(t, validate(&empty))
 
 	assert.Equal(t, origin, test)
 }
@@ -163,8 +164,8 @@ func TestValidateNoValidationPointers(t *testing.T) {
 
 	//assert.Nil(t, validate(test))
 	//assert.Nil(t, validate(&test))
-	assert.Nil(t, validate(empty))
-	assert.Nil(t, validate(&empty))
+	require.NoError(t, validate(empty))
+	require.NoError(t, validate(&empty))
 
 	//assert.Equal(t, origin, test)
 }
@@ -173,22 +174,22 @@ type Object map[string]any
 
 func TestValidatePrimitives(t *testing.T) {
 	obj := Object{"foo": "bar", "bar": 1}
-	assert.NoError(t, validate(obj))
-	assert.NoError(t, validate(&obj))
+	require.NoError(t, validate(obj))
+	require.NoError(t, validate(&obj))
 	assert.Equal(t, Object{"foo": "bar", "bar": 1}, obj)
 
 	obj2 := []Object{{"foo": "bar", "bar": 1}, {"foo": "bar", "bar": 1}}
-	assert.NoError(t, validate(obj2))
-	assert.NoError(t, validate(&obj2))
+	require.NoError(t, validate(obj2))
+	require.NoError(t, validate(&obj2))
 
 	nu := 10
-	assert.NoError(t, validate(nu))
-	assert.NoError(t, validate(&nu))
+	require.NoError(t, validate(nu))
+	require.NoError(t, validate(&nu))
 	assert.Equal(t, 10, nu)
 
 	str := "value"
-	assert.NoError(t, validate(str))
-	assert.NoError(t, validate(&str))
+	require.NoError(t, validate(str))
+	require.NoError(t, validate(&str))
 	assert.Equal(t, "value", str)
 }
 
@@ -212,8 +213,8 @@ func TestValidateAndModifyStruct(t *testing.T) {
 	s := structModifyValidation{Integer: 1}
 	errs := validate(&s)
 
-	assert.Nil(t, errs)
-	assert.Equal(t, s, structModifyValidation{Integer: 0})
+	require.NoError(t, errs)
+	assert.Equal(t, structModifyValidation{Integer: 0}, s)
 }
 
 // structCustomValidation is a helper struct we use to check that
@@ -239,14 +240,14 @@ func TestValidatorEngine(t *testing.T) {
 
 	err := engine.RegisterValidation("notone", notOne)
 	// Check that we can register custom validation without error
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Create an instance which will fail validation
 	withOne := structCustomValidation{Integer: 1}
 	errs := validate(withOne)
 
 	// Check that we got back non-nil errs
-	assert.NotNil(t, errs)
+	require.Error(t, errs)
 	// Check that the error matches expectation
-	assert.Error(t, errs, "", "", "notone")
+	require.Error(t, errs, "", "", "notone")
 }

--- a/context_test.go
+++ b/context_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gin-gonic/gin/binding"
 	testdata "github.com/gin-gonic/gin/testdata/protoexample"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -74,20 +75,18 @@ func TestContextFormFile(t *testing.T) {
 	buf := new(bytes.Buffer)
 	mw := multipart.NewWriter(buf)
 	w, err := mw.CreateFormFile("file", "test")
-	if assert.NoError(t, err) {
-		_, err = w.Write([]byte("test"))
-		assert.NoError(t, err)
-	}
+	require.NoError(t, err)
+	_, err = w.Write([]byte("test"))
+	require.NoError(t, err)
 	mw.Close()
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Request, _ = http.NewRequest("POST", "/", buf)
 	c.Request.Header.Set("Content-Type", mw.FormDataContentType())
 	f, err := c.FormFile("file")
-	if assert.NoError(t, err) {
-		assert.Equal(t, "test", f.Filename)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "test", f.Filename)
 
-	assert.NoError(t, c.SaveUploadedFile(f, "test"))
+	require.NoError(t, c.SaveUploadedFile(f, "test"))
 }
 
 func TestContextFormFileFailed(t *testing.T) {
@@ -99,29 +98,27 @@ func TestContextFormFileFailed(t *testing.T) {
 	c.Request.Header.Set("Content-Type", mw.FormDataContentType())
 	c.engine.MaxMultipartMemory = 8 << 20
 	f, err := c.FormFile("file")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, f)
 }
 
 func TestContextMultipartForm(t *testing.T) {
 	buf := new(bytes.Buffer)
 	mw := multipart.NewWriter(buf)
-	assert.NoError(t, mw.WriteField("foo", "bar"))
+	require.NoError(t, mw.WriteField("foo", "bar"))
 	w, err := mw.CreateFormFile("file", "test")
-	if assert.NoError(t, err) {
-		_, err = w.Write([]byte("test"))
-		assert.NoError(t, err)
-	}
+	require.NoError(t, err)
+	_, err = w.Write([]byte("test"))
+	require.NoError(t, err)
 	mw.Close()
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Request, _ = http.NewRequest("POST", "/", buf)
 	c.Request.Header.Set("Content-Type", mw.FormDataContentType())
 	f, err := c.MultipartForm()
-	if assert.NoError(t, err) {
-		assert.NotNil(t, f)
-	}
+	require.NoError(t, err)
+	assert.NotNil(t, f)
 
-	assert.NoError(t, c.SaveUploadedFile(f.File["file"][0], "test"))
+	require.NoError(t, c.SaveUploadedFile(f.File["file"][0], "test"))
 }
 
 func TestSaveUploadedOpenFailed(t *testing.T) {
@@ -136,27 +133,25 @@ func TestSaveUploadedOpenFailed(t *testing.T) {
 	f := &multipart.FileHeader{
 		Filename: "file",
 	}
-	assert.Error(t, c.SaveUploadedFile(f, "test"))
+	require.Error(t, c.SaveUploadedFile(f, "test"))
 }
 
 func TestSaveUploadedCreateFailed(t *testing.T) {
 	buf := new(bytes.Buffer)
 	mw := multipart.NewWriter(buf)
 	w, err := mw.CreateFormFile("file", "test")
-	if assert.NoError(t, err) {
-		_, err = w.Write([]byte("test"))
-		assert.NoError(t, err)
-	}
+	require.NoError(t, err)
+	_, err = w.Write([]byte("test"))
+	require.NoError(t, err)
 	mw.Close()
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Request, _ = http.NewRequest("POST", "/", buf)
 	c.Request.Header.Set("Content-Type", mw.FormDataContentType())
 	f, err := c.FormFile("file")
-	if assert.NoError(t, err) {
-		assert.Equal(t, "test", f.Filename)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "test", f.Filename)
 
-	assert.Error(t, c.SaveUploadedFile(f, "/"))
+	require.Error(t, c.SaveUploadedFile(f, "/"))
 }
 
 func TestContextReset(t *testing.T) {
@@ -174,10 +169,10 @@ func TestContextReset(t *testing.T) {
 	assert.False(t, c.IsAborted())
 	assert.Nil(t, c.Keys)
 	assert.Nil(t, c.Accepted)
-	assert.Len(t, c.Errors, 0)
+	assert.Empty(t, c.Errors)
 	assert.Empty(t, c.Errors.Errors())
 	assert.Empty(t, c.Errors.ByType(ErrorTypeAny))
-	assert.Len(t, c.Params, 0)
+	assert.Empty(t, c.Params)
 	assert.EqualValues(t, c.index, -1)
 	assert.Equal(t, c.Writer.(*responseWriter), &c.writermem)
 }
@@ -230,13 +225,13 @@ func TestContextSetGetValues(t *testing.T) {
 	var a any = 1
 	c.Set("intInterface", a)
 
-	assert.Exactly(t, c.MustGet("string").(string), "this is a string")
+	assert.Exactly(t, "this is a string", c.MustGet("string").(string))
 	assert.Exactly(t, c.MustGet("int32").(int32), int32(-42))
-	assert.Exactly(t, c.MustGet("int64").(int64), int64(42424242424242))
-	assert.Exactly(t, c.MustGet("uint64").(uint64), uint64(42))
-	assert.Exactly(t, c.MustGet("float32").(float32), float32(4.2))
-	assert.Exactly(t, c.MustGet("float64").(float64), 4.2)
-	assert.Exactly(t, c.MustGet("intInterface").(int), 1)
+	assert.Exactly(t, int64(42424242424242), c.MustGet("int64").(int64))
+	assert.Exactly(t, uint64(42), c.MustGet("uint64").(uint64))
+	assert.InDelta(t, float32(4.2), c.MustGet("float32").(float32), 0.01)
+	assert.InDelta(t, 4.2, c.MustGet("float64").(float64), 0.01)
+	assert.Exactly(t, 1, c.MustGet("intInterface").(int))
 }
 
 func TestContextGetString(t *testing.T) {
@@ -278,7 +273,7 @@ func TestContextGetUint64(t *testing.T) {
 func TestContextGetFloat64(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Set("float64", 4.2)
-	assert.Equal(t, 4.2, c.GetFloat64("float64"))
+	assert.InDelta(t, 4.2, c.GetFloat64("float64"), 0.01)
 }
 
 func TestContextGetTime(t *testing.T) {
@@ -344,12 +339,12 @@ func TestContextCopy(t *testing.T) {
 	assert.Nil(t, cp.writermem.ResponseWriter)
 	assert.Equal(t, &cp.writermem, cp.Writer.(*responseWriter))
 	assert.Equal(t, cp.Request, c.Request)
-	assert.Equal(t, cp.index, abortIndex)
+	assert.Equal(t, abortIndex, cp.index)
 	assert.Equal(t, cp.Keys, c.Keys)
 	assert.Equal(t, cp.engine, c.engine)
 	assert.Equal(t, cp.Params, c.Params)
 	cp.Set("foo", "notBar")
-	assert.False(t, cp.Keys["foo"] == c.Keys["foo"])
+	assert.NotEqual(t, cp.Keys["foo"], c.Keys["foo"])
 	assert.Equal(t, cp.fullPath, c.fullPath)
 }
 
@@ -366,7 +361,7 @@ func TestContextHandlerNames(t *testing.T) {
 
 	names := c.HandlerNames()
 
-	assert.True(t, len(names) == 4)
+	assert.Len(t, names, 4)
 	for _, name := range names {
 		assert.Regexp(t, `^(.*/vendor/)?(github\.com/gin-gonic/gin\.){1}(TestContextHandlerNames\.func.*){0,1}(handlerNameTest.*){0,1}`, name)
 	}
@@ -425,7 +420,7 @@ func TestContextQuery(t *testing.T) {
 
 func TestContextInitQueryCache(t *testing.T) {
 	validURL, err := url.Parse("https://github.com/gin-gonic/gin/pull/3969?key=value&otherkey=othervalue")
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	tests := []struct {
 		testName           string
@@ -531,7 +526,7 @@ func TestContextQueryAndPostForm(t *testing.T) {
 		Both  string   `form:"both"`
 		Array []string `form:"array[]"`
 	}
-	assert.NoError(t, c.Bind(&obj))
+	require.NoError(t, c.Bind(&obj))
 	assert.Equal(t, "bar", obj.Foo, "bar")
 	assert.Equal(t, "main", obj.ID, "main")
 	assert.Equal(t, 11, obj.Page, 11)
@@ -548,10 +543,10 @@ func TestContextQueryAndPostForm(t *testing.T) {
 	assert.Equal(t, "second", values[1])
 
 	values = c.QueryArray("nokey")
-	assert.Equal(t, 0, len(values))
+	assert.Empty(t, values)
 
 	values = c.QueryArray("both")
-	assert.Equal(t, 1, len(values))
+	assert.Len(t, values, 1)
 	assert.Equal(t, "GET", values[0])
 
 	dicts, ok := c.GetQueryMap("ids")
@@ -561,22 +556,22 @@ func TestContextQueryAndPostForm(t *testing.T) {
 
 	dicts, ok = c.GetQueryMap("nokey")
 	assert.False(t, ok)
-	assert.Equal(t, 0, len(dicts))
+	assert.Empty(t, dicts)
 
 	dicts, ok = c.GetQueryMap("both")
 	assert.False(t, ok)
-	assert.Equal(t, 0, len(dicts))
+	assert.Empty(t, dicts)
 
 	dicts, ok = c.GetQueryMap("array")
 	assert.False(t, ok)
-	assert.Equal(t, 0, len(dicts))
+	assert.Empty(t, dicts)
 
 	dicts = c.QueryMap("ids")
 	assert.Equal(t, "hi", dicts["a"])
 	assert.Equal(t, "3.14", dicts["b"])
 
 	dicts = c.QueryMap("nokey")
-	assert.Equal(t, 0, len(dicts))
+	assert.Empty(t, dicts)
 }
 
 func TestContextPostFormMultipart(t *testing.T) {
@@ -594,7 +589,7 @@ func TestContextPostFormMultipart(t *testing.T) {
 		TimeLocation time.Time `form:"time_location" time_format:"02/01/2006 15:04" time_location:"Asia/Tokyo"`
 		BlankTime    time.Time `form:"blank_time" time_format:"02/01/2006 15:04"`
 	}
-	assert.NoError(t, c.Bind(&obj))
+	require.NoError(t, c.Bind(&obj))
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, "10", obj.Bar)
 	assert.Equal(t, 10, obj.BarAsInt)
@@ -648,10 +643,10 @@ func TestContextPostFormMultipart(t *testing.T) {
 	assert.Equal(t, "second", values[1])
 
 	values = c.PostFormArray("nokey")
-	assert.Equal(t, 0, len(values))
+	assert.Empty(t, values)
 
 	values = c.PostFormArray("foo")
-	assert.Equal(t, 1, len(values))
+	assert.Len(t, values, 1)
 	assert.Equal(t, "bar", values[0])
 
 	dicts, ok := c.GetPostFormMap("names")
@@ -661,14 +656,14 @@ func TestContextPostFormMultipart(t *testing.T) {
 
 	dicts, ok = c.GetPostFormMap("nokey")
 	assert.False(t, ok)
-	assert.Equal(t, 0, len(dicts))
+	assert.Empty(t, dicts)
 
 	dicts = c.PostFormMap("names")
 	assert.Equal(t, "thinkerou", dicts["a"])
 	assert.Equal(t, "tianou", dicts["b"])
 
 	dicts = c.PostFormMap("nokey")
-	assert.Equal(t, 0, len(dicts))
+	assert.Empty(t, dicts)
 }
 
 func TestContextSetCookie(t *testing.T) {
@@ -693,7 +688,7 @@ func TestContextGetCookie(t *testing.T) {
 	assert.Equal(t, "gin", cookie)
 
 	_, err := c.Cookie("nokey")
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestContextBodyAllowedForStatus(t *testing.T) {
@@ -798,7 +793,7 @@ func TestContextRenderNoContentAPIJSON(t *testing.T) {
 
 	assert.Equal(t, http.StatusNoContent, w.Code)
 	assert.Empty(t, w.Body.String())
-	assert.Equal(t, w.Header().Get("Content-Type"), "application/vnd.api+json")
+	assert.Equal(t, "application/vnd.api+json", w.Header().Get("Content-Type"))
 }
 
 // Tests that the response is serialized as JSON
@@ -1160,7 +1155,7 @@ func TestContextRenderProtoBuf(t *testing.T) {
 	c.ProtoBuf(http.StatusCreated, data)
 
 	protoData, err := proto.Marshal(data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusCreated, w.Code)
 	assert.Equal(t, string(protoData), w.Body.String())
@@ -1321,7 +1316,7 @@ func TestContextNegotiationNotSupport(t *testing.T) {
 	})
 
 	assert.Equal(t, http.StatusNotAcceptable, w.Code)
-	assert.Equal(t, c.index, abortIndex)
+	assert.Equal(t, abortIndex, c.index)
 	assert.True(t, c.IsAborted())
 }
 
@@ -1349,23 +1344,23 @@ func TestContextNegotiationFormatWithWildcardAccept(t *testing.T) {
 	c.Request, _ = http.NewRequest("POST", "/", nil)
 	c.Request.Header.Add("Accept", "*/*")
 
-	assert.Equal(t, c.NegotiateFormat("*/*"), "*/*")
-	assert.Equal(t, c.NegotiateFormat("text/*"), "text/*")
-	assert.Equal(t, c.NegotiateFormat("application/*"), "application/*")
-	assert.Equal(t, c.NegotiateFormat(MIMEJSON), MIMEJSON)
-	assert.Equal(t, c.NegotiateFormat(MIMEXML), MIMEXML)
-	assert.Equal(t, c.NegotiateFormat(MIMEHTML), MIMEHTML)
+	assert.Equal(t, "*/*", c.NegotiateFormat("*/*"))
+	assert.Equal(t, "text/*", c.NegotiateFormat("text/*"))
+	assert.Equal(t, "application/*", c.NegotiateFormat("application/*"))
+	assert.Equal(t, MIMEJSON, c.NegotiateFormat(MIMEJSON))
+	assert.Equal(t, MIMEXML, c.NegotiateFormat(MIMEXML))
+	assert.Equal(t, MIMEHTML, c.NegotiateFormat(MIMEHTML))
 
 	c, _ = CreateTestContext(httptest.NewRecorder())
 	c.Request, _ = http.NewRequest("POST", "/", nil)
 	c.Request.Header.Add("Accept", "text/*")
 
-	assert.Equal(t, c.NegotiateFormat("*/*"), "*/*")
-	assert.Equal(t, c.NegotiateFormat("text/*"), "text/*")
-	assert.Equal(t, c.NegotiateFormat("application/*"), "")
-	assert.Equal(t, c.NegotiateFormat(MIMEJSON), "")
-	assert.Equal(t, c.NegotiateFormat(MIMEXML), "")
-	assert.Equal(t, c.NegotiateFormat(MIMEHTML), MIMEHTML)
+	assert.Equal(t, "*/*", c.NegotiateFormat("*/*"))
+	assert.Equal(t, "text/*", c.NegotiateFormat("text/*"))
+	assert.Equal(t, "", c.NegotiateFormat("application/*"))
+	assert.Equal(t, "", c.NegotiateFormat(MIMEJSON))
+	assert.Equal(t, "", c.NegotiateFormat(MIMEXML))
+	assert.Equal(t, MIMEHTML, c.NegotiateFormat(MIMEHTML))
 }
 
 func TestContextNegotiationFormatCustom(t *testing.T) {
@@ -1444,7 +1439,7 @@ func TestContextAbortWithStatusJSON(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	_, err := buf.ReadFrom(w.Body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	jsonStringBody := buf.String()
 	assert.Equal(t, "{\"foo\":\"fooValue\",\"bar\":\"barValue\"}", jsonStringBody)
 }
@@ -1669,7 +1664,7 @@ func TestContextAutoBindJSON(t *testing.T) {
 		Foo string `json:"foo"`
 		Bar string `json:"bar"`
 	}
-	assert.NoError(t, c.Bind(&obj))
+	require.NoError(t, c.Bind(&obj))
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Empty(t, c.Errors)
@@ -1686,7 +1681,7 @@ func TestContextBindWithJSON(t *testing.T) {
 		Foo string `json:"foo"`
 		Bar string `json:"bar"`
 	}
-	assert.NoError(t, c.BindJSON(&obj))
+	require.NoError(t, c.BindJSON(&obj))
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, 0, w.Body.Len())
@@ -1707,7 +1702,7 @@ func TestContextBindWithXML(t *testing.T) {
 		Foo string `xml:"foo"`
 		Bar string `xml:"bar"`
 	}
-	assert.NoError(t, c.BindXML(&obj))
+	require.NoError(t, c.BindXML(&obj))
 	assert.Equal(t, "FOO", obj.Foo)
 	assert.Equal(t, "BAR", obj.Bar)
 	assert.Equal(t, 0, w.Body.Len())
@@ -1722,7 +1717,7 @@ func TestContextBindPlain(t *testing.T) {
 
 	var s string
 
-	assert.NoError(t, c.BindPlain(&s))
+	require.NoError(t, c.BindPlain(&s))
 	assert.Equal(t, "test string", s)
 	assert.Equal(t, 0, w.Body.Len())
 
@@ -1732,7 +1727,7 @@ func TestContextBindPlain(t *testing.T) {
 
 	var bs []byte
 
-	assert.NoError(t, c.BindPlain(&bs))
+	require.NoError(t, c.BindPlain(&bs))
 	assert.Equal(t, []byte("test []byte"), bs)
 	assert.Equal(t, 0, w.Body.Len())
 }
@@ -1752,7 +1747,7 @@ func TestContextBindHeader(t *testing.T) {
 		Limit  int    `header:"limit"`
 	}
 
-	assert.NoError(t, c.BindHeader(&testHeader))
+	require.NoError(t, c.BindHeader(&testHeader))
 	assert.Equal(t, 8000, testHeader.Rate)
 	assert.Equal(t, "music", testHeader.Domain)
 	assert.Equal(t, 1000, testHeader.Limit)
@@ -1769,7 +1764,7 @@ func TestContextBindWithQuery(t *testing.T) {
 		Foo string `form:"foo"`
 		Bar string `form:"bar"`
 	}
-	assert.NoError(t, c.BindQuery(&obj))
+	require.NoError(t, c.BindQuery(&obj))
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, 0, w.Body.Len())
@@ -1786,7 +1781,7 @@ func TestContextBindWithYAML(t *testing.T) {
 		Foo string `yaml:"foo"`
 		Bar string `yaml:"bar"`
 	}
-	assert.NoError(t, c.BindYAML(&obj))
+	require.NoError(t, c.BindYAML(&obj))
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, 0, w.Body.Len())
@@ -1803,7 +1798,7 @@ func TestContextBindWithTOML(t *testing.T) {
 		Foo string `toml:"foo"`
 		Bar string `toml:"bar"`
 	}
-	assert.NoError(t, c.BindTOML(&obj))
+	require.NoError(t, c.BindTOML(&obj))
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, 0, w.Body.Len())
@@ -1821,7 +1816,7 @@ func TestContextBadAutoBind(t *testing.T) {
 	}
 
 	assert.False(t, c.IsAborted())
-	assert.Error(t, c.Bind(&obj))
+	require.Error(t, c.Bind(&obj))
 	c.Writer.WriteHeaderNow()
 
 	assert.Empty(t, obj.Bar)
@@ -1839,7 +1834,7 @@ func TestContextAutoShouldBindJSON(t *testing.T) {
 		Foo string `json:"foo"`
 		Bar string `json:"bar"`
 	}
-	assert.NoError(t, c.ShouldBind(&obj))
+	require.NoError(t, c.ShouldBind(&obj))
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Empty(t, c.Errors)
@@ -1856,7 +1851,7 @@ func TestContextShouldBindWithJSON(t *testing.T) {
 		Foo string `json:"foo"`
 		Bar string `json:"bar"`
 	}
-	assert.NoError(t, c.ShouldBindJSON(&obj))
+	require.NoError(t, c.ShouldBindJSON(&obj))
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, 0, w.Body.Len())
@@ -1877,7 +1872,7 @@ func TestContextShouldBindWithXML(t *testing.T) {
 		Foo string `xml:"foo"`
 		Bar string `xml:"bar"`
 	}
-	assert.NoError(t, c.ShouldBindXML(&obj))
+	require.NoError(t, c.ShouldBindXML(&obj))
 	assert.Equal(t, "FOO", obj.Foo)
 	assert.Equal(t, "BAR", obj.Bar)
 	assert.Equal(t, 0, w.Body.Len())
@@ -1892,7 +1887,7 @@ func TestContextShouldBindPlain(t *testing.T) {
 
 	var s string
 
-	assert.NoError(t, c.ShouldBindPlain(&s))
+	require.NoError(t, c.ShouldBindPlain(&s))
 	assert.Equal(t, "test string", s)
 	assert.Equal(t, 0, w.Body.Len())
 	// []byte
@@ -1902,7 +1897,7 @@ func TestContextShouldBindPlain(t *testing.T) {
 
 	var bs []byte
 
-	assert.NoError(t, c.ShouldBindPlain(&bs))
+	require.NoError(t, c.ShouldBindPlain(&bs))
 	assert.Equal(t, []byte("test []byte"), bs)
 	assert.Equal(t, 0, w.Body.Len())
 }
@@ -1922,7 +1917,7 @@ func TestContextShouldBindHeader(t *testing.T) {
 		Limit  int    `header:"limit"`
 	}
 
-	assert.NoError(t, c.ShouldBindHeader(&testHeader))
+	require.NoError(t, c.ShouldBindHeader(&testHeader))
 	assert.Equal(t, 8000, testHeader.Rate)
 	assert.Equal(t, "music", testHeader.Domain)
 	assert.Equal(t, 1000, testHeader.Limit)
@@ -1941,7 +1936,7 @@ func TestContextShouldBindWithQuery(t *testing.T) {
 		Foo1 string `form:"Foo"`
 		Bar1 string `form:"Bar"`
 	}
-	assert.NoError(t, c.ShouldBindQuery(&obj))
+	require.NoError(t, c.ShouldBindQuery(&obj))
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, "foo1", obj.Bar1)
@@ -1960,7 +1955,7 @@ func TestContextShouldBindWithYAML(t *testing.T) {
 		Foo string `yaml:"foo"`
 		Bar string `yaml:"bar"`
 	}
-	assert.NoError(t, c.ShouldBindYAML(&obj))
+	require.NoError(t, c.ShouldBindYAML(&obj))
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, 0, w.Body.Len())
@@ -1977,7 +1972,7 @@ func TestContextShouldBindWithTOML(t *testing.T) {
 		Foo string `toml:"foo"`
 		Bar string `toml:"bar"`
 	}
-	assert.NoError(t, c.ShouldBindTOML(&obj))
+	require.NoError(t, c.ShouldBindTOML(&obj))
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, 0, w.Body.Len())
@@ -1995,7 +1990,7 @@ func TestContextBadAutoShouldBind(t *testing.T) {
 	}
 
 	assert.False(t, c.IsAborted())
-	assert.Error(t, c.ShouldBind(&obj))
+	require.Error(t, c.ShouldBind(&obj))
 
 	assert.Empty(t, obj.Bar)
 	assert.Empty(t, obj.Foo)
@@ -2056,10 +2051,10 @@ func TestContextShouldBindBodyWith(t *testing.T) {
 			// When it binds to typeA and typeB, it finds the body is
 			// not typeB but typeA.
 			objA := typeA{}
-			assert.NoError(t, c.ShouldBindBodyWith(&objA, tt.bindingA))
+			require.NoError(t, c.ShouldBindBodyWith(&objA, tt.bindingA))
 			assert.Equal(t, typeA{"FOO"}, objA)
 			objB := typeB{}
-			assert.Error(t, c.ShouldBindBodyWith(&objB, tt.bindingB))
+			require.Error(t, c.ShouldBindBodyWith(&objB, tt.bindingB))
 			assert.NotEqual(t, typeB{"BAR"}, objB)
 		}
 		// bodyB to typeA and typeB
@@ -2072,10 +2067,10 @@ func TestContextShouldBindBodyWith(t *testing.T) {
 				"POST", "http://example.com", bytes.NewBufferString(tt.bodyB),
 			)
 			objA := typeA{}
-			assert.Error(t, c.ShouldBindBodyWith(&objA, tt.bindingA))
+			require.Error(t, c.ShouldBindBodyWith(&objA, tt.bindingA))
 			assert.NotEqual(t, typeA{"FOO"}, objA)
 			objB := typeB{}
-			assert.NoError(t, c.ShouldBindBodyWith(&objB, tt.bindingB))
+			require.NoError(t, c.ShouldBindBodyWith(&objB, tt.bindingB))
 			assert.Equal(t, typeB{"BAR"}, objB)
 		}
 	}
@@ -2124,22 +2119,22 @@ func TestContextShouldBindBodyWithJSON(t *testing.T) {
 		objJSON := typeJSON{}
 
 		if tt.bindingBody == binding.JSON {
-			assert.NoError(t, c.ShouldBindBodyWithJSON(&objJSON))
+			require.NoError(t, c.ShouldBindBodyWithJSON(&objJSON))
 			assert.Equal(t, typeJSON{"FOO"}, objJSON)
 		}
 
 		if tt.bindingBody == binding.XML {
-			assert.Error(t, c.ShouldBindBodyWithJSON(&objJSON))
+			require.Error(t, c.ShouldBindBodyWithJSON(&objJSON))
 			assert.Equal(t, typeJSON{}, objJSON)
 		}
 
 		if tt.bindingBody == binding.YAML {
-			assert.Error(t, c.ShouldBindBodyWithJSON(&objJSON))
+			require.Error(t, c.ShouldBindBodyWithJSON(&objJSON))
 			assert.Equal(t, typeJSON{}, objJSON)
 		}
 
 		if tt.bindingBody == binding.TOML {
-			assert.Error(t, c.ShouldBindBodyWithJSON(&objJSON))
+			require.Error(t, c.ShouldBindBodyWithJSON(&objJSON))
 			assert.Equal(t, typeJSON{}, objJSON)
 		}
 	}
@@ -2188,22 +2183,22 @@ func TestContextShouldBindBodyWithXML(t *testing.T) {
 		objXML := typeXML{}
 
 		if tt.bindingBody == binding.JSON {
-			assert.Error(t, c.ShouldBindBodyWithXML(&objXML))
+			require.Error(t, c.ShouldBindBodyWithXML(&objXML))
 			assert.Equal(t, typeXML{}, objXML)
 		}
 
 		if tt.bindingBody == binding.XML {
-			assert.NoError(t, c.ShouldBindBodyWithXML(&objXML))
+			require.NoError(t, c.ShouldBindBodyWithXML(&objXML))
 			assert.Equal(t, typeXML{"FOO"}, objXML)
 		}
 
 		if tt.bindingBody == binding.YAML {
-			assert.Error(t, c.ShouldBindBodyWithXML(&objXML))
+			require.Error(t, c.ShouldBindBodyWithXML(&objXML))
 			assert.Equal(t, typeXML{}, objXML)
 		}
 
 		if tt.bindingBody == binding.TOML {
-			assert.Error(t, c.ShouldBindBodyWithXML(&objXML))
+			require.Error(t, c.ShouldBindBodyWithXML(&objXML))
 			assert.Equal(t, typeXML{}, objXML)
 		}
 	}
@@ -2253,22 +2248,22 @@ func TestContextShouldBindBodyWithYAML(t *testing.T) {
 
 		// YAML belongs to a super collection of JSON, so JSON can be parsed by YAML
 		if tt.bindingBody == binding.JSON {
-			assert.NoError(t, c.ShouldBindBodyWithYAML(&objYAML))
+			require.NoError(t, c.ShouldBindBodyWithYAML(&objYAML))
 			assert.Equal(t, typeYAML{"FOO"}, objYAML)
 		}
 
 		if tt.bindingBody == binding.XML {
-			assert.Error(t, c.ShouldBindBodyWithYAML(&objYAML))
+			require.Error(t, c.ShouldBindBodyWithYAML(&objYAML))
 			assert.Equal(t, typeYAML{}, objYAML)
 		}
 
 		if tt.bindingBody == binding.YAML {
-			assert.NoError(t, c.ShouldBindBodyWithYAML(&objYAML))
+			require.NoError(t, c.ShouldBindBodyWithYAML(&objYAML))
 			assert.Equal(t, typeYAML{"FOO"}, objYAML)
 		}
 
 		if tt.bindingBody == binding.TOML {
-			assert.Error(t, c.ShouldBindBodyWithYAML(&objYAML))
+			require.Error(t, c.ShouldBindBodyWithYAML(&objYAML))
 			assert.Equal(t, typeYAML{}, objYAML)
 		}
 	}
@@ -2317,22 +2312,22 @@ func TestContextShouldBindBodyWithTOML(t *testing.T) {
 		objTOML := typeTOML{}
 
 		if tt.bindingBody == binding.JSON {
-			assert.Error(t, c.ShouldBindBodyWithTOML(&objTOML))
+			require.Error(t, c.ShouldBindBodyWithTOML(&objTOML))
 			assert.Equal(t, typeTOML{}, objTOML)
 		}
 
 		if tt.bindingBody == binding.XML {
-			assert.Error(t, c.ShouldBindBodyWithTOML(&objTOML))
+			require.Error(t, c.ShouldBindBodyWithTOML(&objTOML))
 			assert.Equal(t, typeTOML{}, objTOML)
 		}
 
 		if tt.bindingBody == binding.YAML {
-			assert.Error(t, c.ShouldBindBodyWithTOML(&objTOML))
+			require.Error(t, c.ShouldBindBodyWithTOML(&objTOML))
 			assert.Equal(t, typeTOML{}, objTOML)
 		}
 
 		if tt.bindingBody == binding.TOML {
-			assert.NoError(t, c.ShouldBindBodyWithTOML(&objTOML))
+			require.NoError(t, c.ShouldBindBodyWithTOML(&objTOML))
 			assert.Equal(t, typeTOML{"FOO"}, objTOML)
 		}
 	}
@@ -2387,27 +2382,27 @@ func TestContextShouldBindBodyWithPlain(t *testing.T) {
 
 		if tt.bindingBody == binding.Plain {
 			body := ""
-			assert.NoError(t, c.ShouldBindBodyWithPlain(&body))
-			assert.Equal(t, body, "foo=FOO")
+			require.NoError(t, c.ShouldBindBodyWithPlain(&body))
+			assert.Equal(t, "foo=FOO", body)
 		}
 
 		if tt.bindingBody == binding.JSON {
-			assert.NoError(t, c.ShouldBindBodyWithJSON(&objJSON))
+			require.NoError(t, c.ShouldBindBodyWithJSON(&objJSON))
 			assert.Equal(t, typeJSON{"FOO"}, objJSON)
 		}
 
 		if tt.bindingBody == binding.XML {
-			assert.Error(t, c.ShouldBindBodyWithJSON(&objJSON))
+			require.Error(t, c.ShouldBindBodyWithJSON(&objJSON))
 			assert.Equal(t, typeJSON{}, objJSON)
 		}
 
 		if tt.bindingBody == binding.YAML {
-			assert.Error(t, c.ShouldBindBodyWithJSON(&objJSON))
+			require.Error(t, c.ShouldBindBodyWithJSON(&objJSON))
 			assert.Equal(t, typeJSON{}, objJSON)
 		}
 
 		if tt.bindingBody == binding.TOML {
-			assert.Error(t, c.ShouldBindBodyWithJSON(&objJSON))
+			require.Error(t, c.ShouldBindBodyWithJSON(&objJSON))
 			assert.Equal(t, typeJSON{}, objJSON)
 		}
 	}
@@ -2416,10 +2411,10 @@ func TestContextShouldBindBodyWithPlain(t *testing.T) {
 func TestContextGolangContext(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Request, _ = http.NewRequest("POST", "/", bytes.NewBufferString("{\"foo\":\"bar\", \"bar\":\"foo\"}"))
-	assert.NoError(t, c.Err())
+	require.NoError(t, c.Err())
 	assert.Nil(t, c.Done())
 	ti, ok := c.Deadline()
-	assert.Equal(t, ti, time.Time{})
+	assert.Equal(t, time.Time{}, ti)
 	assert.False(t, ok)
 	assert.Equal(t, c.Value(ContextRequestKey), c.Request)
 	assert.Equal(t, c.Value(ContextKey), c)
@@ -2468,7 +2463,7 @@ func TestContextGetRawData(t *testing.T) {
 	c.Request.Header.Add("Content-Type", MIMEPOSTForm)
 
 	data, err := c.GetRawData()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Fetch binary post data", string(data))
 }
 
@@ -2539,7 +2534,7 @@ func TestContextStream(t *testing.T) {
 		}()
 
 		_, err := w.Write([]byte("test"))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		return stopStream
 	})
@@ -2557,7 +2552,7 @@ func TestContextStreamWithClientGone(t *testing.T) {
 		}()
 
 		_, err := writer.Write([]byte("test"))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		return true
 	})
@@ -2685,7 +2680,7 @@ func TestContextWithFallbackErrFromRequestContext(t *testing.T) {
 	// enable ContextWithFallback feature flag
 	c.engine.ContextWithFallback = true
 
-	assert.Nil(t, c.Err())
+	require.NoError(t, c.Err())
 
 	c2, _ := CreateTestContext(httptest.NewRecorder())
 	// enable ContextWithFallback feature flag
@@ -2834,7 +2829,7 @@ func TestContextAddParam(t *testing.T) {
 	c.AddParam(id, value)
 
 	v, ok := c.Params.Get(id)
-	assert.Equal(t, ok, true)
+	assert.True(t, ok)
 	assert.Equal(t, value, v)
 }
 

--- a/debug_test.go
+++ b/debug_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TODO
@@ -154,13 +155,13 @@ func TestGetMinVer(t *testing.T) {
 	var m uint64
 	var e error
 	_, e = getMinVer("go1")
-	assert.NotNil(t, e)
+	require.Error(t, e)
 	m, e = getMinVer("go1.1")
 	assert.Equal(t, uint64(1), m)
-	assert.Nil(t, e)
+	require.NoError(t, e)
 	m, e = getMinVer("go1.1.1")
-	assert.Nil(t, e)
+	require.NoError(t, e)
 	assert.Equal(t, uint64(1), m)
 	_, e = getMinVer("go1.1.1.1")
-	assert.NotNil(t, e)
+	require.Error(t, e)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin/internal/json"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestError(t *testing.T) {
@@ -122,7 +123,7 @@ func TestErrorUnwrap(t *testing.T) {
 	})
 
 	// check that 'errors.Is()' and 'errors.As()' behave as expected :
-	assert.True(t, errors.Is(err, innerErr))
+	require.ErrorIs(t, err, innerErr)
 	var testErr TestErr
-	assert.True(t, errors.As(err, &testErr))
+	require.ErrorAs(t, err, &testErr)
 }

--- a/fs_test.go
+++ b/fs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockFileSystem struct {
@@ -28,7 +29,7 @@ func TestOnlyFilesFS_Open(t *testing.T) {
 
 	file, err := fs.Open("foo")
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, testFile, file.(neutralizedReaddirFile).File)
 }
 
@@ -43,7 +44,7 @@ func TestOnlyFilesFS_Open_err(t *testing.T) {
 
 	file, err := fs.Open("foo")
 
-	assert.ErrorIs(t, err, testError)
+	require.ErrorIs(t, err, testError)
 	assert.Nil(t, file)
 }
 
@@ -52,7 +53,7 @@ func Test_neuteredReaddirFile_Readdir(t *testing.T) {
 
 	res, err := n.Readdir(0)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, res)
 }
 

--- a/gin_integration_test.go
+++ b/gin_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // params[0]=url example:http://127.0.0.1:8080/index (cannot be empty)
@@ -40,11 +41,11 @@ func testRequest(t *testing.T, params ...string) {
 	client := &http.Client{Transport: tr}
 
 	resp, err := client.Get(params[0])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer resp.Body.Close()
 
 	body, ioerr := io.ReadAll(resp.Body)
-	assert.NoError(t, ioerr)
+	require.NoError(t, ioerr)
 
 	var responseStatus = "200 OK"
 	if len(params) > 1 && params[1] != "" {
@@ -73,13 +74,13 @@ func TestRunEmpty(t *testing.T) {
 	// otherwise the main thread will complete
 	time.Sleep(5 * time.Millisecond)
 
-	assert.Error(t, router.Run(":8080"))
+	require.Error(t, router.Run(":8080"))
 	testRequest(t, "http://localhost:8080/example")
 }
 
 func TestBadTrustedCIDRs(t *testing.T) {
 	router := New()
-	assert.Error(t, router.SetTrustedProxies([]string{"hello/world"}))
+	require.Error(t, router.SetTrustedProxies([]string{"hello/world"}))
 }
 
 /* legacy tests
@@ -87,7 +88,7 @@ func TestBadTrustedCIDRsForRun(t *testing.T) {
 	os.Setenv("PORT", "")
 	router := New()
 	router.TrustedProxies = []string{"hello/world"}
-	assert.Error(t, router.Run(":8080"))
+	require.Error(t, router.Run(":8080"))
 }
 
 func TestBadTrustedCIDRsForRunUnix(t *testing.T) {
@@ -100,7 +101,7 @@ func TestBadTrustedCIDRsForRunUnix(t *testing.T) {
 
 	go func() {
 		router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
-		assert.Error(t, router.RunUnix(unixTestSocket))
+		require.Error(t, router.RunUnix(unixTestSocket))
 	}()
 	// have to wait for the goroutine to start and run the server
 	// otherwise the main thread will complete
@@ -112,15 +113,15 @@ func TestBadTrustedCIDRsForRunFd(t *testing.T) {
 	router.TrustedProxies = []string{"hello/world"}
 
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	listener, err := net.ListenTCP("tcp", addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	socketFile, err := listener.File()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	go func() {
 		router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
-		assert.Error(t, router.RunFd(int(socketFile.Fd())))
+		require.Error(t, router.RunFd(int(socketFile.Fd())))
 	}()
 	// have to wait for the goroutine to start and run the server
 	// otherwise the main thread will complete
@@ -132,12 +133,12 @@ func TestBadTrustedCIDRsForRunListener(t *testing.T) {
 	router.TrustedProxies = []string{"hello/world"}
 
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	listener, err := net.ListenTCP("tcp", addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	go func() {
 		router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
-		assert.Error(t, router.RunListener(listener))
+		require.Error(t, router.RunListener(listener))
 	}()
 	// have to wait for the goroutine to start and run the server
 	// otherwise the main thread will complete
@@ -148,7 +149,7 @@ func TestBadTrustedCIDRsForRunTLS(t *testing.T) {
 	os.Setenv("PORT", "")
 	router := New()
 	router.TrustedProxies = []string{"hello/world"}
-	assert.Error(t, router.RunTLS(":8080", "./testdata/certificate/cert.pem", "./testdata/certificate/key.pem"))
+	require.Error(t, router.RunTLS(":8080", "./testdata/certificate/cert.pem", "./testdata/certificate/key.pem"))
 }
 */
 
@@ -164,7 +165,7 @@ func TestRunTLS(t *testing.T) {
 	// otherwise the main thread will complete
 	time.Sleep(5 * time.Millisecond)
 
-	assert.Error(t, router.RunTLS(":8443", "./testdata/certificate/cert.pem", "./testdata/certificate/key.pem"))
+	require.Error(t, router.RunTLS(":8443", "./testdata/certificate/cert.pem", "./testdata/certificate/key.pem"))
 	testRequest(t, "https://localhost:8443/example")
 }
 
@@ -201,7 +202,7 @@ func TestPusher(t *testing.T) {
 	// otherwise the main thread will complete
 	time.Sleep(5 * time.Millisecond)
 
-	assert.Error(t, router.RunTLS(":8449", "./testdata/certificate/cert.pem", "./testdata/certificate/key.pem"))
+	require.Error(t, router.RunTLS(":8449", "./testdata/certificate/cert.pem", "./testdata/certificate/key.pem"))
 	testRequest(t, "https://localhost:8449/pusher")
 }
 
@@ -216,14 +217,14 @@ func TestRunEmptyWithEnv(t *testing.T) {
 	// otherwise the main thread will complete
 	time.Sleep(5 * time.Millisecond)
 
-	assert.Error(t, router.Run(":3123"))
+	require.Error(t, router.Run(":3123"))
 	testRequest(t, "http://localhost:3123/example")
 }
 
 func TestRunTooMuchParams(t *testing.T) {
 	router := New()
 	assert.Panics(t, func() {
-		assert.NoError(t, router.Run("2", "2"))
+		require.NoError(t, router.Run("2", "2"))
 	})
 }
 
@@ -237,7 +238,7 @@ func TestRunWithPort(t *testing.T) {
 	// otherwise the main thread will complete
 	time.Sleep(5 * time.Millisecond)
 
-	assert.Error(t, router.Run(":5150"))
+	require.Error(t, router.Run(":5150"))
 	testRequest(t, "http://localhost:5150/example")
 }
 
@@ -257,7 +258,7 @@ func TestUnixSocket(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 
 	c, err := net.Dial("unix", unixTestSocket)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	fmt.Fprint(c, "GET /example HTTP/1.0\r\n\r\n")
 	scanner := bufio.NewScanner(c)
@@ -271,7 +272,7 @@ func TestUnixSocket(t *testing.T) {
 
 func TestBadUnixSocket(t *testing.T) {
 	router := New()
-	assert.Error(t, router.RunUnix("#/tmp/unix_unit_test"))
+	require.Error(t, router.RunUnix("#/tmp/unix_unit_test"))
 }
 
 func TestRunQUIC(t *testing.T) {
@@ -286,7 +287,7 @@ func TestRunQUIC(t *testing.T) {
 	// otherwise the main thread will complete
 	time.Sleep(5 * time.Millisecond)
 
-	assert.Error(t, router.RunQUIC(":8443", "./testdata/certificate/cert.pem", "./testdata/certificate/key.pem"))
+	require.Error(t, router.RunQUIC(":8443", "./testdata/certificate/cert.pem", "./testdata/certificate/key.pem"))
 	testRequest(t, "https://localhost:8443/example")
 }
 
@@ -294,15 +295,15 @@ func TestFileDescriptor(t *testing.T) {
 	router := New()
 
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	listener, err := net.ListenTCP("tcp", addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	socketFile, err := listener.File()
 	if isWindows() {
 		// not supported by windows, it is unimplemented now
-		assert.Error(t, err)
+		require.Error(t, err)
 	} else {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	if socketFile == nil {
@@ -318,7 +319,7 @@ func TestFileDescriptor(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 
 	c, err := net.Dial("tcp", listener.Addr().String())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	fmt.Fprintf(c, "GET /example HTTP/1.0\r\n\r\n")
 	scanner := bufio.NewScanner(c)
@@ -332,15 +333,15 @@ func TestFileDescriptor(t *testing.T) {
 
 func TestBadFileDescriptor(t *testing.T) {
 	router := New()
-	assert.Error(t, router.RunFd(0))
+	require.Error(t, router.RunFd(0))
 }
 
 func TestListener(t *testing.T) {
 	router := New()
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	listener, err := net.ListenTCP("tcp", addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	go func() {
 		router.GET("/example", func(c *Context) { c.String(http.StatusOK, "it worked") })
 		assert.NoError(t, router.RunListener(listener))
@@ -350,7 +351,7 @@ func TestListener(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 
 	c, err := net.Dial("tcp", listener.Addr().String())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	fmt.Fprintf(c, "GET /example HTTP/1.0\r\n\r\n")
 	scanner := bufio.NewScanner(c)
@@ -365,11 +366,11 @@ func TestListener(t *testing.T) {
 func TestBadListener(t *testing.T) {
 	router := New()
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:10086")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	listener, err := net.ListenTCP("tcp", addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	listener.Close()
-	assert.Error(t, router.RunListener(listener))
+	require.Error(t, router.RunListener(listener))
 }
 
 func TestWithHttptestWithAutoSelectedPort(t *testing.T) {
@@ -395,7 +396,14 @@ func TestConcurrentHandleContext(t *testing.T) {
 	wg.Add(iterations)
 	for i := 0; i < iterations; i++ {
 		go func() {
-			testGetRequestHandler(t, router, "/")
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			assert.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, "it worked", w.Body.String(), "resp body should match")
+			assert.Equal(t, 200, w.Code, "should get a 200")
 			wg.Done()
 		}()
 	}
@@ -416,17 +424,6 @@ func TestConcurrentHandleContext(t *testing.T) {
 
 // 	testRequest(t, "http://localhost:8033/example")
 // }
-
-func testGetRequestHandler(t *testing.T, h http.Handler, url string) {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	assert.NoError(t, err)
-
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-
-	assert.Equal(t, "it worked", w.Body.String(), "resp body should match")
-	assert.Equal(t, 200, w.Code, "should get a 200")
-}
 
 func TestTreeRunDynamicRouting(t *testing.T) {
 	router := New()

--- a/gin_test.go
+++ b/gin_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 )
 
@@ -547,10 +548,10 @@ func TestEngineHandleContextManyReEntries(t *testing.T) {
 	r.GET("/:count", func(c *Context) {
 		countStr := c.Param("count")
 		count, err := strconv.Atoi(countStr)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		n, err := c.Writer.Write([]byte("."))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 1, n)
 
 		switch {
@@ -580,7 +581,7 @@ func TestPrepareTrustedCIRDsWith(t *testing.T) {
 		expectedTrustedCIDRs := []*net.IPNet{parseCIDR("0.0.0.0/0")}
 		err := r.SetTrustedProxies([]string{"0.0.0.0/0"})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expectedTrustedCIDRs, r.trustedCIDRs)
 	}
 
@@ -588,7 +589,7 @@ func TestPrepareTrustedCIRDsWith(t *testing.T) {
 	{
 		err := r.SetTrustedProxies([]string{"192.168.1.33/33"})
 
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 
 	// valid ipv4 address
@@ -597,7 +598,7 @@ func TestPrepareTrustedCIRDsWith(t *testing.T) {
 
 		err := r.SetTrustedProxies([]string{"192.168.1.33"})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expectedTrustedCIDRs, r.trustedCIDRs)
 	}
 
@@ -605,7 +606,7 @@ func TestPrepareTrustedCIRDsWith(t *testing.T) {
 	{
 		err := r.SetTrustedProxies([]string{"192.168.1.256"})
 
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 
 	// valid ipv6 address
@@ -613,7 +614,7 @@ func TestPrepareTrustedCIRDsWith(t *testing.T) {
 		expectedTrustedCIDRs := []*net.IPNet{parseCIDR("2002:0000:0000:1234:abcd:ffff:c0a8:0101/128")}
 		err := r.SetTrustedProxies([]string{"2002:0000:0000:1234:abcd:ffff:c0a8:0101"})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expectedTrustedCIDRs, r.trustedCIDRs)
 	}
 
@@ -621,7 +622,7 @@ func TestPrepareTrustedCIRDsWith(t *testing.T) {
 	{
 		err := r.SetTrustedProxies([]string{"gggg:0000:0000:1234:abcd:ffff:c0a8:0101"})
 
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 
 	// valid ipv6 cidr
@@ -629,7 +630,7 @@ func TestPrepareTrustedCIRDsWith(t *testing.T) {
 		expectedTrustedCIDRs := []*net.IPNet{parseCIDR("::/0")}
 		err := r.SetTrustedProxies([]string{"::/0"})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expectedTrustedCIDRs, r.trustedCIDRs)
 	}
 
@@ -637,7 +638,7 @@ func TestPrepareTrustedCIRDsWith(t *testing.T) {
 	{
 		err := r.SetTrustedProxies([]string{"gggg:0000:0000:1234:abcd:ffff:c0a8:0101/129"})
 
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 
 	// valid combination
@@ -653,7 +654,7 @@ func TestPrepareTrustedCIRDsWith(t *testing.T) {
 			"172.16.0.1",
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expectedTrustedCIDRs, r.trustedCIDRs)
 	}
 
@@ -665,7 +666,7 @@ func TestPrepareTrustedCIRDsWith(t *testing.T) {
 			"172.16.0.256",
 		})
 
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 
 	// nil value
@@ -673,7 +674,7 @@ func TestPrepareTrustedCIRDsWith(t *testing.T) {
 		err := r.SetTrustedProxies(nil)
 
 		assert.Nil(t, r.trustedCIDRs)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	}
 }
 

--- a/githubapi_test.go
+++ b/githubapi_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type route struct {
@@ -295,9 +296,9 @@ func TestShouldBindUri(t *testing.T) {
 	}
 	router.Handle(http.MethodGet, "/rest/:name/:id", func(c *Context) {
 		var person Person
-		assert.NoError(t, c.ShouldBindUri(&person))
-		assert.True(t, person.Name != "")
-		assert.True(t, person.ID != "")
+		require.NoError(t, c.ShouldBindUri(&person))
+		assert.NotEqual(t, "", person.Name)
+		assert.NotEqual(t, "", person.ID)
 		c.String(http.StatusOK, "ShouldBindUri test OK")
 	})
 
@@ -317,9 +318,9 @@ func TestBindUri(t *testing.T) {
 	}
 	router.Handle(http.MethodGet, "/rest/:name/:id", func(c *Context) {
 		var person Person
-		assert.NoError(t, c.BindUri(&person))
-		assert.True(t, person.Name != "")
-		assert.True(t, person.ID != "")
+		require.NoError(t, c.BindUri(&person))
+		assert.NotEqual(t, "", person.Name)
+		assert.NotEqual(t, "", person.ID)
 		c.String(http.StatusOK, "BindUri test OK")
 	})
 
@@ -338,7 +339,7 @@ func TestBindUriError(t *testing.T) {
 	}
 	router.Handle(http.MethodGet, "/new/rest/:num", func(c *Context) {
 		var m Member
-		assert.Error(t, c.BindUri(&m))
+		require.Error(t, c.BindUri(&m))
 	})
 
 	path1, _ := exampleFromPath("/new/rest/:num")

--- a/logger_test.go
+++ b/logger_test.go
@@ -329,13 +329,13 @@ func TestIsOutputColor(t *testing.T) {
 	}
 
 	consoleColorMode = autoColor
-	assert.Equal(t, true, p.IsOutputColor())
+	assert.True(t, p.IsOutputColor())
 
 	ForceConsoleColor()
-	assert.Equal(t, true, p.IsOutputColor())
+	assert.True(t, p.IsOutputColor())
 
 	DisableConsoleColor()
-	assert.Equal(t, false, p.IsOutputColor())
+	assert.False(t, p.IsOutputColor())
 
 	// test with isTerm flag false.
 	p = LogFormatterParams{
@@ -343,13 +343,13 @@ func TestIsOutputColor(t *testing.T) {
 	}
 
 	consoleColorMode = autoColor
-	assert.Equal(t, false, p.IsOutputColor())
+	assert.False(t, p.IsOutputColor())
 
 	ForceConsoleColor()
-	assert.Equal(t, true, p.IsOutputColor())
+	assert.True(t, p.IsOutputColor())
 
 	DisableConsoleColor()
-	assert.Equal(t, false, p.IsOutputColor())
+	assert.False(t, p.IsOutputColor())
 
 	// reset console color mode.
 	consoleColorMode = autoColor

--- a/path_test.go
+++ b/path_test.go
@@ -87,7 +87,7 @@ func TestPathCleanMallocs(t *testing.T) {
 
 	for _, test := range cleanTests {
 		allocs := testing.AllocsPerRun(100, func() { cleanPath(test.result) })
-		assert.EqualValues(t, allocs, 0)
+		assert.InDelta(t, 0, allocs, 0.01)
 	}
 }
 

--- a/render/render_msgpack_test.go
+++ b/render/render_msgpack_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/ugorji/go/codec"
 )
 
@@ -29,7 +30,7 @@ func TestRenderMsgPack(t *testing.T) {
 
 	err := (MsgPack{data}).Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	h := new(codec.MsgpackHandle)
 	assert.NotNil(t, h)
@@ -37,7 +38,7 @@ func TestRenderMsgPack(t *testing.T) {
 	assert.NotNil(t, buf)
 	err = codec.NewEncoder(buf, h).Encode(data)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, w.Body.String(), buf.String())
 	assert.Equal(t, "application/msgpack; charset=utf-8", w.Header().Get("Content-Type"))
 }

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gin-gonic/gin/internal/json"
 	testdata "github.com/gin-gonic/gin/testdata/protoexample"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -36,7 +37,7 @@ func TestRenderJSON(t *testing.T) {
 
 	err := (JSON{data}).Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "{\"foo\":\"bar\",\"html\":\"\\u003cb\\u003e\"}", w.Body.String())
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
 }
@@ -46,7 +47,7 @@ func TestRenderJSONError(t *testing.T) {
 	data := make(chan int)
 
 	// json: unsupported type: chan int
-	assert.Error(t, (JSON{data}).Render(w))
+	require.Error(t, (JSON{data}).Render(w))
 }
 
 func TestRenderIndentedJSON(t *testing.T) {
@@ -58,7 +59,7 @@ func TestRenderIndentedJSON(t *testing.T) {
 
 	err := (IndentedJSON{data}).Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "{\n    \"bar\": \"foo\",\n    \"foo\": \"bar\"\n}", w.Body.String())
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
 }
@@ -69,7 +70,7 @@ func TestRenderIndentedJSONPanics(t *testing.T) {
 
 	// json: unsupported type: chan int
 	err := (IndentedJSON{data}).Render(w)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestRenderSecureJSON(t *testing.T) {
@@ -83,7 +84,7 @@ func TestRenderSecureJSON(t *testing.T) {
 
 	err1 := (SecureJSON{"while(1);", data}).Render(w1)
 
-	assert.NoError(t, err1)
+	require.NoError(t, err1)
 	assert.Equal(t, "{\"foo\":\"bar\"}", w1.Body.String())
 	assert.Equal(t, "application/json; charset=utf-8", w1.Header().Get("Content-Type"))
 
@@ -95,7 +96,7 @@ func TestRenderSecureJSON(t *testing.T) {
 	}}
 
 	err2 := (SecureJSON{"while(1);", datas}).Render(w2)
-	assert.NoError(t, err2)
+	require.NoError(t, err2)
 	assert.Equal(t, "while(1);[{\"foo\":\"bar\"},{\"bar\":\"foo\"}]", w2.Body.String())
 	assert.Equal(t, "application/json; charset=utf-8", w2.Header().Get("Content-Type"))
 }
@@ -106,7 +107,7 @@ func TestRenderSecureJSONFail(t *testing.T) {
 
 	// json: unsupported type: chan int
 	err := (SecureJSON{"while(1);", data}).Render(w)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestRenderJsonpJSON(t *testing.T) {
@@ -120,7 +121,7 @@ func TestRenderJsonpJSON(t *testing.T) {
 
 	err1 := (JsonpJSON{"x", data}).Render(w1)
 
-	assert.NoError(t, err1)
+	require.NoError(t, err1)
 	assert.Equal(t, "x({\"foo\":\"bar\"});", w1.Body.String())
 	assert.Equal(t, "application/javascript; charset=utf-8", w1.Header().Get("Content-Type"))
 
@@ -132,7 +133,7 @@ func TestRenderJsonpJSON(t *testing.T) {
 	}}
 
 	err2 := (JsonpJSON{"x", datas}).Render(w2)
-	assert.NoError(t, err2)
+	require.NoError(t, err2)
 	assert.Equal(t, "x([{\"foo\":\"bar\"},{\"bar\":\"foo\"}]);", w2.Body.String())
 	assert.Equal(t, "application/javascript; charset=utf-8", w2.Header().Get("Content-Type"))
 }
@@ -191,7 +192,7 @@ func TestRenderJsonpJSONError2(t *testing.T) {
 	assert.Equal(t, "application/javascript; charset=utf-8", w.Header().Get("Content-Type"))
 
 	e := (JsonpJSON{"", data}).Render(w)
-	assert.NoError(t, e)
+	require.NoError(t, e)
 
 	assert.Equal(t, "{\"foo\":\"bar\"}", w.Body.String())
 	assert.Equal(t, "application/javascript; charset=utf-8", w.Header().Get("Content-Type"))
@@ -203,7 +204,7 @@ func TestRenderJsonpJSONFail(t *testing.T) {
 
 	// json: unsupported type: chan int
 	err := (JsonpJSON{"x", data}).Render(w)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestRenderAsciiJSON(t *testing.T) {
@@ -215,7 +216,7 @@ func TestRenderAsciiJSON(t *testing.T) {
 
 	err := (AsciiJSON{data1}).Render(w1)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "{\"lang\":\"GO\\u8bed\\u8a00\",\"tag\":\"\\u003cbr\\u003e\"}", w1.Body.String())
 	assert.Equal(t, "application/json", w1.Header().Get("Content-Type"))
 
@@ -223,7 +224,7 @@ func TestRenderAsciiJSON(t *testing.T) {
 	data2 := 3.1415926
 
 	err = (AsciiJSON{data2}).Render(w2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "3.1415926", w2.Body.String())
 }
 
@@ -232,7 +233,7 @@ func TestRenderAsciiJSONFail(t *testing.T) {
 	data := make(chan int)
 
 	// json: unsupported type: chan int
-	assert.Error(t, (AsciiJSON{data}).Render(w))
+	require.Error(t, (AsciiJSON{data}).Render(w))
 }
 
 func TestRenderPureJSON(t *testing.T) {
@@ -242,7 +243,7 @@ func TestRenderPureJSON(t *testing.T) {
 		"html": "<b>",
 	}
 	err := (PureJSON{data}).Render(w)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "{\"foo\":\"bar\",\"html\":\"<b>\"}\n", w.Body.String())
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
 }
@@ -283,7 +284,7 @@ b:
 	assert.Equal(t, "application/yaml; charset=utf-8", w.Header().Get("Content-Type"))
 
 	err := (YAML{data}).Render(w)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "|4-\n    a : Easy!\n    b:\n    \tc: 2\n    \td: [3, 4]\n    \t\n", w.Body.String())
 	assert.Equal(t, "application/yaml; charset=utf-8", w.Header().Get("Content-Type"))
 }
@@ -298,7 +299,7 @@ func (ft *fail) MarshalYAML() (any, error) {
 func TestRenderYAMLFail(t *testing.T) {
 	w := httptest.NewRecorder()
 	err := (YAML{&fail{}}).Render(w)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestRenderTOML(t *testing.T) {
@@ -311,7 +312,7 @@ func TestRenderTOML(t *testing.T) {
 	assert.Equal(t, "application/toml; charset=utf-8", w.Header().Get("Content-Type"))
 
 	err := (TOML{data}).Render(w)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "foo = 'bar'\nhtml = '<b>'\n", w.Body.String())
 	assert.Equal(t, "application/toml; charset=utf-8", w.Header().Get("Content-Type"))
 }
@@ -319,7 +320,7 @@ func TestRenderTOML(t *testing.T) {
 func TestRenderTOMLFail(t *testing.T) {
 	w := httptest.NewRecorder()
 	err := (TOML{net.IPv4bcast}).Render(w)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 // test Protobuf rendering
@@ -334,12 +335,12 @@ func TestRenderProtoBuf(t *testing.T) {
 
 	(ProtoBuf{data}).WriteContentType(w)
 	protoData, err := proto.Marshal(data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "application/x-protobuf", w.Header().Get("Content-Type"))
 
 	err = (ProtoBuf{data}).Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, string(protoData), w.Body.String())
 	assert.Equal(t, "application/x-protobuf", w.Header().Get("Content-Type"))
 }
@@ -348,7 +349,7 @@ func TestRenderProtoBufFail(t *testing.T) {
 	w := httptest.NewRecorder()
 	data := &testdata.Test{}
 	err := (ProtoBuf{data}).Render(w)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestRenderXML(t *testing.T) {
@@ -362,14 +363,14 @@ func TestRenderXML(t *testing.T) {
 
 	err := (XML{data}).Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "<map><foo>bar</foo></map>", w.Body.String())
 	assert.Equal(t, "application/xml; charset=utf-8", w.Header().Get("Content-Type"))
 }
 
 func TestRenderRedirect(t *testing.T) {
 	req, err := http.NewRequest("GET", "/test-redirect", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	data1 := Redirect{
 		Code:     http.StatusMovedPermanently,
@@ -379,7 +380,7 @@ func TestRenderRedirect(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	err = data1.Render(w)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	data2 := Redirect{
 		Code:     http.StatusOK,
@@ -390,7 +391,7 @@ func TestRenderRedirect(t *testing.T) {
 	w = httptest.NewRecorder()
 	assert.PanicsWithValue(t, "Cannot redirect with status code 200", func() {
 		err := data2.Render(w)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	data3 := Redirect{
@@ -401,7 +402,7 @@ func TestRenderRedirect(t *testing.T) {
 
 	w = httptest.NewRecorder()
 	err = data3.Render(w)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// only improve coverage
 	data2.WriteContentType(w)
@@ -416,7 +417,7 @@ func TestRenderData(t *testing.T) {
 		Data:        data,
 	}).Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "#!PNG some raw data", w.Body.String())
 	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
 }
@@ -435,7 +436,7 @@ func TestRenderString(t *testing.T) {
 		Data:   []any{"manu", 2},
 	}).Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "hola manu 2", w.Body.String())
 	assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
 }
@@ -448,7 +449,7 @@ func TestRenderStringLenZero(t *testing.T) {
 		Data:   []any{},
 	}).Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "hola %s %d", w.Body.String())
 	assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
 }
@@ -464,7 +465,7 @@ func TestRenderHTMLTemplate(t *testing.T) {
 
 	err := instance.Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Hello alexandernyquist", w.Body.String())
 	assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 }
@@ -480,7 +481,7 @@ func TestRenderHTMLTemplateEmptyName(t *testing.T) {
 
 	err := instance.Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Hello alexandernyquist", w.Body.String())
 	assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 }
@@ -499,7 +500,7 @@ func TestRenderHTMLDebugFiles(t *testing.T) {
 
 	err := instance.Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "<h1>Hello thinkerou</h1>", w.Body.String())
 	assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 }
@@ -518,7 +519,7 @@ func TestRenderHTMLDebugGlob(t *testing.T) {
 
 	err := instance.Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "<h1>Hello thinkerou</h1>", w.Body.String())
 	assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 }
@@ -548,7 +549,7 @@ func TestRenderReader(t *testing.T) {
 		Headers:       headers,
 	}).Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, body, w.Body.String())
 	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
 	assert.Equal(t, strconv.Itoa(len(body)), w.Header().Get("Content-Length"))
@@ -571,7 +572,7 @@ func TestRenderReaderNoContentLength(t *testing.T) {
 		Headers:       headers,
 	}).Render(w)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, body, w.Body.String())
 	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
 	assert.NotContains(t, "Content-Length", w.Header())
@@ -588,6 +589,6 @@ func TestRenderWriteError(t *testing.T) {
 		ResponseRecorder: httptest.NewRecorder(),
 	}
 	err := r.Render(ew)
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Equal(t, `write "my-prefix:" error`, err.Error())
 }

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TODO
@@ -95,13 +96,13 @@ func TestResponseWriterWrite(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Status())
 	assert.Equal(t, http.StatusOK, testWriter.Code)
 	assert.Equal(t, "hola", testWriter.Body.String())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	n, err = w.Write([]byte(" adios"))
 	assert.Equal(t, 6, n)
 	assert.Equal(t, 10, w.Size())
 	assert.Equal(t, "hola adios", testWriter.Body.String())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestResponseWriterHijack(t *testing.T) {
@@ -112,7 +113,7 @@ func TestResponseWriterHijack(t *testing.T) {
 
 	assert.Panics(t, func() {
 		_, _, err := w.Hijack()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 	assert.True(t, w.Written())
 
@@ -135,7 +136,7 @@ func TestResponseWriterFlush(t *testing.T) {
 
 	// should return 500
 	resp, err := http.Get(testServer.URL)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 }
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type header struct {
@@ -386,7 +387,7 @@ func TestRouteStaticFile(t *testing.T) {
 	}
 	defer os.Remove(f.Name())
 	_, err = f.WriteString("Gin Web Framework")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	f.Close()
 
 	dir, filename := filepath.Split(f.Name())
@@ -421,7 +422,7 @@ func TestRouteStaticFileFS(t *testing.T) {
 	}
 	defer os.Remove(f.Name())
 	_, err = f.WriteString("Gin Web Framework")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	f.Close()
 
 	dir, filename := filepath.Split(f.Name())
@@ -484,7 +485,7 @@ func TestRouterMiddlewareAndStatic(t *testing.T) {
 	// Content-Type='text/plain; charset=utf-8' when go version <= 1.16,
 	// else, Content-Type='text/x-go; charset=utf-8'
 	assert.NotEqual(t, "", w.Header().Get("Content-Type"))
-	assert.NotEqual(t, w.Header().Get("Last-Modified"), "Mon, 02 Jan 2006 15:04:05 MST")
+	assert.NotEqual(t, "Mon, 02 Jan 2006 15:04:05 MST", w.Header().Get("Last-Modified"))
 	assert.Equal(t, "Mon, 02 Jan 2006 15:04:05 MST", w.Header().Get("Expires"))
 	assert.Equal(t, "Gin Framework", w.Header().Get("x-GIN"))
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -145,6 +145,6 @@ func TestMarshalXMLforH(t *testing.T) {
 }
 
 func TestIsASCII(t *testing.T) {
-	assert.Equal(t, isASCII("test"), true)
-	assert.Equal(t, isASCII("🧡💛💚💙💜"), false)
+	assert.True(t, isASCII("test"))
+	assert.False(t, isASCII("🧡💛💚💙💜"))
 }


### PR DESCRIPTION
This PR enables and fixes [testifylint](https://github.com/Antonboom/testifylint) linter to use best practices concerning testify