### PR TITLE
perf(recover): replace bytes with strings in function for better performance

### DIFF
--- a/recovery_test.go
+++ b/recovery_test.go
@@ -90,14 +90,14 @@ func TestPanicWithAbort(t *testing.T) {
 
 func TestSource(t *testing.T) {
 	bs := source(nil, 0)
-	assert.Equal(t, dunno, bs)
+	assert.Equal(t, dunnoBytes, bs)
 
 	in := [][]byte{
 		[]byte("Hello world."),
 		[]byte("Hi, gin.."),
 	}
 	bs = source(in, 10)
-	assert.Equal(t, dunno, bs)
+	assert.Equal(t, dunnoBytes, bs)
 
 	bs = source(in, 1)
 	assert.Equal(t, []byte("Hello world."), bs)


### PR DESCRIPTION
Below is my local test code.  

recover/original.go
```go
package recover

import (
    "bytes"
    "fmt"
    "os"
    "runtime"
)

var (
    dunno     = []byte("???")
    centerDot = []byte("·")
    dot       = []byte(".")
    slash     = []byte("/")
)

// stack returns a nicely formatted stack frame, skipping skip frames.
func stack(skip int) []byte {
    buf := new(bytes.Buffer) // the returned data
    // As we loop, we open files and read them. These variables record the currently
    // loaded file.
    var lines [][]byte
    var lastFile string
    for i := skip; ; i++ { // Skip the expected number of frames
        pc, file, line, ok := runtime.Caller(i)
        if !ok {
            break
        }
        // Print this much at least.  If we can't find the source, it won't show.
        fmt.Fprintf(buf, "%s:%d (0x%x)\n", file, line, pc)
        if file != lastFile {
            data, err := os.ReadFile(file)
            if err != nil {
                continue
            }
            lines = bytes.Split(data, []byte{'\n'})
            lastFile = file
        }
        fmt.Fprintf(buf, "\t%s: %s\n", function(pc), source(lines, line))
    }
    return buf.Bytes()
}

// source returns a space-trimmed slice of the n'th line.
func source(lines [][]byte, n int) []byte {
    n-- // in stack trace, lines are 1-indexed but our array is 0-indexed
    if n < 0 || n >= len(lines) {
        return dunno
    }
    return bytes.TrimSpace(lines[n])
}

// function returns, if possible, the name of the function containing the PC.
func function(pc uintptr) []byte {
    fn := runtime.FuncForPC(pc)
    if fn == nil {
        return dunno
    }
    name := []byte(fn.Name())
    // The name includes the path name to the package, which is unnecessary
    // since the file name is already included.  Plus, it has center dots.
    // That is, we see
    //    runtime/debug.*T·ptrmethod
    // and want
    //    *T.ptrmethod
    // Also the package path might contain dot (e.g. code.google.com/...),
    // so first eliminate the path prefix
    if lastSlash := bytes.LastIndex(name, slash); lastSlash >= 0 {
        name = name[lastSlash+1:]
    }
    if period := bytes.Index(name, dot); period >= 0 {
        name = name[period+1:]
    }
    name = bytes.ReplaceAll(name, centerDot, dot)
    return name
}
```

recover/optimized.go
```go
package recover

import (
    "bytes"
    "fmt"
    "os"
    "runtime"
    "strings"
)

const dunno1 = "???"

// stack returns a nicely formatted stack frame, skipping skip frames.
func stack1(skip int) []byte {
    buf := new(bytes.Buffer) // the returned data
    // As we loop, we open files and read them. These variables record the currently
    // loaded file.
    var lines [][]byte
    var lastFile string
    for i := skip; ; i++ { // Skip the expected number of frames
        pc, file, line, ok := runtime.Caller(i)
        if !ok {
            break
        }
        // Print this much at least.  If we can't find the source, it won't show.
        fmt.Fprintf(buf, "%s:%d (0x%x)\n", file, line, pc)
        if file != lastFile {
            data, err := os.ReadFile(file)
            if err != nil {
                continue
            }
            lines = bytes.Split(data, []byte{'\n'})
            lastFile = file
        }
        fmt.Fprintf(buf, "\t%s: %s\n", function1(pc), source(lines, line))
    }
    return buf.Bytes()
}

// function returns, if possible, the name of the function containing the PC.
func function1(pc uintptr) string {
    fn := runtime.FuncForPC(pc)
    if fn == nil {
        return dunno1
    }
    name := fn.Name()
    // The name includes the path name to the package, which is unnecessary
    // since the file name is already included.  Plus, it has center dots.
    // That is, we see
    //    runtime/debug.*T·ptrmethod
    // and want
    //    *T.ptrmethod
    // Also the package path might contain dot (e.g. code.google.com/...),
    // so first eliminate the path prefix
    if lastSlash := strings.LastIndexByte(name, '/'); lastSlash >= 0 {
        name = name[lastSlash+1:]
    }
    if period := strings.IndexByte(name, '.'); period >= 0 {
        name = name[period+1:]
    }
    name = strings.ReplaceAll(name, "·", ".")
    return name
}
```

recover/function_name.go
```go
package recover

import (
    "bytes"
    "strings"
)

func fnName(nameStr string) []byte {
    name := []byte(nameStr)
    if lastSlash := bytes.LastIndex(name, slash); lastSlash >= 0 {
        name = name[lastSlash+1:]
    }
    if period := bytes.Index(name, dot); period >= 0 {
        name = name[period+1:]
    }
    name = bytes.ReplaceAll(name, centerDot, dot)
    return name
}

func fnName1(name string) string {
    if lastSlash := strings.LastIndexByte(name, '/'); lastSlash >= 0 {
        name = name[lastSlash+1:]
    }
    if period := strings.IndexByte(name, '.'); period >= 0 {
        name = name[period+1:]
    }
    name = strings.ReplaceAll(name, "·", ".")
    return name
}
```

recover/stack_test.go
```go
package recover

import (
    "runtime"
    "testing"
)

func BenchmarkFnName(b *testing.B) {
    name := "a·b.c/d"

    b.Run("original", func(b *testing.B) {
        b.ReportAllocs()

        for i := 0; i < b.N; i++ {
            fnName(name)
        }
    })

    b.Run("optimized", func(b *testing.B) {
        b.ReportAllocs()

        for i := 0; i < b.N; i++ {
            fnName1(name)
        }
    })
}

func BenchmarkFunction(b *testing.B) {
    pc, _, _, _ := runtime.Caller(2)

    b.Run("original", func(b *testing.B) {
        b.ReportAllocs()

        for i := 0; i < b.N; i++ {
            _ = function(pc)
        }
    })

    b.Run("optimized", func(b *testing.B) {
        b.ReportAllocs()

        for i := 0; i < b.N; i++ {
            _ = function1(pc)
        }
    })
}

func BenchmarkStack(b *testing.B) {
    b.Run("original", func(b *testing.B) {
        b.ReportAllocs()

        for i := 0; i < b.N; i++ {
            _ = stack(2)
        }
    })

    b.Run("optimized", func(b *testing.B) {
        b.ReportAllocs()

        for i := 0; i < b.N; i++ {
            _ = stack1(2)
        }
    })
}
```

benchmark output
```text
goos: darwin
goarch: arm64
pkg: test_code/test_gin/recover
cpu: Apple M3 Pro
BenchmarkFnName
BenchmarkFnName/original
BenchmarkFnName/original-11         	38319324	        29.97 ns/op	      16 B/op	       2 allocs/op
BenchmarkFnName/optimized
BenchmarkFnName/optimized-11        	160470892	         7.158 ns/op	       0 B/op	       0 allocs/op
BenchmarkFunction
BenchmarkFunction/original
BenchmarkFunction/original-11       	16994358	        71.61 ns/op	      40 B/op	       2 allocs/op
BenchmarkFunction/optimized
BenchmarkFunction/optimized-11      	28404208	        40.54 ns/op	       0 B/op	       0 allocs/op
BenchmarkStack
BenchmarkStack/original
BenchmarkStack/original-11          	   18630	     67586 ns/op	  146613 B/op	      43 allocs/op
BenchmarkStack/optimized
BenchmarkStack/optimized-11         	   17376	     61093 ns/op	  146483 B/op	      37 allocs/op
PASS

Process finished with the exit code 0
```

