### PR TITLE
perf: optimize path parsing using strings.Count

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -5,19 +5,12 @@
 package gin
 
 import (
-	"bytes"
 	"net/url"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 
 	"github.com/gin-gonic/gin/internal/bytesconv"
-)
-
-var (
-	strColon = []byte(":")
-	strStar  = []byte("*")
-	strSlash = []byte("/")
 )
 
 // Param is a single URL parameter, consisting of a key and a value.
@@ -85,16 +78,13 @@ func (n *node) addChild(child *node) {
 }
 
 func countParams(path string) uint16 {
-	var n uint16
-	s := bytesconv.StringToBytes(path)
-	n += uint16(bytes.Count(s, strColon))
-	n += uint16(bytes.Count(s, strStar))
-	return n
+	colons := strings.Count(path, ":")
+	stars := strings.Count(path, "*")
+	return uint16(colons + stars)
 }
 
 func countSections(path string) uint16 {
-	s := bytesconv.StringToBytes(path)
-	return uint16(bytes.Count(s, strSlash))
+	return uint16(strings.Count(path, "/"))
 }
 
 type nodeType uint8


### PR DESCRIPTION
Refactored `countParams` and `countSections` to use `strings.Count` instead of converting strings to byte slices and using `bytes.Count`. This simplifies the code and results in a slight performance improvement.

Below is my local test code.  

tree.go
```go
package gin

import (
	"bytes"
	"net/url"
	"strings"
	"unicode"
	"unicode/utf8"

	"github.com/gin-gonic/gin/internal/bytesconv"
)

var (
	strColon = []byte(":")
	strStar  = []byte("*")
	strSlash = []byte("/")
)

func countParams(path string) uint16 {
	var n uint16
	s := bytesconv.StringToBytes(path)
	n += uint16(bytes.Count(s, strColon))
	n += uint16(bytes.Count(s, strStar))
	return n
}

func countParamsOptimized(path string) uint16 {
	colons := strings.Count(path, ":")
	stars := strings.Count(path, "*")
	return uint16(colons + stars)
}

func countSections(path string) uint16 {
	s := bytesconv.StringToBytes(path)
	return uint16(bytes.Count(s, strSlash))
}

func countSectionsOptimized(path string) uint16 {
	return uint16(strings.Count(path, "/"))
}
```

benchmark output  
```text
goos: darwin
goarch: amd64
pkg: github.com/gin-gonic/gin
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
Benchmark_countParams
Benchmark_countParams/original
Benchmark_countParams/original-8         	88666104	        12.36 ns/op	       0 B/op	       0 allocs/op
Benchmark_countParams/optimized
Benchmark_countParams/optimized-8        	94042611	        11.48 ns/op	       0 B/op	       0 allocs/op
PASS

Process finished with the exit code 0
```

```text
goos: darwin
goarch: amd64
pkg: github.com/gin-gonic/gin
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
Benchmark_countSections
Benchmark_countSections/original
Benchmark_countSections/original-8         	224172283	         5.353 ns/op	       0 B/op	       0 allocs/op
Benchmark_countSections/optimized
Benchmark_countSections/optimized-8        	243922398	         4.663 ns/op	       0 B/op	       0 allocs/op
PASS

Process finished with the exit code 0
```