### PR TITLE
refactor(context): (reupload) Added an optional permission parameter to the SaveUploadedFile method (#4068)

### DIFF
--- a/context.go
+++ b/context.go
@@ -7,6 +7,7 @@ package gin
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"log"
 	"math"
 	"mime/multipart"
@@ -677,14 +678,22 @@ func (c *Context) MultipartForm() (*multipart.Form, error) {
 }
 
 // SaveUploadedFile uploads the form file to specific dst.
-func (c *Context) SaveUploadedFile(file *multipart.FileHeader, dst string) error {
+func (c *Context) SaveUploadedFile(file *multipart.FileHeader, dst string, perm ...fs.FileMode) error {
 	src, err := file.Open()
 	if err != nil {
 		return err
 	}
 	defer src.Close()
 
-	if err = os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+	if len(perm) <= 0 {
+		perm = append(perm, 0o750)
+	}
+
+	if err = os.MkdirAll(filepath.Dir(dst), perm[0]); err != nil {
+		return err
+	}
+
+	if err = os.Chmod(filepath.Dir(dst), perm[0]); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The SaveUploadedFile method previously set folder permissions to 0o750 by default when creating directories. A third parameter, ...fs.FileMode, has been added to allow customizable permissions. This update enables users to optionally set folder permissions when creating directories and files with the SaveUploadedFile method.

``` go
// example
func SaveFile(ctx *gin.Context) error {
	file, err := ctx.FormFile("file")
	if err != nil {
		return err
	}

	var perm fs.FileMode = 0o755
	return ctx.SaveUploadedFile(file, "/asset/file", perm)
}
```


![image](https://github.com/user-attachments/assets/824413af-60af-46ab-8202-ed44a0e3ff61)