### PR TITLE
Revert "fix(time): binding time with empty value"

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -397,11 +397,6 @@ func setTimeField(val string, structField reflect.StructField, value reflect.Val
 		timeFormat = time.RFC3339
 	}
 
-	if val == "" {
-		value.Set(reflect.ValueOf(time.Time{}))
-		return nil
-	}
-
 	switch tf := strings.ToLower(timeFormat); tf {
 	case "unix", "unixmilli", "unixmicro", "unixnano":
 		tv, err := strconv.ParseInt(val, 10, 64)
@@ -422,6 +417,11 @@ func setTimeField(val string, structField reflect.StructField, value reflect.Val
 		}
 
 		value.Set(reflect.ValueOf(t))
+		return nil
+	}
+
+	if val == "" {
+		value.Set(reflect.ValueOf(time.Time{}))
 		return nil
 	}
 

--- a/binding/form_mapping_test.go
+++ b/binding/form_mapping_test.go
@@ -183,13 +183,11 @@ func TestMapFormWithTag(t *testing.T) {
 
 func TestMappingTime(t *testing.T) {
 	var s struct {
-		Time             time.Time
-		LocalTime        time.Time `time_format:"2006-01-02"`
-		ZeroValue        time.Time
-		ZeroUnixTime     time.Time `time_format:"unix"`
-		ZeroUnixNanoTime time.Time `time_format:"unixnano"`
-		CSTTime          time.Time `time_format:"2006-01-02" time_location:"Asia/Shanghai"`
-		UTCTime          time.Time `time_format:"2006-01-02" time_utc:"1"`
+		Time      time.Time
+		LocalTime time.Time `time_format:"2006-01-02"`
+		ZeroValue time.Time
+		CSTTime   time.Time `time_format:"2006-01-02" time_location:"Asia/Shanghai"`
+		UTCTime   time.Time `time_format:"2006-01-02" time_utc:"1"`
 	}
 
 	var err error
@@ -197,13 +195,11 @@ func TestMappingTime(t *testing.T) {
 	require.NoError(t, err)
 
 	err = mapForm(&s, map[string][]string{
-		"Time":             {"2019-01-20T16:02:58Z"},
-		"LocalTime":        {"2019-01-20"},
-		"ZeroValue":        {},
-		"ZeroUnixTime":     {},
-		"ZeroUnixNanoTime": {},
-		"CSTTime":          {"2019-01-20"},
-		"UTCTime":          {"2019-01-20"},
+		"Time":      {"2019-01-20T16:02:58Z"},
+		"LocalTime": {"2019-01-20"},
+		"ZeroValue": {},
+		"CSTTime":   {"2019-01-20"},
+		"UTCTime":   {"2019-01-20"},
 	})
 	require.NoError(t, err)
 
@@ -211,8 +207,6 @@ func TestMappingTime(t *testing.T) {
 	assert.Equal(t, "2019-01-20 00:00:00 +0100 CET", s.LocalTime.String())
 	assert.Equal(t, "2019-01-19 23:00:00 +0000 UTC", s.LocalTime.UTC().String())
 	assert.Equal(t, "0001-01-01 00:00:00 +0000 UTC", s.ZeroValue.String())
-	assert.Equal(t, "1970-01-01 00:00:00 +0000 UTC", s.ZeroUnixTime.UTC().String())
-	assert.Equal(t, "1970-01-01 00:00:00 +0000 UTC", s.ZeroUnixNanoTime.UTC().String())
 	assert.Equal(t, "2019-01-20 00:00:00 +0800 CST", s.CSTTime.String())
 	assert.Equal(t, "2019-01-19 16:00:00 +0000 UTC", s.CSTTime.UTC().String())
 	assert.Equal(t, "2019-01-20 00:00:00 +0000 UTC", s.UTCTime.String())


### PR DESCRIPTION
Reverts gin-gonic/gin#4103