### PR TITLE
fix: case insensitive comparison for RawPath to resolve incorrect rPath assignments

### DIFF
--- a/routes_test.go
+++ b/routes_test.go
@@ -789,3 +789,19 @@ func TestEngineHandleMethodNotAllowedCornerCase(t *testing.T) {
 	w := PerformRequest(r, "GET", "/base/v1/user/groups")
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
+
+// Test the fix for https://github.com/gin-gonic/gin/issues/4034
+func TestLowercasePercentEncodePath(t *testing.T) {
+	route := Default()
+	route.UnescapePathValues = false
+	route.UseRawPath = true
+	route.RedirectFixedPath = true
+	route.GET("/핫", func(ctx *Context) {
+		ctx.JSON(200, H{})
+	})
+	req := httptest.NewRequest("GET", "/%ed%95%ab", nil)
+	w := httptest.NewRecorder()
+	route.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "{}", w.Body.String())
+}


### PR DESCRIPTION
Go's standard url package doesn't assign `RawPath` if the escaped path is the same as the original path.
But for lower case escaped path, like "%ed%95%ab", it assumes they are different from escaped original path "%ED%95%AB".
So it assigns `RawPath` to "%ed%95%ab".
This has already been discussed in Go, but they said it works as intended.
[net/http: RawPath shows inconsistent case-sensitive behaviour with percentage-encoded Unicode URI strings](https://github.com/golang/go/issues/33596)

Golang Gin checks the length of `URL.RawPath` when `engine.UseRawPath` is enabled.
If a percentage-encoded lower-case path is given, it redirects indefinitely. (Issue: #4034)

So add checks that compare `RawPath` and `EscapedPath()` with case insensitivity.