### PR TITLE
refactor: replace interface{} with any in type declarations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,11 @@ formatters:
     - gofmt
     - gofumpt
     - goimports
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: 'interface{}'
+          replacement: 'any'
   exclusions:
     generated: lax
     paths:

--- a/binding/plain.go
+++ b/binding/plain.go
@@ -15,7 +15,7 @@ func (plainBinding) Name() string {
 	return "plain"
 }
 
-func (plainBinding) Bind(req *http.Request, obj interface{}) error {
+func (plainBinding) Bind(req *http.Request, obj any) error {
 	all, err := io.ReadAll(req.Body)
 	if err != nil {
 		return err

--- a/debug.go
+++ b/debug.go
@@ -25,7 +25,7 @@ func IsDebugging() bool {
 var DebugPrintRouteFunc func(httpMethod, absolutePath, handlerName string, nuHandlers int)
 
 // DebugPrintFunc indicates debug log output format.
-var DebugPrintFunc func(format string, values ...interface{})
+var DebugPrintFunc func(format string, values ...any)
 
 func debugPrintRoute(httpMethod, absolutePath string, handlers HandlersChain) {
 	if IsDebugging() {

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -608,7 +608,7 @@ func TestRenderReaderNoContentLength(t *testing.T) {
 }
 
 func TestRenderWriteError(t *testing.T) {
-	data := []interface{}{"value1", "value2"}
+	data := []any{"value1", "value2"}
 	prefix := "my-prefix:"
 	r := SecureJSON{Data: data, Prefix: prefix}
 	ew := &errorWriter{


### PR DESCRIPTION
- Update golangci.yml to use `any` instead of `interface{}` in gofmt
- Modify debug.go, plain.go, and render_test.go to use `any` type
- Improve code readability and follow modern Go conventions