### PR TITLE
refactor(internal/bytesconv): replace rand usage with crypto/rand and rand.New

### DIFF
--- a/internal/bytesconv/bytesconv_test.go
+++ b/internal/bytesconv/bytesconv_test.go
@@ -6,6 +6,7 @@ package bytesconv
 
 import (
 	"bytes"
+	cRand "crypto/rand"
 	"math/rand"
 	"strings"
 	"testing"
@@ -30,7 +31,10 @@ func rawStrToBytes(s string) []byte {
 func TestBytesToString(t *testing.T) {
 	data := make([]byte, 1024)
 	for i := 0; i < 100; i++ {
-		rand.Read(data)
+		_, err := cRand.Read(data)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if rawBytesToStr(data) != BytesToString(data) {
 			t.Fatal("don't match")
 		}
@@ -44,7 +48,7 @@ const (
 	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
 )
 
-var src = rand.NewSource(time.Now().UnixNano())
+var src = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 func RandStringBytesMaskImprSrcSB(n int) string {
 	sb := strings.Builder{}


### PR DESCRIPTION
This commit refactors random usage to follow current best practices in Go 1.20+:

- Replaced usage of `math/rand.Read`, which is deprecated, with `crypto/rand.Read`.
  As per the deprecation notice, `crypto/rand.Read` is more appropriate for almost all use cases.

- Replaced `rand.NewSource(time.Now().UnixNano())` with `rand.New(rand.NewSource(time.Now().UnixNano()))`.
  `rand.NewSource` returns a bare Source which lacks convenience methods like `Intn`, `Float64`, etc.
  Wrapping it with `rand.New` provides a complete and idiomatic `*rand.Rand` object.
