### PR TITLE
perf(all): use strings.Cut to replace strings.SplitN

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -74,9 +74,9 @@ func CustomRecoveryWithWriter(out io.Writer, handle RecoveryFunc) HandlerFunc {
 					httpRequest, _ := httputil.DumpRequest(c.Request, false)
 					headers := strings.Split(string(httpRequest), "\r\n")
 					for idx, header := range headers {
-						current := strings.Split(header, ":")
-						if current[0] == "Authorization" {
-							headers[idx] = current[0] + ": *"
+						key, _, _ := strings.Cut(header, ":")
+						if key == "Authorization" {
+							headers[idx] = key + ": *"
 						}
 					}
 					headersToStr := strings.Join(headers, "\r\n")

--- a/tree.go
+++ b/tree.go
@@ -234,7 +234,7 @@ walk:
 				// Wildcard conflict
 				pathSeg := path
 				if n.nType != catchAll {
-					pathSeg = strings.SplitN(pathSeg, "/", 2)[0]
+					pathSeg, _, _ = strings.Cut(pathSeg, "/")
 				}
 				prefix := fullPath[:strings.Index(fullPath, pathSeg)] + n.path
 				panic("'" + pathSeg +
@@ -358,7 +358,7 @@ func (n *node) insertChild(path string, fullPath string, handlers HandlersChain)
 		if len(n.path) > 0 && n.path[len(n.path)-1] == '/' {
 			pathSeg := ""
 			if len(n.children) != 0 {
-				pathSeg = strings.SplitN(n.children[0].path, "/", 2)[0]
+				pathSeg, _, _ = strings.Cut(n.children[0].path, "/")
 			}
 			panic("catch-all wildcard '" + path +
 				"' in new path '" + fullPath +


### PR DESCRIPTION
Replaced `strings.SplitN` with `strings.Cut` to reduce memory allocations and improve performance.   
`strings.Cut` also simplifies the code, making it more readable and maintainable.  

Below is my local test code.  

recovery_test.go
```go
package gin

import (
	"strings"
	"testing"
)

func headersStr(s string) string {
	headers := strings.Split(s, "\r\n")
	for idx, header := range headers {
		current := strings.Split(header, ":")
		if current[0] == "Authorization" {
			headers[idx] = current[0] + ": *"
		}
	}
	headersToStr := strings.Join(headers, "\r\n")
	return headersToStr
}

func headersStrOptimized(s string) string {
	headers := strings.Split(s, "\r\n")
	for idx, header := range headers {
		key, _, _ := strings.Cut(header, ":")
		if key == "Authorization" {
			headers[idx] = key + ": *"
		}
	}
	headersToStr := strings.Join(headers, "\r\n")
	return headersToStr
}

var h string

func Benchmark_headersStr(b *testing.B) {
	s := "Authorization: jwt\r\nCookie: k=v"

	b.Run("original", func(b *testing.B) {
		b.ReportAllocs()
		var r string
		for i := 0; i < b.N; i++ {
			r = headersStr(s)
		}
		h = r
	})

	b.Run("optimized", func(b *testing.B) {
		b.ReportAllocs()
		var r string
		for i := 0; i < b.N; i++ {
			r = headersStrOptimized(s)
		}
		h = r
	})
}
```

benchmark output  
```text
goos: darwin
goarch: amd64
pkg: testgolang/gin
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
Benchmark_headersStr
Benchmark_headersStr/original
Benchmark_headersStr/original-8         	 4339076	       278.2 ns/op	     144 B/op	       5 allocs/op
Benchmark_headersStr/optimized
Benchmark_headersStr/optimized-8        	 6661995	       187.9 ns/op	      80 B/op	       3 allocs/op
PASS

Process finished with the exit code 0
```

tree_test.go
```go
package gin

import (
	"strings"
	"testing"
)

func path(p string) string {
	return strings.SplitN(p, "/", 2)[0]
}

func pathOptimized(p string) string {
	pathSeg, _, _ := strings.Cut(p, "/")
	return pathSeg
}

var seg string

func Benchmark_path(b *testing.B) {
	p := "a/b/c"

	b.Run("original", func(b *testing.B) {
		b.ReportAllocs()
		var r string
		for i := 0; i < b.N; i++ {
			r = path(p)
		}
		seg = r
	})

	b.Run("optimized", func(b *testing.B) {
		b.ReportAllocs()
		var r string
		for i := 0; i < b.N; i++ {
			r = pathOptimized(p)
		}
		seg = r
	})
}
```

benchmark output  
```text
goos: darwin
goarch: amd64
pkg: testgolang/gin
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
Benchmark_path
Benchmark_path/original
Benchmark_path/original-8         	30028994	        38.97 ns/op	      32 B/op	       1 allocs/op
Benchmark_path/optimized
Benchmark_path/optimized-8        	158330317	         7.403 ns/op	       0 B/op	       0 allocs/op
PASS

Process finished with the exit code 0
```