### PR TITLE
Replace deprecated CloseNotify with Request.Context().Done() for better client disconnect detection

### DIFF
--- a/context.go
+++ b/context.go
@@ -1208,7 +1208,7 @@ func (c *Context) SSEvent(name string, message any) {
 // indicates "Is client disconnected in middle of stream"
 func (c *Context) Stream(step func(w io.Writer) bool) bool {
 	w := c.Writer
-	clientGone := w.CloseNotify()
+	clientGone := c.Request.Context().Done()
 	for {
 		select {
 		case <-clientGone:


### PR DESCRIPTION
This PR updates the Context.Stream function to use Request.Context().Done() instead of the deprecated CloseNotify() method.

**Changes:**
Replace w.CloseNotify() with c.Request.Context().Done() for client disconnect signal.

**Motivation:**
CloseNotify is deprecated and unreliable in modern HTTP/2 environments or when the connection passes through certain proxies or gateways.

Request.Context().Done() provides a more robust and standard-compliant way to detect client disconnects.

**Impact:**
This change improves compatibility and correctness, especially when using HTTP/2 or reverse proxies.

Let me know if you'd prefer backward compatibility logic for older Gin versions or if further changes are needed.



