### PR TITLE
ci: add go version 1.24 to GitHub Actions

### DIFF
--- a/.github/workflows/gin.yml
+++ b/.github/workflows/gin.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ["1.22", "1.23"]
+        go: ["1.22", "1.23", "1.24"]
         test-tags:
           ["", "-tags nomsgpack", '-tags "sonic avx"', "-tags go_json", "-race"]
         include:


### PR DESCRIPTION
- Add Go version `1.24` to the GitHub Actions workflow


