### PR TITLE
fix(tree): Keep panic infos consistent when wildcard type build faild

### DIFF
--- a/.github/workflows/gin.yml
+++ b/.github/workflows/gin.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.58.1
+          version: v1.61.0
           args: --verbose
   test:
     needs: lint

--- a/tree.go
+++ b/tree.go
@@ -369,7 +369,7 @@ func (n *node) insertChild(path string, fullPath string, handlers HandlersChain)
 
 		// currently fixed width 1 for '/'
 		i--
-		if path[i] != '/' {
+		if i < 0 || path[i] != '/' {
 			panic("no / before catch-all in path '" + fullPath + "'")
 		}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -993,3 +993,28 @@ func TestTreeInvalidEscape(t *testing.T) {
 		}
 	}
 }
+
+func TestWildcardInvalidSlash(t *testing.T) {
+	const panicMsgPrefix = "no / before catch-all in path"
+
+	routes := map[string]bool{
+		"/foo/bar":  true,
+		"/foo/x*zy": false,
+		"/foo/b*r":  false,
+	}
+
+	for route, valid := range routes {
+		tree := &node{}
+		recv := catchPanic(func() {
+			tree.addRoute(route, nil)
+		})
+
+		if recv == nil != valid {
+			t.Fatalf("%s should be %t but got %v", route, valid, recv)
+		}
+
+		if rs, ok := recv.(string); recv != nil && (!ok || !strings.HasPrefix(rs, panicMsgPrefix)) {
+			t.Fatalf(`"Expected panic "%s" for route '%s', got "%v"`, panicMsgPrefix, route, recv)
+		}
+	}
+}


### PR DESCRIPTION
fix(tree): Keep panic infos consistent when wildcard type build faild

When I run the demo1
```go
// demo1
func main() {
	router := gin.Default()
	router.GET("/abc/bar", nil)
	router.GET("/abc/x*z", nil)

	router.Run("localhost:8080")
}
```
it got the panic:`panic: no / before catch-all in path '/abc/x*z'`

but when i run the demo2
```go
// demo2
func main() {
	router := gin.Default()
	router.GET("/abc/bar", nil)
	router.GET("/abc/b*r", nil)

	router.Run("localhost:8080")
} 
```
it got the panic: `panic: runtime error: index out of range [-1]`
Although the end result is the same(panic), the different panic informations may cause some confusion.

So, add the `i < 0` condition to keep the panic infos same
