### PR TITLE
docs(test): improved GoDoc in test_helpers.go 

### DIFF
--- a/test_helpers.go
+++ b/test_helpers.go
@@ -6,7 +6,10 @@ package gin
 
 import "net/http"
 
-// CreateTestContext returns a fresh engine and context for testing purposes
+// CreateTestContext returns a fresh Engine and a Context associated with it.
+// This is useful for tests that need to set up a new Gin engine instance
+// along with a context, for example, to test middleware that doesn't depend on
+// specific routes. The ResponseWriter `w` is used to initialize the context's writer.
 func CreateTestContext(w http.ResponseWriter) (c *Context, r *Engine) {
 	r = New()
 	c = r.allocateContext(0)
@@ -15,7 +18,11 @@ func CreateTestContext(w http.ResponseWriter) (c *Context, r *Engine) {
 	return
 }
 
-// CreateTestContextOnly returns a fresh context base on the engine for testing purposes
+// CreateTestContextOnly returns a fresh Context associated with the provided Engine `r`.
+// This is useful for tests that operate on an existing, possibly pre-configured,
+// Gin engine instance and need a new context for it.
+// The ResponseWriter `w` is used to initialize the context's writer.
+// The context is allocated with the `maxParams` setting from the provided engine.
 func CreateTestContextOnly(w http.ResponseWriter, r *Engine) (c *Context) {
 	c = r.allocateContext(r.maxParams)
 	c.reset()


### PR DESCRIPTION
## Expected Effect
I have made it clearer when and how to use these helper functions by making the GoDoc comments a bit more detailed.

## Changes
### CreateTestContext:
comments from “Returns a new engine and context for testing purposes” to "Useful for tests that require setting up a new Gin engine instance and its associated context. For example, when testing middleware that does not depend on a specific route." We have made this more specific with

### CreateTestContextOnly:
Comment was changed from “Returns a new context based on the engine for testing purposes” to “Useful for tests that run on an existing, possibly preconfigured, Gin engine instance and need a new context for it.” We have made this more specific.
Also, added the information that “Contexts are allocated from the provided engine with the maxParams setting.” to clarify the behavior regarding the allocateContext argument.

fixed https://github.com/gin-gonic/gin/issues/4269
