### PR TITLE
refactor(context): modify SaveUploadedFile

### DIFF
--- a/context.go
+++ b/context.go
@@ -684,15 +684,15 @@ func (c *Context) SaveUploadedFile(file *multipart.FileHeader, dst string, perm 
 	}
 	defer src.Close()
 
-	if len(perm) <= 0 {
-		perm = append(perm, 0o750)
+	var mode os.FileMode = 0o750
+	if len(perm) > 0 {
+		mode = perm[0]
 	}
-
-	if err = os.MkdirAll(filepath.Dir(dst), perm[0]); err != nil {
+	dir := filepath.Dir(dst)
+	if err = os.MkdirAll(dir, mode); err != nil {
 		return err
 	}
-
-	if err = os.Chmod(filepath.Dir(dst), perm[0]); err != nil {
+	if err = os.Chmod(dir, mode); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Optimization 1: Use filepath.Dir once instead.
Optimization 2: Modify the acquisition of mode, which will be more intuitive.
Question: I think it is unnecessary to use os.Chmod every time here, but I don't have a better way to solve it, because it need add theos.Stat function and what should you do if you encounter different permissions