### PR TITLE
fix: move fiximports to goimports section in golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters:
     - durationcheck
     - errcheck
     - errorlint
-    - exportloopref
+    - copyloopvar
     - gci
     - gofmt
     - goimports
@@ -39,10 +39,11 @@ linters-settings:
   perfsprint:
     err-error: true
     errorf: true
-    fiximports: true
     int-conversion: true
     sprintf1: true
     strconcat: true
+  goimports:
+    fiximports: true
   testifylint:
     enable-all: true
 


### PR DESCRIPTION
https://github.com/gin-gonic/gin/actions/runs/13537431187/job/37831527911?pr=4167

`fiximports` property is not allowed under the `perfsprint`, move `fiximports` to `goimports` section.
`exportloopref` linter has been deprecated since Go1.22, replace `exportloopref` with `copyloopvar`.