### PR TITLE
logger: allow skipping query string output

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -22,6 +22,7 @@
   - [How to write log file](#how-to-write-log-file)
   - [Custom Log Format](#custom-log-format)
   - [Controlling Log output coloring](#controlling-log-output-coloring)
+  - [Avoid logging query strings](#avoid-loging-query-strings)
   - [Model binding and validation](#model-binding-and-validation)
   - [Custom Validators](#custom-validators)
   - [Only Bind Query String](#only-bind-query-string)
@@ -586,6 +587,20 @@ func main() {
   })
 
   router.Run(":8080")
+}
+```
+
+### Avoid logging query strings
+
+```go
+func main() {
+  router := gin.New()
+  
+  // SkipQueryString indicates that the logger should not log the query string.
+  // For example, /path?q=1 will be logged as /path
+  loggerConfig := gin.LoggerConfig{SkipQueryString: true}
+  
+  router.Use(gin.LoggerWithConfig(loggerConfig))
 }
 ```
 

--- a/logger.go
+++ b/logger.go
@@ -44,6 +44,11 @@ type LoggerConfig struct {
 	// Optional. Default value is gin.DefaultWriter.
 	Output io.Writer
 
+	// SkipQueryString indicates that query strings should not be written
+	// for cases such as when API keys are passed via query strings.
+	// Optional. Default value is false.
+	SkipQueryString bool
+
 	// SkipPaths is an url path array which logs are not written.
 	// Optional.
 	SkipPaths []string
@@ -270,7 +275,7 @@ func LoggerWithConfig(conf LoggerConfig) HandlerFunc {
 
 		param.BodySize = c.Writer.Size()
 
-		if raw != "" {
+		if raw != "" && !conf.SkipQueryString {
 			path = path + "?" + raw
 		}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -454,3 +454,17 @@ func TestForceConsoleColor(t *testing.T) {
 	// reset console color mode.
 	consoleColorMode = autoColor
 }
+
+func TestLoggerWithConfigSkipQueryString(t *testing.T) {
+	buffer := new(strings.Builder)
+	router := New()
+	router.Use(LoggerWithConfig(LoggerConfig{
+		Output:          buffer,
+		SkipQueryString: true,
+	}))
+	router.GET("/logged", func(c *Context) { c.Status(http.StatusOK) })
+
+	PerformRequest(router, "GET", "/logged?a=21")
+	assert.Contains(t, buffer.String(), "200")
+	assert.NotContains(t, buffer.String(), "a=21")
+}


### PR DESCRIPTION
This is useful for APIs that might have sensitive information in the query string, such as API keys.

This patch does not change the default behavior of the code unless the new `SkipQueryString` config option is passed in as `true`.

The "skip" term is a bit of a misnomer here, as this doesn't actually skip that log, but modifies the output. I'm open to suggestions for a more appropriate name.