### PR TITLE
fix: remove impossible case

### DIFF
--- a/mode.go
+++ b/mode.go
@@ -65,7 +65,7 @@ func SetMode(value string) {
 	}
 
 	switch value {
-	case DebugMode, "":
+	case DebugMode:
 		atomic.StoreInt32(&ginMode, debugCode)
 	case ReleaseMode:
 		atomic.StoreInt32(&ginMode, releaseCode)


### PR DESCRIPTION
If `value` is null, it will be set to `test` or `debug` so it doesn't need to catch "" case anymore.