### PR TITLE
test(internal/fs): fix test function name

### DIFF
--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -18,7 +18,7 @@ func (m *mockFileSystem) Open(name string) (http.File, error) {
 	return m.open(name)
 }
 
-func TesFileSystem_Open(t *testing.T) {
+func TestFileSystem_Open(t *testing.T) {
 	var testFile *os.File
 	mockFS := &mockFileSystem{
 		open: func(name string) (http.File, error) {


### PR DESCRIPTION
Fixes the test function name `TesFileSystem_Open`, which caused the **success** case for `FileSystem.Open` to be ignored during test runs.

![CleanShot 2025-05-11 at 22 55 08@2x](https://github.com/user-attachments/assets/a525ab4a-6eb5-4871-87a1-ff07c0ca7c2d)


- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

