### PR TITLE
ci: integrate Trivy vulnerability scanning into CI workflow

### DIFF
--- a/.github/workflows/gin.yml
+++ b/.github/workflows/gin.yml
@@ -81,3 +81,19 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           flags: ${{ matrix.os }},go-${{ matrix.go }},${{ matrix.test-tags }}
+
+  vulnerability-scanning:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'table'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH,MEDIUM'


### PR DESCRIPTION
- Add a GitHub Actions job for vulnerability scanning using Trivy
- Configure Trivy to scan the repository for vulnerabilities of severity critical, high, and medium
- Ensure the workflow fails if vulnerabilities are found

