### PR TITLE
test(context): add cleanup for uploaded file in SaveUploadedFile test

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -173,6 +173,9 @@ func TestSaveUploadedFileWithPermission(t *testing.T) {
 	assert.Equal(t, "permission_test", f.Filename)
 	var mode fs.FileMode = 0o755
 	require.NoError(t, c.SaveUploadedFile(f, "permission_test", mode))
+	t.Cleanup(func() {
+		assert.NoError(t, os.Remove("permission_test"))
+	})
 	info, err := os.Stat(filepath.Dir("permission_test"))
 	require.NoError(t, err)
 	assert.Equal(t, info.Mode().Perm(), mode)


### PR DESCRIPTION
<img width="534" alt="image" src="https://github.com/user-attachments/assets/e94fd283-1723-47c7-ab81-a1593ab2c969" />

After the unit tests are executed, clean up the test artifacts.