### PR TITLE
add a thread safe context that can be used downstream and mutated

### DIFF
--- a/test_helpers.go
+++ b/test_helpers.go
@@ -10,9 +10,12 @@ import "net/http"
 // This is useful for tests that need to set up a new Gin engine instance
 // along with a context, for example, to test middleware that doesn't depend on
 // specific routes. The ResponseWriter `w` is used to initialize the context's writer.
-func CreateTestContext(w http.ResponseWriter) (c *Context, r *Engine) {
+func CreateTestContext(w http.ResponseWriter, opts ...func(c *Context)) (c *Context, r *Engine) {
 	r = New()
 	c = r.allocateContext(0)
+	for _, opt := range opts {
+		opt(c)
+	}
 	c.reset()
 	c.writermem.reset(w)
 	return


### PR DESCRIPTION
It's currently unsafe to use `c.Request.Context` from the `*gin.Context` to pass to downstream functions AND do any mutations to the `c.Request.Context`.  
Even when you do `c.Request = c.Request.WithContext(...)` you'll end up with the go race detector flagging the unsafe reading of the `c.Request` and writing to `c.Request`.

And even when you're not really doing anything `.WithContext` there's a chance that the context pool causes the race detector to get angry


However it would be really nice to be able to put values into the `*gin.Context` with `context.WithValue()` in a thread-safe way that allows downstream usage of `*gin.Context` as `context.Context` to access those values.  
For example, an auth middleware adding some debugging /loggin related values with `context.WithValue()` will not be lost along the way, or adding a `otel.Tracer` to the context with additional options etc.
 

Making all the places where gin touches `c.Request` thread-safe with a lock would be a significant undertaking and would have an impact on performance (probably talking about nano seconds, but still non zero impact).  

With the MR we're adding a thread-safe way to carry around and mutate a `context.Context` inside `*gin.Context` without having to protect `c.Request`.  

In practice the `c.Request.Context` isn't going to be very interesting to wrap anyway, so loosing that as the "root" context probably isn't a issue for anyone.  
It's trivial to make the root `InternalContext` the `c.Request.Context` when we do `.reset()` (if `ContextWithFallback` is enabled), but I wanted to keep this MR as small as possible.  
And it would have one quirky downside that if someone uses `UseInternalContext` and does something like `c.Request = c.Request.WithContext(...)` then it wouldn't have any effect.


There's a couple of mentions of issues around this before:
  - https://github.com/gin-gonic/gin/issues/4117
  - https://github.com/gin-gonic/gin/issues/3931
  - https://github.com/gin-gonic/gin/issues/1118
