### PR TITLE
refactor(ginS): use sync.OnceValue to simplify engine function

### DIFF
--- a/ginS/gins.go
+++ b/ginS/gins.go
@@ -12,17 +12,9 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-var (
-	once           sync.Once
-	internalEngine *gin.Engine
-)
-
-func engine() *gin.Engine {
-	once.Do(func() {
-		internalEngine = gin.Default()
-	})
-	return internalEngine
-}
+var engine = sync.OnceValue(func() *gin.Engine {
+	return gin.Default()
+})
 
 // LoadHTMLGlob is a wrapper for Engine.LoadHTMLGlob.
 func LoadHTMLGlob(pattern string) {


### PR DESCRIPTION
Replacing sync.Once with sync.OnceValue can reduce 
the number of global variables and lines of code, 
and this approach is recommended in the Go source code.

https://go-review.googlesource.com/c/go/+/672235