### PR TITLE
fix(binding): improve empty slice/array handling in form binding

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -230,9 +230,12 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 
 	switch value.Kind() {
 	case reflect.Slice:
-		if !ok {
-			vs = []string{opt.defaultValue}
+		if len(vs) == 0 {
+			if !opt.isDefaultExists {
+				return false, nil
+			}
 
+			vs = []string{opt.defaultValue}
 			// pre-process the default value for multi if present
 			cfTag := field.Tag.Get("collection_format")
 			if cfTag == "" || cfTag == "multi" {
@@ -250,9 +253,12 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 
 		return true, setSlice(vs, value, field)
 	case reflect.Array:
-		if !ok {
-			vs = []string{opt.defaultValue}
+		if len(vs) == 0 {
+			if !opt.isDefaultExists {
+				return false, nil
+			}
 
+			vs = []string{opt.defaultValue}
 			// pre-process the default value for multi if present
 			cfTag := field.Tag.Get("collection_format")
 			if cfTag == "" || cfTag == "multi" {


### PR DESCRIPTION
This ensures that empty slices/arrays properly use default values when available,
 and prevents index out of bounds errors when no defaults exist.
Fix #4377
