### PR TITLE
Prevention of Hijack() runtime panics

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -6,6 +6,7 @@ package gin
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -15,6 +16,8 @@ const (
 	noWritten     = -1
 	defaultStatus = http.StatusOK
 )
+
+var errHijackAlreadyWritten = errors.New("gin: response already written")
 
 // ResponseWriter ...
 type ResponseWriter interface {
@@ -106,6 +109,9 @@ func (w *responseWriter) Written() bool {
 
 // Hijack implements the http.Hijacker interface.
 func (w *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if w.Written() {
+		return nil, nil, errHijackAlreadyWritten
+	}
 	if w.size < 0 {
 		w.size = 0
 	}

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -174,11 +174,12 @@ func TestResponseWriterHijackAfterWrite(t *testing.T) {
 			require.NoError(t, tc.action(w), "unexpected error during pre-hijack action")
 
 			_, _, hijackErr := w.Hijack()
-			assert.ErrorIs(t, hijackErr, tc.expectError, "unexpected error from Hijack()")
+			require.ErrorIs(t, hijackErr, tc.expectError, "unexpected error from Hijack()")
 			assert.Equal(t, tc.expectHijack, hijacker.hijacked, "unexpected hijacker.hijacked state")
 			assert.Equal(t, tc.expectWritten, w.Written(), "unexpected w.Written() state")
 		})
-	}}
+	}
+}
 
 func TestResponseWriterFlush(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -5,6 +5,8 @@
 package gin
 
 import (
+	"bufio"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -122,6 +124,45 @@ func TestResponseWriterHijack(t *testing.T) {
 	})
 
 	w.Flush()
+}
+
+type mockHijacker struct {
+	*httptest.ResponseRecorder
+	hijacked bool
+}
+
+func (m *mockHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	m.hijacked = true
+	return nil, nil, nil
+}
+
+func TestResponseWriterHijackAfterWrite(t *testing.T) {
+	// Test case 1: Hijack before writing
+	hijacker := &mockHijacker{ResponseRecorder: httptest.NewRecorder()}
+	writer := &responseWriter{}
+	writer.reset(hijacker)
+	w := ResponseWriter(writer)
+
+	_, _, err := w.Hijack()
+	require.NoError(t, err)
+	assert.True(t, hijacker.hijacked, "Hijack should be called")
+	assert.True(t, w.Written(), "Written() should be true after Hijack")
+
+	// Test case 2: Hijack after writing
+	hijacker2 := &mockHijacker{ResponseRecorder: httptest.NewRecorder()}
+	writer2 := &responseWriter{}
+	writer2.reset(hijacker2)
+	w2 := ResponseWriter(writer2)
+
+	_, err = w2.Write([]byte("test"))
+	require.NoError(t, err)
+	assert.True(t, w2.Written(), "Written() should be true after Write")
+
+	// Now, try to hijack
+	_, _, err = w2.Hijack()
+	require.Error(t, err)
+	assert.Equal(t, errHijackAlreadyWritten, err, "Hijack after write should return errHijackAlreadyWritten")
+	assert.False(t, hijacker2.hijacked, "Hijack should not be called after write")
 }
 
 func TestResponseWriterFlush(t *testing.T) {


### PR DESCRIPTION
## Proposal

The current implementation of the Hijack() method allows it to be called even after the response body has already been written to the client;
Go's internal implementation of http.Server is designed so that calling `Hijack ()` after `Write()` or `WriteHeader()` has been called is designed to return an error,
and the current Gin implementation differs from this.

Because of this difference,
some implementations of the underlying http.ResponseWriter may experience unexpected panics if Hijack() is called at an unintended time.

Therefore, we suggest changing the Hijack() method to check at the beginning of the method to see if the response has already been written
 and return a clear and descriptive error if it has.

## Changes
### Definition of `errHijackAlreadyWritten`:
- Define an explicit error variable to return when `Hijack()` fails.

### Update `Hijack()` method:
- At the beginning of the method, call `w.Written()` to see if the response has already been written.
- If it has already been written, return an `errHijackAlreadyWritten` error and stop further execution.