### PR TITLE
refactor function joinPaths and isAscii in utils.go

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -114,13 +114,6 @@ func parseAccept(acceptHeader string) []string {
 	return out
 }
 
-func lastChar(str string) uint8 {
-	if str == "" {
-		panic("The length of the string can't be 0")
-	}
-	return str[len(str)-1]
-}
-
 func nameOfFunction(f any) string {
 	return runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
 }
@@ -131,7 +124,7 @@ func joinPaths(absolutePath, relativePath string) string {
 	}
 
 	finalPath := path.Join(absolutePath, relativePath)
-	if lastChar(relativePath) == '/' && lastChar(finalPath) != '/' {
+	if strings.HasSuffix(relativePath, "/") && !strings.HasSuffix(finalPath, "/") {
 		return finalPath + "/"
 	}
 	return finalPath
@@ -155,10 +148,7 @@ func resolveAddress(addr []string) string {
 
 // https://stackoverflow.com/questions/53069040/checking-a-string-contains-only-ascii-characters
 func isASCII(s string) bool {
-	for i := 0; i < len(s); i++ {
-		if s[i] > unicode.MaxASCII {
-			return false
-		}
-	}
-	return true
+	return !strings.ContainsFunc(s, func(r rune) bool {
+		return r > unicode.MaxASCII
+	})
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -54,12 +54,6 @@ func TestWrap(t *testing.T) {
 	assert.Equal(t, "hola!", w.Body.String())
 }
 
-func TestLastChar(t *testing.T) {
-	assert.Equal(t, uint8('a'), lastChar("hola"))
-	assert.Equal(t, uint8('s'), lastChar("adios"))
-	assert.Panics(t, func() { lastChar("") })
-}
-
 func TestParseAccept(t *testing.T) {
 	parts := parseAccept("text/html , application/xhtml+xml,application/xml;q=0.9,  */* ;q=0.8")
 	assert.Len(t, parts, 4)


### PR DESCRIPTION
I would suggest some improvements to further improve robustness and readability

##Proposal
### Improve robustness of joinPaths function
Currently, the joinPaths function uses a homebrew lastChar function to determine if a path ends with a trailing slash. lastChar is a potential risk because it panics when passed an empty string. Replacing this logic with strings.HasSuffix, which is safer and clearer in intent, improves robustness and readability. 
This change also eliminates the need for the lastChar function, 
making the code base simpler.


### Simplify isASCII functions
The current isASCII function is implemented using a for loop; it can be rewritten to be more modern and concise using strings.ContainsFunc, available in Go 1.19 and later. is safe.


### Delete unnecessary tests
In conjunction with the removal of the lastChar function, we have also removed the associated test in utils_test.go.