### PR TITLE
perf: use textproto.TrimString for HTTP header parsing to improve performance

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"net"
 	"net/http"
+	"net/textproto"
 	"os"
 	"path"
 	"regexp"
@@ -475,7 +476,7 @@ func (engine *Engine) validateHeader(header string) (clientIP string, valid bool
 	}
 	items := strings.Split(header, ",")
 	for i := len(items) - 1; i >= 0; i-- {
-		ipStr := strings.TrimSpace(items[i])
+		ipStr := textproto.TrimString(items[i])
 		ip := net.ParseIP(ipStr)
 		if ip == nil {
 			break

--- a/utils.go
+++ b/utils.go
@@ -7,6 +7,7 @@ package gin
 import (
 	"encoding/xml"
 	"net/http"
+	"net/textproto"
 	"os"
 	"path"
 	"reflect"
@@ -107,7 +108,7 @@ func parseAccept(acceptHeader string) []string {
 		if i := strings.IndexByte(part, ';'); i > 0 {
 			part = part[:i]
 		}
-		if part = strings.TrimSpace(part); part != "" {
+		if part = textproto.TrimString(part); part != "" {
 			out = append(out, part)
 		}
 	}


### PR DESCRIPTION
Replaced `strings.TrimSpace` with `textproto.TrimString` in HTTP header parsing functions to
improve performance and better align with HTTP spec. `textproto.TrimString` trims only ASCII
whitespace, which is sufficient and more efficient for HTTP headers like X-Forwarded-For and Accept.
