### PR TITLE
fix(binding): prevent duplicate decoding and add validation in decodeToml

### DIFF
--- a/binding/toml.go
+++ b/binding/toml.go
@@ -31,5 +31,5 @@ func decodeToml(r io.Reader, obj any) error {
 	if err := decoder.Decode(obj); err != nil {
 		return err
 	}
-	return decoder.Decode(obj)
+	return validate(obj)
 }


### PR DESCRIPTION
```go
// binding/toml.go:29
func decodeToml(r io.Reader, obj any) error {
	decoder := toml.NewDecoder(r)
	if err := decoder.Decode(obj); err != nil {
		return err
	}
	return decoder.Decode(obj)
}
```
- Removed the redundant second call to `decoder.Decode(obj)` which caused incorrect behavior.
- Added a `validate(obj)` function to ensure proper validation of decoded TOML data.
- Fixes potential issues with data integrity caused by duplicate decoding.