### PR TITLE
ci(lint): enable usestdlibvars linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - nolintlint
     - revive
     - testifylint
+    - usestdlibvars
     - wastedassign
 
 linters-settings:

--- a/auth_test.go
+++ b/auth_test.go
@@ -90,7 +90,7 @@ func TestBasicAuthSucceed(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/login", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/login", nil)
 	req.Header.Set("Authorization", authorizationHeader("admin", "password"))
 	router.ServeHTTP(w, req)
 
@@ -109,7 +109,7 @@ func TestBasicAuth401(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/login", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/login", nil)
 	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("admin:password")))
 	router.ServeHTTP(w, req)
 
@@ -129,7 +129,7 @@ func TestBasicAuth401WithCustomRealm(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/login", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/login", nil)
 	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("admin:password")))
 	router.ServeHTTP(w, req)
 
@@ -147,7 +147,7 @@ func TestBasicAuthForProxySucceed(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/test", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Proxy-Authorization", authorizationHeader("admin", "password"))
 	router.ServeHTTP(w, req)
 
@@ -166,7 +166,7 @@ func TestBasicAuthForProxy407(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/test", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("admin:password")))
 	router.ServeHTTP(w, req)
 

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -14,21 +14,21 @@ import (
 func BenchmarkOneRoute(B *testing.B) {
 	router := New()
 	router.GET("/ping", func(c *Context) {})
-	runRequest(B, router, "GET", "/ping")
+	runRequest(B, router, http.MethodGet, "/ping")
 }
 
 func BenchmarkRecoveryMiddleware(B *testing.B) {
 	router := New()
 	router.Use(Recovery())
 	router.GET("/", func(c *Context) {})
-	runRequest(B, router, "GET", "/")
+	runRequest(B, router, http.MethodGet, "/")
 }
 
 func BenchmarkLoggerMiddleware(B *testing.B) {
 	router := New()
 	router.Use(LoggerWithWriter(newMockWriter()))
 	router.GET("/", func(c *Context) {})
-	runRequest(B, router, "GET", "/")
+	runRequest(B, router, http.MethodGet, "/")
 }
 
 func BenchmarkManyHandlers(B *testing.B) {
@@ -37,7 +37,7 @@ func BenchmarkManyHandlers(B *testing.B) {
 	router.Use(func(c *Context) {})
 	router.Use(func(c *Context) {})
 	router.GET("/ping", func(c *Context) {})
-	runRequest(B, router, "GET", "/ping")
+	runRequest(B, router, http.MethodGet, "/ping")
 }
 
 func Benchmark5Params(B *testing.B) {
@@ -45,7 +45,7 @@ func Benchmark5Params(B *testing.B) {
 	router := New()
 	router.Use(func(c *Context) {})
 	router.GET("/param/:param1/:params2/:param3/:param4/:param5", func(c *Context) {})
-	runRequest(B, router, "GET", "/param/path/to/parameter/john/12345")
+	runRequest(B, router, http.MethodGet, "/param/path/to/parameter/john/12345")
 }
 
 func BenchmarkOneRouteJSON(B *testing.B) {
@@ -56,7 +56,7 @@ func BenchmarkOneRouteJSON(B *testing.B) {
 	router.GET("/json", func(c *Context) {
 		c.JSON(http.StatusOK, data)
 	})
-	runRequest(B, router, "GET", "/json")
+	runRequest(B, router, http.MethodGet, "/json")
 }
 
 func BenchmarkOneRouteHTML(B *testing.B) {
@@ -68,7 +68,7 @@ func BenchmarkOneRouteHTML(B *testing.B) {
 	router.GET("/html", func(c *Context) {
 		c.HTML(http.StatusOK, "index", "hola")
 	})
-	runRequest(B, router, "GET", "/html")
+	runRequest(B, router, http.MethodGet, "/html")
 }
 
 func BenchmarkOneRouteSet(B *testing.B) {
@@ -76,7 +76,7 @@ func BenchmarkOneRouteSet(B *testing.B) {
 	router.GET("/ping", func(c *Context) {
 		c.Set("key", "value")
 	})
-	runRequest(B, router, "GET", "/ping")
+	runRequest(B, router, http.MethodGet, "/ping")
 }
 
 func BenchmarkOneRouteString(B *testing.B) {
@@ -84,13 +84,13 @@ func BenchmarkOneRouteString(B *testing.B) {
 	router.GET("/text", func(c *Context) {
 		c.String(http.StatusOK, "this is a plain text")
 	})
-	runRequest(B, router, "GET", "/text")
+	runRequest(B, router, http.MethodGet, "/text")
 }
 
 func BenchmarkManyRoutesFist(B *testing.B) {
 	router := New()
 	router.Any("/ping", func(c *Context) {})
-	runRequest(B, router, "GET", "/ping")
+	runRequest(B, router, http.MethodGet, "/ping")
 }
 
 func BenchmarkManyRoutesLast(B *testing.B) {
@@ -103,7 +103,7 @@ func Benchmark404(B *testing.B) {
 	router := New()
 	router.Any("/something", func(c *Context) {})
 	router.NoRoute(func(c *Context) {})
-	runRequest(B, router, "GET", "/ping")
+	runRequest(B, router, http.MethodGet, "/ping")
 }
 
 func Benchmark404Many(B *testing.B) {
@@ -118,7 +118,7 @@ func Benchmark404Many(B *testing.B) {
 	router.GET("/user/:id/:mode", func(c *Context) {})
 
 	router.NoRoute(func(c *Context) {})
-	runRequest(B, router, "GET", "/viewfake")
+	runRequest(B, router, http.MethodGet, "/viewfake")
 }
 
 type mockWriter struct {

--- a/binding/binding_msgpack_test.go
+++ b/binding/binding_msgpack_test.go
@@ -8,6 +8,7 @@ package binding
 
 import (
 	"bytes"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,20 +40,20 @@ func testMsgPackBodyBinding(t *testing.T, b Binding, name, path, badPath, body, 
 	assert.Equal(t, name, b.Name())
 
 	obj := FooStruct{}
-	req := requestWithBody("POST", path, body)
+	req := requestWithBody(http.MethodPost, path, body)
 	req.Header.Add("Content-Type", MIMEMSGPACK)
 	err := b.Bind(req, &obj)
 	require.NoError(t, err)
 	assert.Equal(t, "bar", obj.Foo)
 
 	obj = FooStruct{}
-	req = requestWithBody("POST", badPath, badBody)
+	req = requestWithBody(http.MethodPost, badPath, badBody)
 	req.Header.Add("Content-Type", MIMEMSGPACK)
 	err = MsgPack.Bind(req, &obj)
 	require.Error(t, err)
 }
 
 func TestBindingDefaultMsgPack(t *testing.T) {
-	assert.Equal(t, MsgPack, Default("POST", MIMEMSGPACK))
-	assert.Equal(t, MsgPack, Default("PUT", MIMEMSGPACK2))
+	assert.Equal(t, MsgPack, Default(http.MethodPost, MIMEMSGPACK))
+	assert.Equal(t, MsgPack, Default(http.MethodPut, MIMEMSGPACK2))
 }

--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -145,31 +145,31 @@ type FooStructForMapPtrType struct {
 }
 
 func TestBindingDefault(t *testing.T) {
-	assert.Equal(t, Form, Default("GET", ""))
-	assert.Equal(t, Form, Default("GET", MIMEJSON))
+	assert.Equal(t, Form, Default(http.MethodGet, ""))
+	assert.Equal(t, Form, Default(http.MethodGet, MIMEJSON))
 
-	assert.Equal(t, JSON, Default("POST", MIMEJSON))
-	assert.Equal(t, JSON, Default("PUT", MIMEJSON))
+	assert.Equal(t, JSON, Default(http.MethodPost, MIMEJSON))
+	assert.Equal(t, JSON, Default(http.MethodPut, MIMEJSON))
 
-	assert.Equal(t, XML, Default("POST", MIMEXML))
-	assert.Equal(t, XML, Default("PUT", MIMEXML2))
+	assert.Equal(t, XML, Default(http.MethodPost, MIMEXML))
+	assert.Equal(t, XML, Default(http.MethodPut, MIMEXML2))
 
-	assert.Equal(t, Form, Default("POST", MIMEPOSTForm))
-	assert.Equal(t, Form, Default("PUT", MIMEPOSTForm))
+	assert.Equal(t, Form, Default(http.MethodPost, MIMEPOSTForm))
+	assert.Equal(t, Form, Default(http.MethodPut, MIMEPOSTForm))
 
-	assert.Equal(t, FormMultipart, Default("POST", MIMEMultipartPOSTForm))
-	assert.Equal(t, FormMultipart, Default("PUT", MIMEMultipartPOSTForm))
+	assert.Equal(t, FormMultipart, Default(http.MethodPost, MIMEMultipartPOSTForm))
+	assert.Equal(t, FormMultipart, Default(http.MethodPut, MIMEMultipartPOSTForm))
 
-	assert.Equal(t, ProtoBuf, Default("POST", MIMEPROTOBUF))
-	assert.Equal(t, ProtoBuf, Default("PUT", MIMEPROTOBUF))
+	assert.Equal(t, ProtoBuf, Default(http.MethodPost, MIMEPROTOBUF))
+	assert.Equal(t, ProtoBuf, Default(http.MethodPut, MIMEPROTOBUF))
 
-	assert.Equal(t, YAML, Default("POST", MIMEYAML))
-	assert.Equal(t, YAML, Default("PUT", MIMEYAML))
-	assert.Equal(t, YAML, Default("POST", MIMEYAML2))
-	assert.Equal(t, YAML, Default("PUT", MIMEYAML2))
+	assert.Equal(t, YAML, Default(http.MethodPost, MIMEYAML))
+	assert.Equal(t, YAML, Default(http.MethodPut, MIMEYAML))
+	assert.Equal(t, YAML, Default(http.MethodPost, MIMEYAML2))
+	assert.Equal(t, YAML, Default(http.MethodPut, MIMEYAML2))
 
-	assert.Equal(t, TOML, Default("POST", MIMETOML))
-	assert.Equal(t, TOML, Default("PUT", MIMETOML))
+	assert.Equal(t, TOML, Default(http.MethodPost, MIMETOML))
+	assert.Equal(t, TOML, Default(http.MethodPut, MIMETOML))
 }
 
 func TestBindingJSONNilBody(t *testing.T) {
@@ -227,137 +227,137 @@ func TestBindingJSONStringMap(t *testing.T) {
 }
 
 func TestBindingForm(t *testing.T) {
-	testFormBinding(t, "POST",
+	testFormBinding(t, http.MethodPost,
 		"/", "/",
 		"foo=bar&bar=foo", "bar2=foo")
 }
 
 func TestBindingForm2(t *testing.T) {
-	testFormBinding(t, "GET",
+	testFormBinding(t, http.MethodGet,
 		"/?foo=bar&bar=foo", "/?bar2=foo",
 		"", "")
 }
 
 func TestBindingFormEmbeddedStruct(t *testing.T) {
-	testFormBindingEmbeddedStruct(t, "POST",
+	testFormBindingEmbeddedStruct(t, http.MethodPost,
 		"/", "/",
 		"page=1&size=2&appkey=test-appkey", "bar2=foo")
 }
 
 func TestBindingFormEmbeddedStruct2(t *testing.T) {
-	testFormBindingEmbeddedStruct(t, "GET",
+	testFormBindingEmbeddedStruct(t, http.MethodGet,
 		"/?page=1&size=2&appkey=test-appkey", "/?bar2=foo",
 		"", "")
 }
 
 func TestBindingFormDefaultValue(t *testing.T) {
-	testFormBindingDefaultValue(t, "POST",
+	testFormBindingDefaultValue(t, http.MethodPost,
 		"/", "/",
 		"foo=bar", "bar2=foo")
 }
 
 func TestBindingFormDefaultValue2(t *testing.T) {
-	testFormBindingDefaultValue(t, "GET",
+	testFormBindingDefaultValue(t, http.MethodGet,
 		"/?foo=bar", "/?bar2=foo",
 		"", "")
 }
 
 func TestBindingFormForTime(t *testing.T) {
-	testFormBindingForTime(t, "POST",
+	testFormBindingForTime(t, http.MethodPost,
 		"/", "/",
 		"time_foo=2017-11-15&time_bar=&createTime=1562400033000000123&unixTime=1562400033", "bar2=foo")
-	testFormBindingForTimeNotUnixFormat(t, "POST",
+	testFormBindingForTimeNotUnixFormat(t, http.MethodPost,
 		"/", "/",
 		"time_foo=2017-11-15&createTime=bad&unixTime=bad", "bar2=foo")
-	testFormBindingForTimeNotFormat(t, "POST",
+	testFormBindingForTimeNotFormat(t, http.MethodPost,
 		"/", "/",
 		"time_foo=2017-11-15", "bar2=foo")
-	testFormBindingForTimeFailFormat(t, "POST",
+	testFormBindingForTimeFailFormat(t, http.MethodPost,
 		"/", "/",
 		"time_foo=2017-11-15", "bar2=foo")
-	testFormBindingForTimeFailLocation(t, "POST",
+	testFormBindingForTimeFailLocation(t, http.MethodPost,
 		"/", "/",
 		"time_foo=2017-11-15", "bar2=foo")
 }
 
 func TestBindingFormForTime2(t *testing.T) {
-	testFormBindingForTime(t, "GET",
+	testFormBindingForTime(t, http.MethodGet,
 		"/?time_foo=2017-11-15&time_bar=&createTime=1562400033000000123&unixTime=1562400033", "/?bar2=foo",
 		"", "")
-	testFormBindingForTimeNotUnixFormat(t, "POST",
+	testFormBindingForTimeNotUnixFormat(t, http.MethodPost,
 		"/", "/",
 		"time_foo=2017-11-15&createTime=bad&unixTime=bad", "bar2=foo")
-	testFormBindingForTimeNotFormat(t, "GET",
+	testFormBindingForTimeNotFormat(t, http.MethodGet,
 		"/?time_foo=2017-11-15", "/?bar2=foo",
 		"", "")
-	testFormBindingForTimeFailFormat(t, "GET",
+	testFormBindingForTimeFailFormat(t, http.MethodGet,
 		"/?time_foo=2017-11-15", "/?bar2=foo",
 		"", "")
-	testFormBindingForTimeFailLocation(t, "GET",
+	testFormBindingForTimeFailLocation(t, http.MethodGet,
 		"/?time_foo=2017-11-15", "/?bar2=foo",
 		"", "")
 }
 
 func TestFormBindingIgnoreField(t *testing.T) {
-	testFormBindingIgnoreField(t, "POST",
+	testFormBindingIgnoreField(t, http.MethodPost,
 		"/", "/",
 		"-=bar", "")
 }
 
 func TestBindingFormInvalidName(t *testing.T) {
-	testFormBindingInvalidName(t, "POST",
+	testFormBindingInvalidName(t, http.MethodPost,
 		"/", "/",
 		"test_name=bar", "bar2=foo")
 }
 
 func TestBindingFormInvalidName2(t *testing.T) {
-	testFormBindingInvalidName2(t, "POST",
+	testFormBindingInvalidName2(t, http.MethodPost,
 		"/", "/",
 		"map_foo=bar", "bar2=foo")
 }
 
 func TestBindingFormForType(t *testing.T) {
-	testFormBindingForType(t, "POST",
+	testFormBindingForType(t, http.MethodPost,
 		"/", "/",
 		"map_foo={\"bar\":123}", "map_foo=1", "Map")
 
-	testFormBindingForType(t, "POST",
+	testFormBindingForType(t, http.MethodPost,
 		"/", "/",
 		"slice_foo=1&slice_foo=2", "bar2=1&bar2=2", "Slice")
 
-	testFormBindingForType(t, "GET",
+	testFormBindingForType(t, http.MethodGet,
 		"/?slice_foo=1&slice_foo=2", "/?bar2=1&bar2=2",
 		"", "", "Slice")
 
-	testFormBindingForType(t, "POST",
+	testFormBindingForType(t, http.MethodPost,
 		"/", "/",
 		"slice_map_foo=1&slice_map_foo=2", "bar2=1&bar2=2", "SliceMap")
 
-	testFormBindingForType(t, "GET",
+	testFormBindingForType(t, http.MethodGet,
 		"/?slice_map_foo=1&slice_map_foo=2", "/?bar2=1&bar2=2",
 		"", "", "SliceMap")
 
-	testFormBindingForType(t, "POST",
+	testFormBindingForType(t, http.MethodPost,
 		"/", "/",
 		"ptr_bar=test", "bar2=test", "Ptr")
 
-	testFormBindingForType(t, "GET",
+	testFormBindingForType(t, http.MethodGet,
 		"/?ptr_bar=test", "/?bar2=test",
 		"", "", "Ptr")
 
-	testFormBindingForType(t, "POST",
+	testFormBindingForType(t, http.MethodPost,
 		"/", "/",
 		"idx=123", "id1=1", "Struct")
 
-	testFormBindingForType(t, "GET",
+	testFormBindingForType(t, http.MethodGet,
 		"/?idx=123", "/?id1=1",
 		"", "", "Struct")
 
-	testFormBindingForType(t, "POST",
+	testFormBindingForType(t, http.MethodPost,
 		"/", "/",
 		"name=thinkerou", "name1=ou", "StructPointer")
 
-	testFormBindingForType(t, "GET",
+	testFormBindingForType(t, http.MethodGet,
 		"/?name=thinkerou", "/?name1=ou",
 		"", "", "StructPointer")
 }
@@ -374,7 +374,7 @@ func TestBindingFormStringMap(t *testing.T) {
 
 func TestBindingFormStringSliceMap(t *testing.T) {
 	obj := make(map[string][]string)
-	req := requestWithBody("POST", "/", "foo=something&foo=bar&hello=world")
+	req := requestWithBody(http.MethodPost, "/", "foo=something&foo=bar&hello=world")
 	req.Header.Add("Content-Type", MIMEPOSTForm)
 	err := Form.Bind(req, &obj)
 	require.NoError(t, err)
@@ -387,38 +387,38 @@ func TestBindingFormStringSliceMap(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(obj, target))
 
 	objInvalid := make(map[string][]int)
-	req = requestWithBody("POST", "/", "foo=something&foo=bar&hello=world")
+	req = requestWithBody(http.MethodPost, "/", "foo=something&foo=bar&hello=world")
 	req.Header.Add("Content-Type", MIMEPOSTForm)
 	err = Form.Bind(req, &objInvalid)
 	require.Error(t, err)
 }
 
 func TestBindingQuery(t *testing.T) {
-	testQueryBinding(t, "POST",
+	testQueryBinding(t, http.MethodPost,
 		"/?foo=bar&bar=foo", "/",
 		"foo=unused", "bar2=foo")
 }
 
 func TestBindingQuery2(t *testing.T) {
-	testQueryBinding(t, "GET",
+	testQueryBinding(t, http.MethodGet,
 		"/?foo=bar&bar=foo", "/?bar2=foo",
 		"foo=unused", "")
 }
 
 func TestBindingQueryFail(t *testing.T) {
-	testQueryBindingFail(t, "POST",
+	testQueryBindingFail(t, http.MethodPost,
 		"/?map_foo=", "/",
 		"map_foo=unused", "bar2=foo")
 }
 
 func TestBindingQueryFail2(t *testing.T) {
-	testQueryBindingFail(t, "GET",
+	testQueryBindingFail(t, http.MethodGet,
 		"/?map_foo=", "/?bar2=foo",
 		"map_foo=unused", "")
 }
 
 func TestBindingQueryBoolFail(t *testing.T) {
-	testQueryBindingBoolFail(t, "GET",
+	testQueryBindingBoolFail(t, http.MethodGet,
 		"/?bool_foo=fasl", "/?bar2=foo",
 		"bool_foo=unused", "")
 }
@@ -427,7 +427,7 @@ func TestBindingQueryStringMap(t *testing.T) {
 	b := Query
 
 	obj := make(map[string]string)
-	req := requestWithBody("GET", "/?foo=bar&hello=world", "")
+	req := requestWithBody(http.MethodGet, "/?foo=bar&hello=world", "")
 	err := b.Bind(req, &obj)
 	require.NoError(t, err)
 	assert.NotNil(t, obj)
@@ -436,7 +436,7 @@ func TestBindingQueryStringMap(t *testing.T) {
 	assert.Equal(t, "world", obj["hello"])
 
 	obj = make(map[string]string)
-	req = requestWithBody("GET", "/?foo=bar&foo=2&hello=world", "") // should pick last
+	req = requestWithBody(http.MethodGet, "/?foo=bar&foo=2&hello=world", "") // should pick last
 	err = b.Bind(req, &obj)
 	require.NoError(t, err)
 	assert.NotNil(t, obj)
@@ -495,28 +495,28 @@ func TestBindingYAMLFail(t *testing.T) {
 }
 
 func createFormPostRequest(t *testing.T) *http.Request {
-	req, err := http.NewRequest("POST", "/?foo=getfoo&bar=getbar", bytes.NewBufferString("foo=bar&bar=foo"))
+	req, err := http.NewRequest(http.MethodPost, "/?foo=getfoo&bar=getbar", bytes.NewBufferString("foo=bar&bar=foo"))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEPOSTForm)
 	return req
 }
 
 func createDefaultFormPostRequest(t *testing.T) *http.Request {
-	req, err := http.NewRequest("POST", "/?foo=getfoo&bar=getbar", bytes.NewBufferString("foo=bar"))
+	req, err := http.NewRequest(http.MethodPost, "/?foo=getfoo&bar=getbar", bytes.NewBufferString("foo=bar"))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEPOSTForm)
 	return req
 }
 
 func createFormPostRequestForMap(t *testing.T) *http.Request {
-	req, err := http.NewRequest("POST", "/?map_foo=getfoo", bytes.NewBufferString("map_foo={\"bar\":123}"))
+	req, err := http.NewRequest(http.MethodPost, "/?map_foo=getfoo", bytes.NewBufferString("map_foo={\"bar\":123}"))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEPOSTForm)
 	return req
 }
 
 func createFormPostRequestForMapFail(t *testing.T) *http.Request {
-	req, err := http.NewRequest("POST", "/?map_foo=getfoo", bytes.NewBufferString("map_foo=hello"))
+	req, err := http.NewRequest(http.MethodPost, "/?map_foo=getfoo", bytes.NewBufferString("map_foo=hello"))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEPOSTForm)
 	return req
@@ -540,7 +540,7 @@ func createFormFilesMultipartRequest(t *testing.T) *http.Request {
 	_, err = io.Copy(fw, f)
 	require.NoError(t, err)
 
-	req, err2 := http.NewRequest("POST", "/?foo=getfoo&bar=getbar", body)
+	req, err2 := http.NewRequest(http.MethodPost, "/?foo=getfoo&bar=getbar", body)
 	require.NoError(t, err2)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+boundary)
 
@@ -565,7 +565,7 @@ func createFormFilesMultipartRequestFail(t *testing.T) *http.Request {
 	_, err = io.Copy(fw, f)
 	require.NoError(t, err)
 
-	req, err2 := http.NewRequest("POST", "/?foo=getfoo&bar=getbar", body)
+	req, err2 := http.NewRequest(http.MethodPost, "/?foo=getfoo&bar=getbar", body)
 	require.NoError(t, err2)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+boundary)
 
@@ -581,7 +581,7 @@ func createFormMultipartRequest(t *testing.T) *http.Request {
 	require.NoError(t, mw.SetBoundary(boundary))
 	require.NoError(t, mw.WriteField("foo", "bar"))
 	require.NoError(t, mw.WriteField("bar", "foo"))
-	req, err := http.NewRequest("POST", "/?foo=getfoo&bar=getbar", body)
+	req, err := http.NewRequest(http.MethodPost, "/?foo=getfoo&bar=getbar", body)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+boundary)
 	return req
@@ -595,7 +595,7 @@ func createFormMultipartRequestForMap(t *testing.T) *http.Request {
 
 	require.NoError(t, mw.SetBoundary(boundary))
 	require.NoError(t, mw.WriteField("map_foo", "{\"bar\":123, \"name\":\"thinkerou\", \"pai\": 3.14}"))
-	req, err := http.NewRequest("POST", "/?map_foo=getfoo", body)
+	req, err := http.NewRequest(http.MethodPost, "/?map_foo=getfoo", body)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+boundary)
 	return req
@@ -609,7 +609,7 @@ func createFormMultipartRequestForMapFail(t *testing.T) *http.Request {
 
 	require.NoError(t, mw.SetBoundary(boundary))
 	require.NoError(t, mw.WriteField("map_foo", "3.14"))
-	req, err := http.NewRequest("POST", "/?map_foo=getfoo", body)
+	req, err := http.NewRequest(http.MethodPost, "/?map_foo=getfoo", body)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+boundary)
 	return req
@@ -731,7 +731,7 @@ func TestBindingProtoBufFail(t *testing.T) {
 
 func TestValidationFails(t *testing.T) {
 	var obj FooStruct
-	req := requestWithBody("POST", "/", `{"bar": "foo"}`)
+	req := requestWithBody(http.MethodPost, "/", `{"bar": "foo"}`)
 	err := JSON.Bind(req, &obj)
 	require.Error(t, err)
 }
@@ -742,7 +742,7 @@ func TestValidationDisabled(t *testing.T) {
 	defer func() { Validator = backup }()
 
 	var obj FooStruct
-	req := requestWithBody("POST", "/", `{"bar": "foo"}`)
+	req := requestWithBody(http.MethodPost, "/", `{"bar": "foo"}`)
 	err := JSON.Bind(req, &obj)
 	require.NoError(t, err)
 }
@@ -753,7 +753,7 @@ func TestRequiredSucceeds(t *testing.T) {
 	}
 
 	var obj HogeStruct
-	req := requestWithBody("POST", "/", `{"hoge": 0}`)
+	req := requestWithBody(http.MethodPost, "/", `{"hoge": 0}`)
 	err := JSON.Bind(req, &obj)
 	require.NoError(t, err)
 }
@@ -764,7 +764,7 @@ func TestRequiredFails(t *testing.T) {
 	}
 
 	var obj HogeStruct
-	req := requestWithBody("POST", "/", `{"boen": 0}`)
+	req := requestWithBody(http.MethodPost, "/", `{"boen": 0}`)
 	err := JSON.Bind(req, &obj)
 	require.Error(t, err)
 }
@@ -778,12 +778,12 @@ func TestHeaderBinding(t *testing.T) {
 	}
 
 	var theader tHeader
-	req := requestWithBody("GET", "/", "")
+	req := requestWithBody(http.MethodGet, "/", "")
 	req.Header.Add("limit", "1000")
 	require.NoError(t, h.Bind(req, &theader))
 	assert.Equal(t, 1000, theader.Limit)
 
-	req = requestWithBody("GET", "/", "")
+	req = requestWithBody(http.MethodGet, "/", "")
 	req.Header.Add("fail", `{fail:fail}`)
 
 	type failStruct struct {
@@ -843,7 +843,7 @@ func testFormBindingEmbeddedStruct(t *testing.T, method, path, badPath, body, ba
 
 	obj := QueryTest{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -859,7 +859,7 @@ func testFormBinding(t *testing.T, method, path, badPath, body, badBody string) 
 
 	obj := FooBarStruct{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -879,7 +879,7 @@ func testFormBindingDefaultValue(t *testing.T, method, path, badPath, body, badB
 
 	obj := FooDefaultBarStruct{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -898,14 +898,14 @@ func TestFormBindingFail(t *testing.T) {
 	assert.Equal(t, "form", b.Name())
 
 	obj := FooBarStruct{}
-	req, _ := http.NewRequest("POST", "/", nil)
+	req, _ := http.NewRequest(http.MethodPost, "/", nil)
 	err := b.Bind(req, &obj)
 	require.Error(t, err)
 }
 
 func TestFormBindingMultipartFail(t *testing.T) {
 	obj := FooBarStruct{}
-	req, err := http.NewRequest("POST", "/", strings.NewReader("foo=bar"))
+	req, err := http.NewRequest(http.MethodPost, "/", strings.NewReader("foo=bar"))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+";boundary=testboundary")
 	_, err = req.MultipartReader()
@@ -919,7 +919,7 @@ func TestFormPostBindingFail(t *testing.T) {
 	assert.Equal(t, "form-urlencoded", b.Name())
 
 	obj := FooBarStruct{}
-	req, _ := http.NewRequest("POST", "/", nil)
+	req, _ := http.NewRequest(http.MethodPost, "/", nil)
 	err := b.Bind(req, &obj)
 	require.Error(t, err)
 }
@@ -929,7 +929,7 @@ func TestFormMultipartBindingFail(t *testing.T) {
 	assert.Equal(t, "multipart/form-data", b.Name())
 
 	obj := FooBarStruct{}
-	req, _ := http.NewRequest("POST", "/", nil)
+	req, _ := http.NewRequest(http.MethodPost, "/", nil)
 	err := b.Bind(req, &obj)
 	require.Error(t, err)
 }
@@ -940,7 +940,7 @@ func testFormBindingForTime(t *testing.T, method, path, badPath, body, badBody s
 
 	obj := FooBarStructForTimeType{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -965,7 +965,7 @@ func testFormBindingForTimeNotUnixFormat(t *testing.T, method, path, badPath, bo
 
 	obj := FooStructForTimeTypeNotUnixFormat{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -983,7 +983,7 @@ func testFormBindingForTimeNotFormat(t *testing.T, method, path, badPath, body, 
 
 	obj := FooStructForTimeTypeNotFormat{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -1001,7 +1001,7 @@ func testFormBindingForTimeFailFormat(t *testing.T, method, path, badPath, body,
 
 	obj := FooStructForTimeTypeFailFormat{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -1019,7 +1019,7 @@ func testFormBindingForTimeFailLocation(t *testing.T, method, path, badPath, bod
 
 	obj := FooStructForTimeTypeFailLocation{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -1037,7 +1037,7 @@ func testFormBindingIgnoreField(t *testing.T, method, path, badPath, body, badBo
 
 	obj := FooStructForIgnoreFormTag{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -1052,7 +1052,7 @@ func testFormBindingInvalidName(t *testing.T, method, path, badPath, body, badBo
 
 	obj := InvalidNameType{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -1071,7 +1071,7 @@ func testFormBindingInvalidName2(t *testing.T, method, path, badPath, body, badB
 
 	obj := InvalidNameMapType{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -1088,7 +1088,7 @@ func testFormBindingForType(t *testing.T, method, path, badPath, body, badBody s
 	assert.Equal(t, "form", b.Name())
 
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	switch typ {
@@ -1159,7 +1159,7 @@ func testQueryBinding(t *testing.T, method, path, badPath, body, badBody string)
 
 	obj := FooBarStruct{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -1174,7 +1174,7 @@ func testQueryBindingFail(t *testing.T, method, path, badPath, body, badBody str
 
 	obj := FooStructForMapType{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -1187,7 +1187,7 @@ func testQueryBindingBoolFail(t *testing.T, method, path, badPath, body, badBody
 
 	obj := FooStructForBoolType{}
 	req := requestWithBody(method, path, body)
-	if method == "POST" {
+	if method == http.MethodPost {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
 	err := b.Bind(req, &obj)
@@ -1198,13 +1198,13 @@ func testBodyBinding(t *testing.T, b Binding, name, path, badPath, body, badBody
 	assert.Equal(t, name, b.Name())
 
 	obj := FooStruct{}
-	req := requestWithBody("POST", path, body)
+	req := requestWithBody(http.MethodPost, path, body)
 	err := b.Bind(req, &obj)
 	require.NoError(t, err)
 	assert.Equal(t, "bar", obj.Foo)
 
 	obj = FooStruct{}
-	req = requestWithBody("POST", badPath, badBody)
+	req = requestWithBody(http.MethodPost, badPath, badBody)
 	err = JSON.Bind(req, &obj)
 	require.Error(t, err)
 }
@@ -1213,19 +1213,19 @@ func testBodyBindingSlice(t *testing.T, b Binding, name, path, badPath, body, ba
 	assert.Equal(t, name, b.Name())
 
 	var obj1 []FooStruct
-	req := requestWithBody("POST", path, body)
+	req := requestWithBody(http.MethodPost, path, body)
 	err := b.Bind(req, &obj1)
 	require.NoError(t, err)
 
 	var obj2 []FooStruct
-	req = requestWithBody("POST", badPath, badBody)
+	req = requestWithBody(http.MethodPost, badPath, badBody)
 	err = JSON.Bind(req, &obj2)
 	require.Error(t, err)
 }
 
 func testBodyBindingStringMap(t *testing.T, b Binding, path, badPath, body, badBody string) {
 	obj := make(map[string]string)
-	req := requestWithBody("POST", path, body)
+	req := requestWithBody(http.MethodPost, path, body)
 	if b.Name() == "form" {
 		req.Header.Add("Content-Type", MIMEPOSTForm)
 	}
@@ -1238,13 +1238,13 @@ func testBodyBindingStringMap(t *testing.T, b Binding, path, badPath, body, badB
 
 	if badPath != "" && badBody != "" {
 		obj = make(map[string]string)
-		req = requestWithBody("POST", badPath, badBody)
+		req = requestWithBody(http.MethodPost, badPath, badBody)
 		err = b.Bind(req, &obj)
 		require.Error(t, err)
 	}
 
 	objInt := make(map[string]int)
-	req = requestWithBody("POST", path, body)
+	req = requestWithBody(http.MethodPost, path, body)
 	err = b.Bind(req, &objInt)
 	require.Error(t, err)
 }
@@ -1253,7 +1253,7 @@ func testBodyBindingUseNumber(t *testing.T, b Binding, name, path, badPath, body
 	assert.Equal(t, name, b.Name())
 
 	obj := FooStructUseNumber{}
-	req := requestWithBody("POST", path, body)
+	req := requestWithBody(http.MethodPost, path, body)
 	EnableDecoderUseNumber = true
 	err := b.Bind(req, &obj)
 	require.NoError(t, err)
@@ -1263,7 +1263,7 @@ func testBodyBindingUseNumber(t *testing.T, b Binding, name, path, badPath, body
 	assert.Equal(t, int64(123), v)
 
 	obj = FooStructUseNumber{}
-	req = requestWithBody("POST", badPath, badBody)
+	req = requestWithBody(http.MethodPost, badPath, badBody)
 	err = JSON.Bind(req, &obj)
 	require.Error(t, err)
 }
@@ -1272,7 +1272,7 @@ func testBodyBindingUseNumber2(t *testing.T, b Binding, name, path, badPath, bod
 	assert.Equal(t, name, b.Name())
 
 	obj := FooStructUseNumber{}
-	req := requestWithBody("POST", path, body)
+	req := requestWithBody(http.MethodPost, path, body)
 	EnableDecoderUseNumber = false
 	err := b.Bind(req, &obj)
 	require.NoError(t, err)
@@ -1281,7 +1281,7 @@ func testBodyBindingUseNumber2(t *testing.T, b Binding, name, path, badPath, bod
 	assert.InDelta(t, float64(123), obj.Foo, 0.01)
 
 	obj = FooStructUseNumber{}
-	req = requestWithBody("POST", badPath, badBody)
+	req = requestWithBody(http.MethodPost, badPath, badBody)
 	err = JSON.Bind(req, &obj)
 	require.Error(t, err)
 }
@@ -1293,13 +1293,13 @@ func testBodyBindingDisallowUnknownFields(t *testing.T, b Binding, path, badPath
 	}()
 
 	obj := FooStructDisallowUnknownFields{}
-	req := requestWithBody("POST", path, body)
+	req := requestWithBody(http.MethodPost, path, body)
 	err := b.Bind(req, &obj)
 	require.NoError(t, err)
 	assert.Equal(t, "bar", obj.Foo)
 
 	obj = FooStructDisallowUnknownFields{}
-	req = requestWithBody("POST", badPath, badBody)
+	req = requestWithBody(http.MethodPost, badPath, badBody)
 	err = JSON.Bind(req, &obj)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "what")
@@ -1309,13 +1309,13 @@ func testBodyBindingFail(t *testing.T, b Binding, name, path, badPath, body, bad
 	assert.Equal(t, name, b.Name())
 
 	obj := FooStruct{}
-	req := requestWithBody("POST", path, body)
+	req := requestWithBody(http.MethodPost, path, body)
 	err := b.Bind(req, &obj)
 	require.Error(t, err)
 	assert.Equal(t, "", obj.Foo)
 
 	obj = FooStruct{}
-	req = requestWithBody("POST", badPath, badBody)
+	req = requestWithBody(http.MethodPost, badPath, badBody)
 	err = JSON.Bind(req, &obj)
 	require.Error(t, err)
 }
@@ -1324,14 +1324,14 @@ func testProtoBodyBinding(t *testing.T, b Binding, name, path, badPath, body, ba
 	assert.Equal(t, name, b.Name())
 
 	obj := protoexample.Test{}
-	req := requestWithBody("POST", path, body)
+	req := requestWithBody(http.MethodPost, path, body)
 	req.Header.Add("Content-Type", MIMEPROTOBUF)
 	err := b.Bind(req, &obj)
 	require.NoError(t, err)
 	assert.Equal(t, "yes", *obj.Label)
 
 	obj = protoexample.Test{}
-	req = requestWithBody("POST", badPath, badBody)
+	req = requestWithBody(http.MethodPost, badPath, badBody)
 	req.Header.Add("Content-Type", MIMEPROTOBUF)
 	err = ProtoBuf.Bind(req, &obj)
 	require.Error(t, err)
@@ -1358,28 +1358,28 @@ func TestPlainBinding(t *testing.T) {
 	assert.Equal(t, "plain", p.Name())
 
 	var s string
-	req := requestWithBody("POST", "/", "test string")
+	req := requestWithBody(http.MethodPost, "/", "test string")
 	require.NoError(t, p.Bind(req, &s))
 	assert.Equal(t, "test string", s)
 
 	var bs []byte
-	req = requestWithBody("POST", "/", "test []byte")
+	req = requestWithBody(http.MethodPost, "/", "test []byte")
 	require.NoError(t, p.Bind(req, &bs))
 	assert.Equal(t, bs, []byte("test []byte"))
 
 	var i int
-	req = requestWithBody("POST", "/", "test fail")
+	req = requestWithBody(http.MethodPost, "/", "test fail")
 	require.Error(t, p.Bind(req, &i))
 
-	req = requestWithBody("POST", "/", "")
+	req = requestWithBody(http.MethodPost, "/", "")
 	req.Body = &failRead{}
 	require.Error(t, p.Bind(req, &s))
 
-	req = requestWithBody("POST", "/", "")
+	req = requestWithBody(http.MethodPost, "/", "")
 	require.NoError(t, p.Bind(req, nil))
 
 	var ptr *string
-	req = requestWithBody("POST", "/", "")
+	req = requestWithBody(http.MethodPost, "/", "")
 	require.NoError(t, p.Bind(req, ptr))
 }
 
@@ -1387,7 +1387,7 @@ func testProtoBodyBindingFail(t *testing.T, b Binding, name, path, badPath, body
 	assert.Equal(t, name, b.Name())
 
 	obj := protoexample.Test{}
-	req := requestWithBody("POST", path, body)
+	req := requestWithBody(http.MethodPost, path, body)
 
 	req.Body = io.NopCloser(&hook{})
 	req.Header.Add("Content-Type", MIMEPROTOBUF)
@@ -1402,7 +1402,7 @@ func testProtoBodyBindingFail(t *testing.T, b Binding, name, path, badPath, body
 	assert.Equal(t, "obj is not ProtoMessage", err.Error())
 
 	obj = protoexample.Test{}
-	req = requestWithBody("POST", badPath, badBody)
+	req = requestWithBody(http.MethodPost, badPath, badBody)
 	req.Header.Add("Content-Type", MIMEPROTOBUF)
 	err = ProtoBuf.Bind(req, &obj)
 	require.Error(t, err)

--- a/binding/multipart_form_mapping_test.go
+++ b/binding/multipart_form_mapping_test.go
@@ -116,7 +116,7 @@ func createRequestMultipartFiles(t *testing.T, files ...testFile) *http.Request 
 	err := mw.Close()
 	require.NoError(t, err)
 
-	req, err := http.NewRequest("POST", "/", &body)
+	req, err := http.NewRequest(http.MethodPost, "/", &body)
 	require.NoError(t, err)
 
 	req.Header.Set("Content-Type", MIMEMultipartPOSTForm+"; boundary="+mw.Boundary())

--- a/debug_test.go
+++ b/debug_test.go
@@ -10,6 +10,7 @@ import (
 	"html/template"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"runtime"
 	"strings"
@@ -60,7 +61,7 @@ func TestDebugPrintError(t *testing.T) {
 func TestDebugPrintRoutes(t *testing.T) {
 	re := captureOutput(t, func() {
 		SetMode(DebugMode)
-		debugPrintRoute("GET", "/path/to/route/:param", HandlersChain{func(c *Context) {}, handlerNameTest})
+		debugPrintRoute(http.MethodGet, "/path/to/route/:param", HandlersChain{func(c *Context) {}, handlerNameTest})
 		SetMode(TestMode)
 	})
 	assert.Regexp(t, `^\[GIN-debug\] GET    /path/to/route/:param     --> (.*/vendor/)?github.com/gin-gonic/gin.handlerNameTest \(2 handlers\)\n$`, re)
@@ -72,7 +73,7 @@ func TestDebugPrintRouteFunc(t *testing.T) {
 	}
 	re := captureOutput(t, func() {
 		SetMode(DebugMode)
-		debugPrintRoute("GET", "/path/to/route/:param1/:param2", HandlersChain{func(c *Context) {}, handlerNameTest})
+		debugPrintRoute(http.MethodGet, "/path/to/route/:param1/:param2", HandlersChain{func(c *Context) {}, handlerNameTest})
 		SetMode(TestMode)
 	})
 	assert.Regexp(t, `^\[GIN-debug\] GET    /path/to/route/:param1/:param2           --> (.*/vendor/)?github.com/gin-gonic/gin.handlerNameTest \(2 handlers\)\n$`, re)

--- a/deprecated_test.go
+++ b/deprecated_test.go
@@ -18,7 +18,7 @@ func TestBindWith(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := CreateTestContext(w)
 
-	c.Request, _ = http.NewRequest("POST", "/?foo=bar&bar=foo", bytes.NewBufferString("foo=unused"))
+	c.Request, _ = http.NewRequest(http.MethodPost, "/?foo=bar&bar=foo", bytes.NewBufferString("foo=unused"))
 
 	var obj struct {
 		Foo string `form:"foo"`

--- a/gin_test.go
+++ b/gin_test.go
@@ -327,31 +327,31 @@ func TestLoadHTMLFilesFuncMap(t *testing.T) {
 
 func TestAddRoute(t *testing.T) {
 	router := New()
-	router.addRoute("GET", "/", HandlersChain{func(_ *Context) {}})
+	router.addRoute(http.MethodGet, "/", HandlersChain{func(_ *Context) {}})
 
 	assert.Len(t, router.trees, 1)
-	assert.NotNil(t, router.trees.get("GET"))
-	assert.Nil(t, router.trees.get("POST"))
+	assert.NotNil(t, router.trees.get(http.MethodGet))
+	assert.Nil(t, router.trees.get(http.MethodPost))
 
-	router.addRoute("POST", "/", HandlersChain{func(_ *Context) {}})
+	router.addRoute(http.MethodPost, "/", HandlersChain{func(_ *Context) {}})
 
 	assert.Len(t, router.trees, 2)
-	assert.NotNil(t, router.trees.get("GET"))
-	assert.NotNil(t, router.trees.get("POST"))
+	assert.NotNil(t, router.trees.get(http.MethodGet))
+	assert.NotNil(t, router.trees.get(http.MethodPost))
 
-	router.addRoute("POST", "/post", HandlersChain{func(_ *Context) {}})
+	router.addRoute(http.MethodPost, "/post", HandlersChain{func(_ *Context) {}})
 	assert.Len(t, router.trees, 2)
 }
 
 func TestAddRouteFails(t *testing.T) {
 	router := New()
 	assert.Panics(t, func() { router.addRoute("", "/", HandlersChain{func(_ *Context) {}}) })
-	assert.Panics(t, func() { router.addRoute("GET", "a", HandlersChain{func(_ *Context) {}}) })
-	assert.Panics(t, func() { router.addRoute("GET", "/", HandlersChain{}) })
+	assert.Panics(t, func() { router.addRoute(http.MethodGet, "a", HandlersChain{func(_ *Context) {}}) })
+	assert.Panics(t, func() { router.addRoute(http.MethodGet, "/", HandlersChain{}) })
 
-	router.addRoute("POST", "/post", HandlersChain{func(_ *Context) {}})
+	router.addRoute(http.MethodPost, "/post", HandlersChain{func(_ *Context) {}})
 	assert.Panics(t, func() {
-		router.addRoute("POST", "/post", HandlersChain{func(_ *Context) {}})
+		router.addRoute(http.MethodPost, "/post", HandlersChain{func(_ *Context) {}})
 	})
 }
 
@@ -493,27 +493,27 @@ func TestListOfRoutes(t *testing.T) {
 
 	assert.Len(t, list, 7)
 	assertRoutePresent(t, list, RouteInfo{
-		Method:  "GET",
+		Method:  http.MethodGet,
 		Path:    "/favicon.ico",
 		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest1$",
 	})
 	assertRoutePresent(t, list, RouteInfo{
-		Method:  "GET",
+		Method:  http.MethodGet,
 		Path:    "/",
 		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest1$",
 	})
 	assertRoutePresent(t, list, RouteInfo{
-		Method:  "GET",
+		Method:  http.MethodGet,
 		Path:    "/users/",
 		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest2$",
 	})
 	assertRoutePresent(t, list, RouteInfo{
-		Method:  "GET",
+		Method:  http.MethodGet,
 		Path:    "/users/:id",
 		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest1$",
 	})
 	assertRoutePresent(t, list, RouteInfo{
-		Method:  "POST",
+		Method:  http.MethodPost,
 		Path:    "/users/:id",
 		Handler: "^(.*/vendor/)?github.com/gin-gonic/gin.handlerTest2$",
 	})
@@ -531,7 +531,7 @@ func TestEngineHandleContext(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		w := PerformRequest(r, "GET", "/")
+		w := PerformRequest(r, http.MethodGet, "/")
 		assert.Equal(t, 301, w.Code)
 	})
 }
@@ -564,7 +564,7 @@ func TestEngineHandleContextManyReEntries(t *testing.T) {
 	})
 
 	assert.NotPanics(t, func() {
-		w := PerformRequest(r, "GET", "/"+strconv.Itoa(expectValue-1)) // include 0 value
+		w := PerformRequest(r, http.MethodGet, "/"+strconv.Itoa(expectValue-1)) // include 0 value
 		assert.Equal(t, 200, w.Code)
 		assert.Equal(t, expectValue, w.Body.Len())
 	})
@@ -712,8 +712,8 @@ func TestNewOptionFunc(t *testing.T) {
 	r := New(fc)
 
 	routes := r.Routes()
-	assertRoutePresent(t, routes, RouteInfo{Path: "/test1", Method: "GET", Handler: "github.com/gin-gonic/gin.handlerTest1"})
-	assertRoutePresent(t, routes, RouteInfo{Path: "/test2", Method: "GET", Handler: "github.com/gin-gonic/gin.handlerTest2"})
+	assertRoutePresent(t, routes, RouteInfo{Path: "/test1", Method: http.MethodGet, Handler: "github.com/gin-gonic/gin.handlerTest1"})
+	assertRoutePresent(t, routes, RouteInfo{Path: "/test2", Method: http.MethodGet, Handler: "github.com/gin-gonic/gin.handlerTest2"})
 }
 
 func TestWithOptionFunc(t *testing.T) {
@@ -729,8 +729,8 @@ func TestWithOptionFunc(t *testing.T) {
 	})
 
 	routes := r.Routes()
-	assertRoutePresent(t, routes, RouteInfo{Path: "/test1", Method: "GET", Handler: "github.com/gin-gonic/gin.handlerTest1"})
-	assertRoutePresent(t, routes, RouteInfo{Path: "/test2", Method: "GET", Handler: "github.com/gin-gonic/gin.handlerTest2"})
+	assertRoutePresent(t, routes, RouteInfo{Path: "/test1", Method: http.MethodGet, Handler: "github.com/gin-gonic/gin.handlerTest1"})
+	assertRoutePresent(t, routes, RouteInfo{Path: "/test2", Method: http.MethodGet, Handler: "github.com/gin-gonic/gin.handlerTest2"})
 }
 
 type Birthday string
@@ -749,7 +749,7 @@ func TestCustomUnmarshalStruct(t *testing.T) {
 		_ = ctx.BindQuery(&request)
 		ctx.JSON(200, request.Birthday)
 	})
-	req := httptest.NewRequest("GET", "/test?birthday=2000-01-01", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test?birthday=2000-01-01", nil)
 	w := httptest.NewRecorder()
 	route.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
@@ -761,7 +761,7 @@ func TestMethodNotAllowedNoRoute(t *testing.T) {
 	g := New()
 	g.HandleMethodNotAllowed = true
 
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	resp := httptest.NewRecorder()
 	assert.NotPanics(t, func() { g.ServeHTTP(resp, req) })
 	assert.Equal(t, http.StatusNotFound, resp.Code)

--- a/logger_test.go
+++ b/logger_test.go
@@ -31,9 +31,9 @@ func TestLogger(t *testing.T) {
 	router.HEAD("/example", func(c *Context) {})
 	router.OPTIONS("/example", func(c *Context) {})
 
-	PerformRequest(router, "GET", "/example?a=100")
+	PerformRequest(router, http.MethodGet, "/example?a=100")
 	assert.Contains(t, buffer.String(), "200")
-	assert.Contains(t, buffer.String(), "GET")
+	assert.Contains(t, buffer.String(), http.MethodGet)
 	assert.Contains(t, buffer.String(), "/example")
 	assert.Contains(t, buffer.String(), "a=100")
 
@@ -41,21 +41,21 @@ func TestLogger(t *testing.T) {
 	// like integration tests because they test the whole logging process rather
 	// than individual functions.  Im not sure where these should go.
 	buffer.Reset()
-	PerformRequest(router, "POST", "/example")
+	PerformRequest(router, http.MethodPost, "/example")
 	assert.Contains(t, buffer.String(), "200")
-	assert.Contains(t, buffer.String(), "POST")
+	assert.Contains(t, buffer.String(), http.MethodPost)
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	PerformRequest(router, "PUT", "/example")
+	PerformRequest(router, http.MethodPut, "/example")
 	assert.Contains(t, buffer.String(), "200")
-	assert.Contains(t, buffer.String(), "PUT")
+	assert.Contains(t, buffer.String(), http.MethodPut)
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	PerformRequest(router, "DELETE", "/example")
+	PerformRequest(router, http.MethodDelete, "/example")
 	assert.Contains(t, buffer.String(), "200")
-	assert.Contains(t, buffer.String(), "DELETE")
+	assert.Contains(t, buffer.String(), http.MethodDelete)
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
@@ -77,9 +77,9 @@ func TestLogger(t *testing.T) {
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	PerformRequest(router, "GET", "/notfound")
+	PerformRequest(router, http.MethodGet, "/notfound")
 	assert.Contains(t, buffer.String(), "404")
-	assert.Contains(t, buffer.String(), "GET")
+	assert.Contains(t, buffer.String(), http.MethodGet)
 	assert.Contains(t, buffer.String(), "/notfound")
 }
 
@@ -95,9 +95,9 @@ func TestLoggerWithConfig(t *testing.T) {
 	router.HEAD("/example", func(c *Context) {})
 	router.OPTIONS("/example", func(c *Context) {})
 
-	PerformRequest(router, "GET", "/example?a=100")
+	PerformRequest(router, http.MethodGet, "/example?a=100")
 	assert.Contains(t, buffer.String(), "200")
-	assert.Contains(t, buffer.String(), "GET")
+	assert.Contains(t, buffer.String(), http.MethodGet)
 	assert.Contains(t, buffer.String(), "/example")
 	assert.Contains(t, buffer.String(), "a=100")
 
@@ -105,21 +105,21 @@ func TestLoggerWithConfig(t *testing.T) {
 	// like integration tests because they test the whole logging process rather
 	// than individual functions.  Im not sure where these should go.
 	buffer.Reset()
-	PerformRequest(router, "POST", "/example")
+	PerformRequest(router, http.MethodPost, "/example")
 	assert.Contains(t, buffer.String(), "200")
-	assert.Contains(t, buffer.String(), "POST")
+	assert.Contains(t, buffer.String(), http.MethodPost)
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	PerformRequest(router, "PUT", "/example")
+	PerformRequest(router, http.MethodPut, "/example")
 	assert.Contains(t, buffer.String(), "200")
-	assert.Contains(t, buffer.String(), "PUT")
+	assert.Contains(t, buffer.String(), http.MethodPut)
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	PerformRequest(router, "DELETE", "/example")
+	PerformRequest(router, http.MethodDelete, "/example")
 	assert.Contains(t, buffer.String(), "200")
-	assert.Contains(t, buffer.String(), "DELETE")
+	assert.Contains(t, buffer.String(), http.MethodDelete)
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
@@ -141,9 +141,9 @@ func TestLoggerWithConfig(t *testing.T) {
 	assert.Contains(t, buffer.String(), "/example")
 
 	buffer.Reset()
-	PerformRequest(router, "GET", "/notfound")
+	PerformRequest(router, http.MethodGet, "/notfound")
 	assert.Contains(t, buffer.String(), "404")
-	assert.Contains(t, buffer.String(), "GET")
+	assert.Contains(t, buffer.String(), http.MethodGet)
 	assert.Contains(t, buffer.String(), "/notfound")
 }
 
@@ -169,12 +169,12 @@ func TestLoggerWithFormatter(t *testing.T) {
 		)
 	}))
 	router.GET("/example", func(c *Context) {})
-	PerformRequest(router, "GET", "/example?a=100")
+	PerformRequest(router, http.MethodGet, "/example?a=100")
 
 	// output test
 	assert.Contains(t, buffer.String(), "[FORMATTER TEST]")
 	assert.Contains(t, buffer.String(), "200")
-	assert.Contains(t, buffer.String(), "GET")
+	assert.Contains(t, buffer.String(), http.MethodGet)
 	assert.Contains(t, buffer.String(), "/example")
 	assert.Contains(t, buffer.String(), "a=100")
 }
@@ -210,12 +210,12 @@ func TestLoggerWithConfigFormatting(t *testing.T) {
 		gotKeys = c.Keys
 		time.Sleep(time.Millisecond)
 	})
-	PerformRequest(router, "GET", "/example?a=100")
+	PerformRequest(router, http.MethodGet, "/example?a=100")
 
 	// output test
 	assert.Contains(t, buffer.String(), "[FORMATTER TEST]")
 	assert.Contains(t, buffer.String(), "200")
-	assert.Contains(t, buffer.String(), "GET")
+	assert.Contains(t, buffer.String(), http.MethodGet)
 	assert.Contains(t, buffer.String(), "/example")
 	assert.Contains(t, buffer.String(), "a=100")
 
@@ -225,7 +225,7 @@ func TestLoggerWithConfigFormatting(t *testing.T) {
 	assert.Equal(t, 200, gotParam.StatusCode)
 	assert.NotEmpty(t, gotParam.Latency)
 	assert.Equal(t, "20.20.20.20", gotParam.ClientIP)
-	assert.Equal(t, "GET", gotParam.Method)
+	assert.Equal(t, http.MethodGet, gotParam.Method)
 	assert.Equal(t, "/example?a=100", gotParam.Path)
 	assert.Empty(t, gotParam.ErrorMessage)
 	assert.Equal(t, gotKeys, gotParam.Keys)
@@ -239,7 +239,7 @@ func TestDefaultLogFormatter(t *testing.T) {
 		StatusCode:   200,
 		Latency:      time.Second * 5,
 		ClientIP:     "20.20.20.20",
-		Method:       "GET",
+		Method:       http.MethodGet,
 		Path:         "/",
 		ErrorMessage: "",
 		isTerm:       false,
@@ -250,7 +250,7 @@ func TestDefaultLogFormatter(t *testing.T) {
 		StatusCode:   200,
 		Latency:      time.Second * 5,
 		ClientIP:     "20.20.20.20",
-		Method:       "GET",
+		Method:       http.MethodGet,
 		Path:         "/",
 		ErrorMessage: "",
 		isTerm:       true,
@@ -260,7 +260,7 @@ func TestDefaultLogFormatter(t *testing.T) {
 		StatusCode:   200,
 		Latency:      time.Millisecond * 9876543210,
 		ClientIP:     "20.20.20.20",
-		Method:       "GET",
+		Method:       http.MethodGet,
 		Path:         "/",
 		ErrorMessage: "",
 		isTerm:       true,
@@ -271,7 +271,7 @@ func TestDefaultLogFormatter(t *testing.T) {
 		StatusCode:   200,
 		Latency:      time.Millisecond * 9876543210,
 		ClientIP:     "20.20.20.20",
-		Method:       "GET",
+		Method:       http.MethodGet,
 		Path:         "/",
 		ErrorMessage: "",
 		isTerm:       false,
@@ -292,10 +292,10 @@ func TestColorForMethod(t *testing.T) {
 		return p.MethodColor()
 	}
 
-	assert.Equal(t, blue, colorForMethod("GET"), "get should be blue")
-	assert.Equal(t, cyan, colorForMethod("POST"), "post should be cyan")
-	assert.Equal(t, yellow, colorForMethod("PUT"), "put should be yellow")
-	assert.Equal(t, red, colorForMethod("DELETE"), "delete should be red")
+	assert.Equal(t, blue, colorForMethod(http.MethodGet), "get should be blue")
+	assert.Equal(t, cyan, colorForMethod(http.MethodPost), "post should be cyan")
+	assert.Equal(t, yellow, colorForMethod(http.MethodPut), "put should be yellow")
+	assert.Equal(t, red, colorForMethod(http.MethodDelete), "delete should be red")
 	assert.Equal(t, green, colorForMethod("PATCH"), "patch should be green")
 	assert.Equal(t, magenta, colorForMethod("HEAD"), "head should be magenta")
 	assert.Equal(t, white, colorForMethod("OPTIONS"), "options should be white")
@@ -369,15 +369,15 @@ func TestErrorLogger(t *testing.T) {
 		c.String(http.StatusInternalServerError, "hola!")
 	})
 
-	w := PerformRequest(router, "GET", "/error")
+	w := PerformRequest(router, http.MethodGet, "/error")
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "{\"error\":\"this is an error\"}", w.Body.String())
 
-	w = PerformRequest(router, "GET", "/abort")
+	w = PerformRequest(router, http.MethodGet, "/abort")
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	assert.Equal(t, "{\"error\":\"no authorized\"}", w.Body.String())
 
-	w = PerformRequest(router, "GET", "/print")
+	w = PerformRequest(router, http.MethodGet, "/print")
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Equal(t, "hola!{\"error\":\"this is an error\"}", w.Body.String())
 }
@@ -389,11 +389,11 @@ func TestLoggerWithWriterSkippingPaths(t *testing.T) {
 	router.GET("/logged", func(c *Context) {})
 	router.GET("/skipped", func(c *Context) {})
 
-	PerformRequest(router, "GET", "/logged")
+	PerformRequest(router, http.MethodGet, "/logged")
 	assert.Contains(t, buffer.String(), "200")
 
 	buffer.Reset()
-	PerformRequest(router, "GET", "/skipped")
+	PerformRequest(router, http.MethodGet, "/skipped")
 	assert.Contains(t, buffer.String(), "")
 }
 
@@ -407,11 +407,11 @@ func TestLoggerWithConfigSkippingPaths(t *testing.T) {
 	router.GET("/logged", func(c *Context) {})
 	router.GET("/skipped", func(c *Context) {})
 
-	PerformRequest(router, "GET", "/logged")
+	PerformRequest(router, http.MethodGet, "/logged")
 	assert.Contains(t, buffer.String(), "200")
 
 	buffer.Reset()
-	PerformRequest(router, "GET", "/skipped")
+	PerformRequest(router, http.MethodGet, "/skipped")
 	assert.Contains(t, buffer.String(), "")
 }
 
@@ -427,11 +427,11 @@ func TestLoggerWithConfigSkipper(t *testing.T) {
 	router.GET("/logged", func(c *Context) { c.Status(http.StatusOK) })
 	router.GET("/skipped", func(c *Context) { c.Status(http.StatusNoContent) })
 
-	PerformRequest(router, "GET", "/logged")
+	PerformRequest(router, http.MethodGet, "/logged")
 	assert.Contains(t, buffer.String(), "200")
 
 	buffer.Reset()
-	PerformRequest(router, "GET", "/skipped")
+	PerformRequest(router, http.MethodGet, "/skipped")
 	assert.Contains(t, buffer.String(), "")
 }
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -35,7 +35,7 @@ func TestMiddlewareGeneralCase(t *testing.T) {
 		signature += " XX "
 	})
 	// RUN
-	w := PerformRequest(router, "GET", "/")
+	w := PerformRequest(router, http.MethodGet, "/")
 
 	// TEST
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -71,7 +71,7 @@ func TestMiddlewareNoRoute(t *testing.T) {
 		signature += " X "
 	})
 	// RUN
-	w := PerformRequest(router, "GET", "/")
+	w := PerformRequest(router, http.MethodGet, "/")
 
 	// TEST
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -108,7 +108,7 @@ func TestMiddlewareNoMethodEnabled(t *testing.T) {
 		signature += " XX "
 	})
 	// RUN
-	w := PerformRequest(router, "GET", "/")
+	w := PerformRequest(router, http.MethodGet, "/")
 
 	// TEST
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
@@ -149,7 +149,7 @@ func TestMiddlewareNoMethodDisabled(t *testing.T) {
 	})
 
 	// RUN
-	w := PerformRequest(router, "GET", "/")
+	w := PerformRequest(router, http.MethodGet, "/")
 
 	// TEST
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -175,7 +175,7 @@ func TestMiddlewareAbort(t *testing.T) {
 	})
 
 	// RUN
-	w := PerformRequest(router, "GET", "/")
+	w := PerformRequest(router, http.MethodGet, "/")
 
 	// TEST
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
@@ -196,7 +196,7 @@ func TestMiddlewareAbortHandlersChainAndNext(t *testing.T) {
 		c.Next()
 	})
 	// RUN
-	w := PerformRequest(router, "GET", "/")
+	w := PerformRequest(router, http.MethodGet, "/")
 
 	// TEST
 	assert.Equal(t, http.StatusGone, w.Code)
@@ -219,7 +219,7 @@ func TestMiddlewareFailHandlersChain(t *testing.T) {
 		signature += "C"
 	})
 	// RUN
-	w := PerformRequest(router, "GET", "/")
+	w := PerformRequest(router, http.MethodGet, "/")
 
 	// TEST
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
@@ -246,7 +246,7 @@ func TestMiddlewareWrite(t *testing.T) {
 		})
 	})
 
-	w := PerformRequest(router, "GET", "/")
+	w := PerformRequest(router, http.MethodGet, "/")
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, strings.Replace("hola\n<map><foo>bar</foo></map>{\"foo\":\"bar\"}{\"foo\":\"bar\"}event:test\ndata:message\n\n", " ", "", -1), strings.Replace(w.Body.String(), " ", "", -1))

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -26,7 +26,7 @@ func TestPanicClean(t *testing.T) {
 		panic("Oupps, Houston, we have a problem")
 	})
 	// RUN
-	w := PerformRequest(router, "GET", "/recovery",
+	w := PerformRequest(router, http.MethodGet, "/recovery",
 		header{
 			Key:   "Host",
 			Value: "www.google.com",
@@ -56,7 +56,7 @@ func TestPanicInHandler(t *testing.T) {
 		panic("Oupps, Houston, we have a problem")
 	})
 	// RUN
-	w := PerformRequest(router, "GET", "/recovery")
+	w := PerformRequest(router, http.MethodGet, "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, buffer.String(), "panic recovered")
@@ -67,7 +67,7 @@ func TestPanicInHandler(t *testing.T) {
 	// Debug mode prints the request
 	SetMode(DebugMode)
 	// RUN
-	w = PerformRequest(router, "GET", "/recovery")
+	w = PerformRequest(router, http.MethodGet, "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, buffer.String(), "GET /recovery")
@@ -84,7 +84,7 @@ func TestPanicWithAbort(t *testing.T) {
 		panic("Oupps, Houston, we have a problem")
 	})
 	// RUN
-	w := PerformRequest(router, "GET", "/recovery")
+	w := PerformRequest(router, http.MethodGet, "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -135,7 +135,7 @@ func TestPanicWithBrokenPipe(t *testing.T) {
 				panic(e)
 			})
 			// RUN
-			w := PerformRequest(router, "GET", "/recovery")
+			w := PerformRequest(router, http.MethodGet, "/recovery")
 			// TEST
 			assert.Equal(t, expectCode, w.Code)
 			assert.Contains(t, strings.ToLower(buf.String()), expectMsg)
@@ -156,7 +156,7 @@ func TestCustomRecoveryWithWriter(t *testing.T) {
 		panic("Oupps, Houston, we have a problem")
 	})
 	// RUN
-	w := PerformRequest(router, "GET", "/recovery")
+	w := PerformRequest(router, http.MethodGet, "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, buffer.String(), "panic recovered")
@@ -167,7 +167,7 @@ func TestCustomRecoveryWithWriter(t *testing.T) {
 	// Debug mode prints the request
 	SetMode(DebugMode)
 	// RUN
-	w = PerformRequest(router, "GET", "/recovery")
+	w = PerformRequest(router, http.MethodGet, "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, buffer.String(), "GET /recovery")
@@ -191,7 +191,7 @@ func TestCustomRecovery(t *testing.T) {
 		panic("Oupps, Houston, we have a problem")
 	})
 	// RUN
-	w := PerformRequest(router, "GET", "/recovery")
+	w := PerformRequest(router, http.MethodGet, "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, buffer.String(), "panic recovered")
@@ -202,7 +202,7 @@ func TestCustomRecovery(t *testing.T) {
 	// Debug mode prints the request
 	SetMode(DebugMode)
 	// RUN
-	w = PerformRequest(router, "GET", "/recovery")
+	w = PerformRequest(router, http.MethodGet, "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, buffer.String(), "GET /recovery")
@@ -226,7 +226,7 @@ func TestRecoveryWithWriterWithCustomRecovery(t *testing.T) {
 		panic("Oupps, Houston, we have a problem")
 	})
 	// RUN
-	w := PerformRequest(router, "GET", "/recovery")
+	w := PerformRequest(router, http.MethodGet, "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, buffer.String(), "panic recovered")
@@ -237,7 +237,7 @@ func TestRecoveryWithWriterWithCustomRecovery(t *testing.T) {
 	// Debug mode prints the request
 	SetMode(DebugMode)
 	// RUN
-	w = PerformRequest(router, "GET", "/recovery")
+	w = PerformRequest(router, http.MethodGet, "/recovery")
 	// TEST
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, buffer.String(), "GET /recovery")

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -369,7 +369,7 @@ func TestRenderXML(t *testing.T) {
 }
 
 func TestRenderRedirect(t *testing.T) {
-	req, err := http.NewRequest("GET", "/test-redirect", nil)
+	req, err := http.NewRequest(http.MethodGet, "/test-redirect", nil)
 	require.NoError(t, err)
 
 	data1 := Redirect{

--- a/routes_test.go
+++ b/routes_test.go
@@ -523,8 +523,8 @@ func TestRouteNotAllowedEnabled3(t *testing.T) {
 	w := PerformRequest(router, http.MethodPut, "/path")
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 	allowed := w.Header().Get("Allow")
-	assert.Contains(t, allowed, "GET")
-	assert.Contains(t, allowed, "POST")
+	assert.Contains(t, allowed, http.MethodGet)
+	assert.Contains(t, allowed, http.MethodPost)
 }
 
 func TestRouteNotAllowedDisabled(t *testing.T) {
@@ -557,7 +557,7 @@ func TestRouterNotFoundWithRemoveExtraSlash(t *testing.T) {
 		{"/nope", http.StatusNotFound, ""}, // NotFound
 	}
 	for _, tr := range testRoutes {
-		w := PerformRequest(router, "GET", tr.route)
+		w := PerformRequest(router, http.MethodGet, tr.route)
 		assert.Equal(t, tr.code, w.Code)
 		if w.Code != http.StatusNotFound {
 			assert.Equal(t, tr.location, fmt.Sprint(w.Header().Get("Location")))
@@ -786,6 +786,6 @@ func TestEngineHandleMethodNotAllowedCornerCase(t *testing.T) {
 	v1.GET("/orgs/:id", handlerTest1)
 	v1.DELETE("/orgs/:id", handlerTest1)
 
-	w := PerformRequest(r, "GET", "/base/v1/user/groups")
+	w := PerformRequest(r, http.MethodGet, "/base/v1/user/groups")
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -29,7 +29,7 @@ type testStruct struct {
 }
 
 func (t *testStruct) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	assert.Equal(t.T, "POST", req.Method)
+	assert.Equal(t.T, http.MethodPost, req.Method)
 	assert.Equal(t.T, "/path", req.URL.Path)
 	w.WriteHeader(http.StatusInternalServerError)
 	fmt.Fprint(w, "hello")
@@ -39,17 +39,17 @@ func TestWrap(t *testing.T) {
 	router := New()
 	router.POST("/path", WrapH(&testStruct{t}))
 	router.GET("/path2", WrapF(func(w http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, "GET", req.Method)
+		assert.Equal(t, http.MethodGet, req.Method)
 		assert.Equal(t, "/path2", req.URL.Path)
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, "hola!")
 	}))
 
-	w := PerformRequest(router, "POST", "/path")
+	w := PerformRequest(router, http.MethodPost, "/path")
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Equal(t, "hello", w.Body.String())
 
-	w = PerformRequest(router, "GET", "/path2")
+	w = PerformRequest(router, http.MethodGet, "/path2")
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, "hola!", w.Body.String())
 }
@@ -119,13 +119,13 @@ func TestBindMiddleware(t *testing.T) {
 		called = true
 		value = c.MustGet(BindKey).(*bindTestStruct)
 	})
-	PerformRequest(router, "GET", "/?foo=hola&bar=10")
+	PerformRequest(router, http.MethodGet, "/?foo=hola&bar=10")
 	assert.True(t, called)
 	assert.Equal(t, "hola", value.Foo)
 	assert.Equal(t, 10, value.Bar)
 
 	called = false
-	PerformRequest(router, "GET", "/?foo=hola&bar=1")
+	PerformRequest(router, http.MethodGet, "/?foo=hola&bar=1")
 	assert.False(t, called)
 
 	assert.Panics(t, func() {


### PR DESCRIPTION
This PR enables and fixes [usestdlibvars](https://github.com/sashamelentyev/usestdlibvars) linter that detect the possibility to use variables/constants from the Go standard library.