### PR TITLE
docs: fix comment with AI

### DIFF
--- a/binding/protobuf.go
+++ b/binding/protobuf.go
@@ -34,7 +34,7 @@ func (protobufBinding) BindBody(body []byte, obj any) error {
 	if err := proto.Unmarshal(body, msg); err != nil {
 		return err
 	}
-	// Here it's same to return validate(obj), but util now we can't add
+	// Here it's same to return validate(obj), but until now we can't add
 	// `binding:""` to the struct which automatically generate by gen-proto
 	return nil
 	// return validate(obj)

--- a/ginS/gins.go
+++ b/ginS/gins.go
@@ -154,7 +154,7 @@ func RunUnix(file string) (err error) {
 
 // RunFd attaches the router to a http.Server and starts listening and serving HTTP requests
 // through the specified file descriptor.
-// Note: the method will block the calling goroutine indefinitely unless on error happens.
+// Note: the method will block the calling goroutine indefinitely unless an error happens.
 func RunFd(fd int) (err error) {
 	return engine().RunFd(fd)
 }


### PR DESCRIPTION
I used AI to find ​two spelling errors in words  😂

- "on error"  -> "an error"
<img width="471" alt="image" src="https://github.com/user-attachments/assets/9da2e0c0-fbdf-41fc-9aa7-90d34133f6f9" />

- "util now" -> "until now"
<img width="542" alt="image" src="https://github.com/user-attachments/assets/ce833a89-0936-4d7f-ad14-d4a4c128f33d" />
