### PR TITLE
perf(context): optimize getMapFromFormData performance

### DIFF
--- a/context.go
+++ b/context.go
@@ -654,14 +654,23 @@ func (c *Context) GetPostFormMap(key string) (map[string]string, bool) {
 func getMapFromFormData(m map[string][]string, key string) (map[string]string, bool) {
 	d := make(map[string]string)
 	found := false
+	keyLen := len(key)
+
 	for k, v := range m {
-		if i := strings.IndexByte(k, '['); i >= 1 && k[0:i] == key {
-			if j := strings.IndexByte(k[i+1:], ']'); j >= 1 {
-				found = true
-				d[k[i+1:][:j]] = v[0]
-			}
+		if len(k) < keyLen+3 { // key + "[" + at least one char + "]"
+			continue
+		}
+
+		if k[:keyLen] != key || k[keyLen] != '[' {
+			continue
+		}
+
+		if j := strings.IndexByte(k[keyLen+1:], ']'); j > 0 {
+			found = true
+			d[k[keyLen+1:keyLen+1+j]] = v[0]
 		}
 	}
+
 	return d, found
 }
 


### PR DESCRIPTION
## Below is a comparison of the results before and after optimizing the getMapFromFormData function in my local benchmark

### Before Optimization
```text
goos: darwin
goarch: amd64
pkg: github.com/gin-gonic/gin
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
BenchmarkGetMapFromFormData
BenchmarkGetMapFromFormData/Small_Bracket
BenchmarkGetMapFromFormData/Small_Bracket-8         	 4073180	       299.7 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/Small_Names
BenchmarkGetMapFromFormData/Small_Names-8           	 4073487	       272.4 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/Medium_Bracket
BenchmarkGetMapFromFormData/Medium_Bracket-8        	 2672517	       448.2 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/Medium_Names
BenchmarkGetMapFromFormData/Medium_Names-8          	 2494389	       463.8 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/Medium_Other
BenchmarkGetMapFromFormData/Medium_Other-8          	 2886765	       406.9 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/Large_Bracket
BenchmarkGetMapFromFormData/Large_Bracket-8         	   96352	     11929 ns/op	   10506 B/op	      11 allocs/op
BenchmarkGetMapFromFormData/Large_Names
BenchmarkGetMapFromFormData/Large_Names-8           	  149754	      7647 ns/op	    5036 B/op	       7 allocs/op
BenchmarkGetMapFromFormData/Large_Other
BenchmarkGetMapFromFormData/Large_Other-8           	  224056	      5400 ns/op	    2313 B/op	       4 allocs/op
BenchmarkGetMapFromFormData/WorstCase_Bracket
BenchmarkGetMapFromFormData/WorstCase_Bracket-8     	  621686	      1758 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/ShortKeys_Bracket
BenchmarkGetMapFromFormData/ShortKeys_Bracket-8     	 4081970	       273.4 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/Empty_Key
BenchmarkGetMapFromFormData/Empty_Key-8             	 9204097	       124.9 ns/op	      48 B/op	       1 allocs/op
PASS

Process finished with the exit code 0
```

### After Optimization
```text
goos: darwin
goarch: amd64
pkg: github.com/gin-gonic/gin
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
BenchmarkGetMapFromFormData
BenchmarkGetMapFromFormData/Small_Bracket
BenchmarkGetMapFromFormData/Small_Bracket-8         	 4154392	       272.4 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/Small_Names
BenchmarkGetMapFromFormData/Small_Names-8           	 4467927	       259.6 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/Medium_Bracket
BenchmarkGetMapFromFormData/Medium_Bracket-8        	 2679399	       424.5 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/Medium_Names
BenchmarkGetMapFromFormData/Medium_Names-8          	 2957089	       389.9 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/Medium_Other
BenchmarkGetMapFromFormData/Medium_Other-8          	 3139431	       356.5 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/Large_Bracket
BenchmarkGetMapFromFormData/Large_Bracket-8         	   96458	     11507 ns/op	   10506 B/op	      11 allocs/op
BenchmarkGetMapFromFormData/Large_Names
BenchmarkGetMapFromFormData/Large_Names-8           	  158836	      6802 ns/op	    5034 B/op	       7 allocs/op
BenchmarkGetMapFromFormData/Large_Other
BenchmarkGetMapFromFormData/Large_Other-8           	  251412	      4702 ns/op	    2313 B/op	       4 allocs/op
BenchmarkGetMapFromFormData/WorstCase_Bracket
BenchmarkGetMapFromFormData/WorstCase_Bracket-8     	  593670	      1833 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/ShortKeys_Bracket
BenchmarkGetMapFromFormData/ShortKeys_Bracket-8     	 4468412	       261.0 ns/op	     336 B/op	       2 allocs/op
BenchmarkGetMapFromFormData/Empty_Key
BenchmarkGetMapFromFormData/Empty_Key-8             	10324942	       108.3 ns/op	      48 B/op	       1 allocs/op
PASS

Process finished with the exit code 0
```