### PR TITLE
fix: in fixpath case, wildcard node should be the last child.

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -833,7 +833,7 @@ walk: // Outer loop for walking the tree
 			return nil
 		}
 
-		n = n.children[0]
+		n = n.children[len(n.children)-1]
 		switch n.nType {
 		case param:
 			// Find param end (either '/' or path end)

--- a/tree_test.go
+++ b/tree_test.go
@@ -751,6 +751,8 @@ func TestTreeFindCaseInsensitivePath(t *testing.T) {
 		"/w/𠜎",  // 4 byte
 		"/w/𠜏/", // 4 byte
 		longPath,
+		"/param/same/:id",
+		"/param/same/1",
 	}
 
 	for _, route := range routes {
@@ -844,6 +846,7 @@ func TestTreeFindCaseInsensitivePath(t *testing.T) {
 		{"/w/𠜎/", "/w/𠜎", true, true},
 		{"/w/𠜏", "/w/𠜏/", true, true},
 		{lOngPath, longPath, true, true},
+		{"/param/same/prefix/noexist", "", false, false},
 	}
 	// With fixTrailingSlash = true
 	for _, test := range tests {


### PR DESCRIPTION
define `{prefix}/{param path like :id}`  and `{prefix}/`, and than access no defined path like `{prefix}/...`  will panic for `panic("invalid node type")`.
for it didn't obtain the wildcard child node correctly.

here is a example case.  after start server, access http://localhost:8080/prefix/a/b/c , will cause panic.
```go
package main

import (
	"errors"
	"net/http"

	"github.com/gin-gonic/gin"
)

func main() {
	r := gin.Default()
	r.RedirectFixedPath = true
	r.GET("/prefix/:id", func(c *gin.Context) {
		c.JSON(200, "id")
	})
	r.GET("/prefix/xxx", func(c *gin.Context) {
		c.JSON(200, "xxx")
	})
	if err := r.Run(":8080"); err != nil && errors.Is(err, http.ErrServerClosed) {
		panic(err)
	}
}
```