### PR TITLE
fix: suppress http.ErrAbortHandler in recover

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -68,6 +68,12 @@ func CustomRecoveryWithWriter(out io.Writer, handle RecoveryFunc) HandlerFunc {
 						}
 					}
 				}
+				if e, ok := err.(error); ok {
+					// ErrAbortHandler should be treated as broken pipe too.
+					if errors.Is(e, http.ErrAbortHandler) {
+						brokenPipe = true
+					}
+				}
 				if logger != nil {
 					const stackSkip = 3
 					if brokenPipe {

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -142,6 +142,28 @@ func TestPanicWithBrokenPipe(t *testing.T) {
 	}
 }
 
+// TestPanicWithAbortHandler asserts that recovery handles http.ErrAbortHandler as broken pipe
+func TestPanicWithAbortHandler(t *testing.T) {
+	const expectCode = 204
+
+	var buf strings.Builder
+	router := New()
+	router.Use(RecoveryWithWriter(&buf))
+	router.GET("/recovery", func(c *Context) {
+		// Start writing response
+		c.Header("X-Test", "Value")
+		c.Status(expectCode)
+
+		// Panic with ErrAbortHandler which should be treated as broken pipe
+		panic(http.ErrAbortHandler)
+	})
+	// RUN
+	w := PerformRequest(router, http.MethodGet, "/recovery")
+	// TEST
+	assert.Equal(t, expectCode, w.Code)
+	assert.Contains(t, buf.String(), "net/http: abort Handler")
+}
+
 func TestCustomRecoveryWithWriter(t *testing.T) {
 	errBuffer := new(strings.Builder)
 	buffer := new(strings.Builder)


### PR DESCRIPTION
This PR resolves an issue where `http.ErrAbortHandler` panics are incorrectly logged as errors by the `gin.Recovery` middleware.

The current `gin.Recovery` middleware only handles "broken pipe" errors, causing it to log unnecessary stack traces when a client prematurely closes a connection. This behavior is misleading, as `http.ErrAbortHandler` is intentionally used by `httputil.ReverseProxy` to abort requests and is not a true application error.

This change modifies the `Recovery` middleware to explicitly check for `http.ErrAbortHandler` and suppress the logging of stack traces for this specific panic. This aligns the middleware with the intended behavior of the Go standard library and improves log clarity by filtering out expected panics.

### Related Issue

* [https://github.com/gin-gonic/gin/issues/1714](https://github.com/gin-gonic/gin/issues/1714)

### References

* **golang/go#28239:** The Go issue discussing the intended use of `http.ErrAbortHandler`.
* **go-chi/chi#449:** A similar implementation in the go-chi/chi library.

### Similar PRs

* [https://github.com/gin-gonic/gin/pull/2590](https://github.com/gin-gonic/gin/pull/2590) (lacks tests)
* [https://github.com/gin-gonic/gin/pull/3487](https://github.com/gin-gonic/gin/pull/3487) (lacks tests)