### PR TITLE
docs(context): fix wrong function name in comment

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -1233,7 +1233,7 @@ func TestContextRenderNoContentHTML(t *testing.T) {
 	assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 }
 
-// TestContextXML tests that the response is serialized as XML
+// TestContextRenderXML tests that the response is serialized as XML
 // and Content-Type is set to application/xml
 func TestContextRenderXML(t *testing.T) {
 	w := httptest.NewRecorder()


### PR DESCRIPTION
# Pull Request Checklist


fix wrong function name in comment
