### PR TITLE
feat(logger):color latency

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -277,11 +277,11 @@ func TestDefaultLogFormatter(t *testing.T) {
 		isTerm:       false,
 	}
 
-	assert.Equal(t, "[GIN] 2018/12/07 - 09:11:42 | 200 |            5s |     20.20.20.20 | GET      \"/\"\n", defaultLogFormatter(termFalseParam))
-	assert.Equal(t, "[GIN] 2018/12/07 - 09:11:42 | 200 |    2743h29m3s |     20.20.20.20 | GET      \"/\"\n", defaultLogFormatter(termFalseLongDurationParam))
+	assert.Equal(t, "[GIN] 2018/12/07 - 09:11:42 | 200 |       5s |     20.20.20.20 | GET      \"/\"\n", defaultLogFormatter(termFalseParam))
+	assert.Equal(t, "[GIN] 2018/12/07 - 09:11:42 | 200 | 2743h29m0s |     20.20.20.20 | GET      \"/\"\n", defaultLogFormatter(termFalseLongDurationParam))
 
-	assert.Equal(t, "[GIN] 2018/12/07 - 09:11:42 |\x1b[97;42m 200 \x1b[0m|            5s |     20.20.20.20 |\x1b[97;44m GET     \x1b[0m \"/\"\n", defaultLogFormatter(termTrueParam))
-	assert.Equal(t, "[GIN] 2018/12/07 - 09:11:42 |\x1b[97;42m 200 \x1b[0m|    2743h29m3s |     20.20.20.20 |\x1b[97;44m GET     \x1b[0m \"/\"\n", defaultLogFormatter(termTrueLongDurationParam))
+	assert.Equal(t, "[GIN] 2018/12/07 - 09:11:42 |\x1b[97;42m 200 \x1b[0m|\x1b[97;41m       5s \x1b[0m|     20.20.20.20 |\x1b[97;44m GET     \x1b[0m \"/\"\n", defaultLogFormatter(termTrueParam))
+	assert.Equal(t, "[GIN] 2018/12/07 - 09:11:42 |\x1b[97;42m 200 \x1b[0m|\x1b[97;41m 2743h29m0s \x1b[0m|     20.20.20.20 |\x1b[97;44m GET     \x1b[0m \"/\"\n", defaultLogFormatter(termTrueLongDurationParam))
 }
 
 func TestColorForMethod(t *testing.T) {
@@ -315,6 +315,23 @@ func TestColorForStatus(t *testing.T) {
 	assert.Equal(t, white, colorForStatus(http.StatusMovedPermanently), "3xx should be white")
 	assert.Equal(t, yellow, colorForStatus(http.StatusNotFound), "4xx should be yellow")
 	assert.Equal(t, red, colorForStatus(2), "other things should be red")
+}
+
+func TestColorForLatency(t *testing.T) {
+	colorForLantency := func(latency time.Duration) string {
+		p := LogFormatterParams{
+			Latency: latency,
+		}
+		return p.LatencyColor()
+	}
+
+	assert.Equal(t, white, colorForLantency(time.Duration(0)), "0 should be white")
+	assert.Equal(t, white, colorForLantency(time.Millisecond*20), "20ms should be white")
+	assert.Equal(t, green, colorForLantency(time.Millisecond*150), "150ms should be green")
+	assert.Equal(t, cyan, colorForLantency(time.Millisecond*250), "250ms should be cyan")
+	assert.Equal(t, yellow, colorForLantency(time.Millisecond*600), "600ms should be yellow")
+	assert.Equal(t, magenta, colorForLantency(time.Millisecond*1500), "1.5s should be magenta")
+	assert.Equal(t, red, colorForLantency(time.Second*3), "other things should be red")
 }
 
 func TestResetColor(t *testing.T) {


### PR DESCRIPTION
add colored latency to log output based on latency thresholds
## Summary

This PR introduces a new function `LatencyColor` in the logger middleware of the Gin framework. This function assigns colors to log output based on the request latency, improving the readability and visual identification of performance bottlenecks.

## Motivation

The current logging system outputs latency as plain text, making it difficult to quickly identify performance issues at a glance. By adding color-coded latency information, developers can more easily distinguish between different latency levels, aiding in faster debugging and performance monitoring.

## Changes

1. **Add LatencyColor Function**: Implement a function that returns a color string based on the request latency.


![image](https://github.com/user-attachments/assets/10589e6b-ff8b-4397-b283-91312c71ce41)

