### PR TITLE
Fixed version number discrepancy

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -13,7 +13,7 @@ import (
 	"sync/atomic"
 )
 
-const ginSupportMinGoVer = 21
+const ginSupportMinGoVer = 23
 
 // IsDebugging returns true if the framework is running in debug mode.
 // Use SetMode(gin.ReleaseMode) to disable debug mode.


### PR DESCRIPTION
## Fix mismatch between Go version check logic and warning message

### Problem

There is a mismatch between the Go version check logic and the warning message shown to users:

- Constant: `const ginSupportMinGoVer = 21`
- Message: `"[WARNING] Now Gin requires Go 1.23+\n"`

As a result, users running Go 1.21 or 1.22 cannot see the warning, even though the message states that 1.23+ is required.
## Cause
The logic in `debugPrintWARNINGDefault()`:

```go
func debugPrintWARNINGDefault() {
	if v, e := getMinVer(runtime.Version()); e == nil && v < ginSupportMinGoVer {
		debugPrint(`[WARNING] Now Gin requires Go 1.23+.

`)
```
With ginSupportMinGoVer = 21, however, users on Go 1.21 (v = 21) or 1.22 (v = 22) don't trigger the warning (v < 21 is false).
## Fix
Update the constant ginSupportMinGoVer to 23 to match the warning message indicating that Go 1.23+ is required.

This ensures users running Go versions below 1.23 will properly receive the warning,
aligning behavior with messaging.