### PR TITLE
feat: add new function to get engine from Context type

### DIFF
--- a/context.go
+++ b/context.go
@@ -93,6 +93,14 @@ type Context struct {
 	sameSite http.SameSite
 }
 
+// Get Engine from Context to handle contexts
+func (c *Context) GetEngine() *Engine {
+	if c.engine == nil {
+		panic("context engine is nil")
+	}
+	return c.engine
+}
+
 /************************************/
 /********** CONTEXT CREATION ********/
 /************************************/


### PR DESCRIPTION
This change resolves #4267 by adding option to get engine from context.

Signed-off-by: Youssef Ayman <youssef.ayman992003@gmail.com>