### PR TITLE
fix(time): binding time with empty value

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -399,6 +399,10 @@ func setTimeField(val string, structField reflect.StructField, value reflect.Val
 
 	switch tf := strings.ToLower(timeFormat); tf {
 	case "unix", "unixnano":
+		if val == "" {
+			val = "0"
+		}
+
 		tv, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return err

--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -397,12 +397,13 @@ func setTimeField(val string, structField reflect.StructField, value reflect.Val
 		timeFormat = time.RFC3339
 	}
 
+	if val == "" {
+		value.Set(reflect.ValueOf(time.Time{}))
+		return nil
+	}
+
 	switch tf := strings.ToLower(timeFormat); tf {
 	case "unix", "unixnano":
-		if val == "" {
-			val = "0"
-		}
-
 		tv, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return err
@@ -415,11 +416,6 @@ func setTimeField(val string, structField reflect.StructField, value reflect.Val
 
 		t := time.Unix(tv/int64(d), tv%int64(d))
 		value.Set(reflect.ValueOf(t))
-		return nil
-	}
-
-	if val == "" {
-		value.Set(reflect.ValueOf(time.Time{}))
 		return nil
 	}
 

--- a/binding/form_mapping_test.go
+++ b/binding/form_mapping_test.go
@@ -183,12 +183,13 @@ func TestMapFormWithTag(t *testing.T) {
 
 func TestMappingTime(t *testing.T) {
 	var s struct {
-		Time         time.Time
-		LocalTime    time.Time `time_format:"2006-01-02"`
-		ZeroValue    time.Time
-		ZeroUnixTime time.Time `time_format:"unix"` // see issue #4098
-		CSTTime      time.Time `time_format:"2006-01-02" time_location:"Asia/Shanghai"`
-		UTCTime      time.Time `time_format:"2006-01-02" time_utc:"1"`
+		Time             time.Time
+		LocalTime        time.Time `time_format:"2006-01-02"`
+		ZeroValue        time.Time
+		ZeroUnixTime     time.Time `time_format:"unix"`
+		ZeroUnixNanoTime time.Time `time_format:"unixnano"`
+		CSTTime          time.Time `time_format:"2006-01-02" time_location:"Asia/Shanghai"`
+		UTCTime          time.Time `time_format:"2006-01-02" time_utc:"1"`
 	}
 
 	var err error
@@ -196,12 +197,13 @@ func TestMappingTime(t *testing.T) {
 	require.NoError(t, err)
 
 	err = mapForm(&s, map[string][]string{
-		"Time":         {"2019-01-20T16:02:58Z"},
-		"LocalTime":    {"2019-01-20"},
-		"ZeroValue":    {},
-		"ZeroUnixTime": {},
-		"CSTTime":      {"2019-01-20"},
-		"UTCTime":      {"2019-01-20"},
+		"Time":             {"2019-01-20T16:02:58Z"},
+		"LocalTime":        {"2019-01-20"},
+		"ZeroValue":        {},
+		"ZeroUnixTime":     {},
+		"ZeroUnixNanoTime": {},
+		"CSTTime":          {"2019-01-20"},
+		"UTCTime":          {"2019-01-20"},
 	})
 	require.NoError(t, err)
 
@@ -210,6 +212,7 @@ func TestMappingTime(t *testing.T) {
 	assert.Equal(t, "2019-01-19 23:00:00 +0000 UTC", s.LocalTime.UTC().String())
 	assert.Equal(t, "0001-01-01 00:00:00 +0000 UTC", s.ZeroValue.String())
 	assert.Equal(t, "1970-01-01 00:00:00 +0000 UTC", s.ZeroUnixTime.UTC().String())
+	assert.Equal(t, "1970-01-01 00:00:00 +0000 UTC", s.ZeroUnixNanoTime.UTC().String())
 	assert.Equal(t, "2019-01-20 00:00:00 +0800 CST", s.CSTTime.String())
 	assert.Equal(t, "2019-01-19 16:00:00 +0000 UTC", s.CSTTime.UTC().String())
 	assert.Equal(t, "2019-01-20 00:00:00 +0000 UTC", s.UTCTime.String())

--- a/binding/form_mapping_test.go
+++ b/binding/form_mapping_test.go
@@ -183,11 +183,12 @@ func TestMapFormWithTag(t *testing.T) {
 
 func TestMappingTime(t *testing.T) {
 	var s struct {
-		Time      time.Time
-		LocalTime time.Time `time_format:"2006-01-02"`
-		ZeroValue time.Time
-		CSTTime   time.Time `time_format:"2006-01-02" time_location:"Asia/Shanghai"`
-		UTCTime   time.Time `time_format:"2006-01-02" time_utc:"1"`
+		Time         time.Time
+		LocalTime    time.Time `time_format:"2006-01-02"`
+		ZeroValue    time.Time
+		ZeroUnixTime time.Time `time_format:"unix"` // see issue #4098
+		CSTTime      time.Time `time_format:"2006-01-02" time_location:"Asia/Shanghai"`
+		UTCTime      time.Time `time_format:"2006-01-02" time_utc:"1"`
 	}
 
 	var err error
@@ -195,11 +196,12 @@ func TestMappingTime(t *testing.T) {
 	require.NoError(t, err)
 
 	err = mapForm(&s, map[string][]string{
-		"Time":      {"2019-01-20T16:02:58Z"},
-		"LocalTime": {"2019-01-20"},
-		"ZeroValue": {},
-		"CSTTime":   {"2019-01-20"},
-		"UTCTime":   {"2019-01-20"},
+		"Time":         {"2019-01-20T16:02:58Z"},
+		"LocalTime":    {"2019-01-20"},
+		"ZeroValue":    {},
+		"ZeroUnixTime": {},
+		"CSTTime":      {"2019-01-20"},
+		"UTCTime":      {"2019-01-20"},
 	})
 	require.NoError(t, err)
 
@@ -207,6 +209,7 @@ func TestMappingTime(t *testing.T) {
 	assert.Equal(t, "2019-01-20 00:00:00 +0100 CET", s.LocalTime.String())
 	assert.Equal(t, "2019-01-19 23:00:00 +0000 UTC", s.LocalTime.UTC().String())
 	assert.Equal(t, "0001-01-01 00:00:00 +0000 UTC", s.ZeroValue.String())
+	assert.Equal(t, "1970-01-01 00:00:00 +0000 UTC", s.ZeroUnixTime.UTC().String())
 	assert.Equal(t, "2019-01-20 00:00:00 +0800 CST", s.CSTTime.String())
 	assert.Equal(t, "2019-01-19 16:00:00 +0000 UTC", s.CSTTime.UTC().String())
 	assert.Equal(t, "2019-01-20 00:00:00 +0000 UTC", s.UTCTime.String())


### PR DESCRIPTION
Fixes: #4098 
In `setTimeField`, when the string `val` is empty and the `timeFormat` is `unix` or `unixnano`, an error occurs due to `strconv.ParseInt` handling empty values. We can handle this by filling it with a zero value before parsing.

- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

