### PR TITLE
fix render: write content length in Data.Render

### DIFF
--- a/render/data.go
+++ b/render/data.go
@@ -4,7 +4,10 @@
 
 package render
 
-import "net/http"
+import (
+	"net/http"
+	"strconv"
+)
 
 // Data contains ContentType and bytes data.
 type Data struct {
@@ -15,6 +18,9 @@ type Data struct {
 // Render (Data) writes data with custom ContentType.
 func (r Data) Render(w http.ResponseWriter) (err error) {
 	r.WriteContentType(w)
+	if len(r.Data) > 0 {
+		w.Header().Set("Content-Length", strconv.Itoa(len(r.Data)))
+	}
 	_, err = w.Write(r.Data)
 	return
 }

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -421,7 +421,7 @@ func TestRenderData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "#!PNG some raw data", w.Body.String())
 	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
-	assert.Equal(t, "", w.Header().Get("Content-Length"))
+	assert.Equal(t, "19", w.Header().Get("Content-Length"))
 }
 
 func TestRenderDataContentLength(t *testing.T) {


### PR DESCRIPTION
This PR fixes an issue where the `Content-Length` header is not set correctly for large data written by ResponseWriter.Write. According to the Go documentation, the `Content-Length` header is automatically added only for small data sizes. For larger data, it is necessary to explicitly set the `Content-Length` header to ensure proper behavior.