### PR TITLE
fix: sonic on arm64

### DIFF
--- a/.github/workflows/gin.yml
+++ b/.github/workflows/gin.yml
@@ -38,7 +38,7 @@ jobs:
           [
             "",
             "-tags nomsgpack",
-            '--ldflags="-checklinkname=0" -tags "sonic avx"',
+            '--ldflags="-checklinkname=0" -tags sonic',
             "-tags go_json",
             "-race",
           ]

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -84,10 +84,10 @@ go build -tags=jsoniter .
 go build -tags=go_json .
 ```
 
-[sonic](https://github.com/bytedance/sonic) (you have to ensure that your cpu supports avx instruction.)
+[sonic](https://github.com/bytedance/sonic)
 
 ```sh
-$ go build -tags="sonic avx" .
+$ go build -tags=sonic .
 ```
 
 ### Build without `MsgPack` rendering feature

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gin-gonic/gin
 go 1.23.0
 
 require (
-	github.com/bytedance/sonic v1.13.1
+	github.com/bytedance/sonic v1.13.2
 	github.com/gin-contrib/sse v1.1.0
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/goccy/go-json v0.10.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bytedance/sonic v1.13.1 h1:Jyd5CIvdFnkOWuKXr+wm4Nyk2h0yAFsr8ucJgEasO3g=
-github.com/bytedance/sonic v1.13.1/go.mod h1:o68xyaF9u2gvVBuGHPlUVCy+ZfmNNO5ETf1+KgkJhz4=
+github.com/bytedance/sonic v1.13.2 h1:8/H1FempDZqC4VqjptGo14QQlJx8VdZJegxs6wwfqpQ=
+github.com/bytedance/sonic v1.13.2/go.mod h1:o68xyaF9u2gvVBuGHPlUVCy+ZfmNNO5ETf1+KgkJhz4=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.4 h1:ZWCw4stuXUsn1/+zQDqeE7JKP+QO47tz7QCNan80NzY=
 github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-//go:build !jsoniter && !go_json && !(sonic && avx && (linux || windows || darwin) && amd64)
+//go:build !jsoniter && !go_json && !(sonic && (linux || windows || darwin))
 
 package json
 

--- a/internal/json/sonic.go
+++ b/internal/json/sonic.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT style
 // license that can be found in the LICENSE file.
 
-//go:build sonic && avx && (linux || windows || darwin) && amd64
+//go:build sonic && (linux || windows || darwin)
 
 package json
 


### PR DESCRIPTION
Closes #4233

- Drop `amd64` build constraint
- Drop redundant `avx` build tag
