### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -7,6 +7,7 @@ package binding
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"mime/multipart"
 	"reflect"
 	"strconv"
@@ -489,9 +490,7 @@ func setFormMap(ptr any, form map[string][]string) error {
 		if !ok {
 			return ErrConvertMapStringSlice
 		}
-		for k, v := range form {
-			ptrMap[k] = v
-		}
+		maps.Copy(ptrMap, form)
 
 		return nil
 	}

--- a/context.go
+++ b/context.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"maps"
 	"math"
 	"mime/multipart"
 	"net"
@@ -132,9 +133,7 @@ func (c *Context) Copy() *Context {
 	cKeys := c.Keys
 	cp.Keys = make(map[any]any, len(cKeys))
 	c.mu.RLock()
-	for k, v := range cKeys {
-		cp.Keys[k] = v
-	}
+	maps.Copy(cp.Keys, cKeys)
 	c.mu.RUnlock()
 
 	cParams := c.Params


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.