### PR TITLE
refactor(context): omit the return value names

### DIFF
--- a/context.go
+++ b/context.go
@@ -306,162 +306,162 @@ func getTyped[T any](c *Context, key any) (res T) {
 }
 
 // GetString returns the value associated with the key as a string.
-func (c *Context) GetString(key any) (s string) {
+func (c *Context) GetString(key any) string {
 	return getTyped[string](c, key)
 }
 
 // GetBool returns the value associated with the key as a boolean.
-func (c *Context) GetBool(key any) (b bool) {
+func (c *Context) GetBool(key any) bool {
 	return getTyped[bool](c, key)
 }
 
 // GetInt returns the value associated with the key as an integer.
-func (c *Context) GetInt(key any) (i int) {
+func (c *Context) GetInt(key any) int {
 	return getTyped[int](c, key)
 }
 
 // GetInt8 returns the value associated with the key as an integer 8.
-func (c *Context) GetInt8(key any) (i8 int8) {
+func (c *Context) GetInt8(key any) int8 {
 	return getTyped[int8](c, key)
 }
 
 // GetInt16 returns the value associated with the key as an integer 16.
-func (c *Context) GetInt16(key any) (i16 int16) {
+func (c *Context) GetInt16(key any) int16 {
 	return getTyped[int16](c, key)
 }
 
 // GetInt32 returns the value associated with the key as an integer 32.
-func (c *Context) GetInt32(key any) (i32 int32) {
+func (c *Context) GetInt32(key any) int32 {
 	return getTyped[int32](c, key)
 }
 
 // GetInt64 returns the value associated with the key as an integer 64.
-func (c *Context) GetInt64(key any) (i64 int64) {
+func (c *Context) GetInt64(key any) int64 {
 	return getTyped[int64](c, key)
 }
 
 // GetUint returns the value associated with the key as an unsigned integer.
-func (c *Context) GetUint(key any) (ui uint) {
+func (c *Context) GetUint(key any) uint {
 	return getTyped[uint](c, key)
 }
 
 // GetUint8 returns the value associated with the key as an unsigned integer 8.
-func (c *Context) GetUint8(key any) (ui8 uint8) {
+func (c *Context) GetUint8(key any) uint8 {
 	return getTyped[uint8](c, key)
 }
 
 // GetUint16 returns the value associated with the key as an unsigned integer 16.
-func (c *Context) GetUint16(key any) (ui16 uint16) {
+func (c *Context) GetUint16(key any) uint16 {
 	return getTyped[uint16](c, key)
 }
 
 // GetUint32 returns the value associated with the key as an unsigned integer 32.
-func (c *Context) GetUint32(key any) (ui32 uint32) {
+func (c *Context) GetUint32(key any) uint32 {
 	return getTyped[uint32](c, key)
 }
 
 // GetUint64 returns the value associated with the key as an unsigned integer 64.
-func (c *Context) GetUint64(key any) (ui64 uint64) {
+func (c *Context) GetUint64(key any) uint64 {
 	return getTyped[uint64](c, key)
 }
 
 // GetFloat32 returns the value associated with the key as a float32.
-func (c *Context) GetFloat32(key any) (f32 float32) {
+func (c *Context) GetFloat32(key any) float32 {
 	return getTyped[float32](c, key)
 }
 
 // GetFloat64 returns the value associated with the key as a float64.
-func (c *Context) GetFloat64(key any) (f64 float64) {
+func (c *Context) GetFloat64(key any) float64 {
 	return getTyped[float64](c, key)
 }
 
 // GetTime returns the value associated with the key as time.
-func (c *Context) GetTime(key any) (t time.Time) {
+func (c *Context) GetTime(key any) time.Time {
 	return getTyped[time.Time](c, key)
 }
 
 // GetDuration returns the value associated with the key as a duration.
-func (c *Context) GetDuration(key any) (d time.Duration) {
+func (c *Context) GetDuration(key any) time.Duration {
 	return getTyped[time.Duration](c, key)
 }
 
 // GetIntSlice returns the value associated with the key as a slice of integers.
-func (c *Context) GetIntSlice(key any) (is []int) {
+func (c *Context) GetIntSlice(key any) []int {
 	return getTyped[[]int](c, key)
 }
 
 // GetInt8Slice returns the value associated with the key as a slice of int8 integers.
-func (c *Context) GetInt8Slice(key any) (i8s []int8) {
+func (c *Context) GetInt8Slice(key any) []int8 {
 	return getTyped[[]int8](c, key)
 }
 
 // GetInt16Slice returns the value associated with the key as a slice of int16 integers.
-func (c *Context) GetInt16Slice(key any) (i16s []int16) {
+func (c *Context) GetInt16Slice(key any) []int16 {
 	return getTyped[[]int16](c, key)
 }
 
 // GetInt32Slice returns the value associated with the key as a slice of int32 integers.
-func (c *Context) GetInt32Slice(key any) (i32s []int32) {
+func (c *Context) GetInt32Slice(key any) []int32 {
 	return getTyped[[]int32](c, key)
 }
 
 // GetInt64Slice returns the value associated with the key as a slice of int64 integers.
-func (c *Context) GetInt64Slice(key any) (i64s []int64) {
+func (c *Context) GetInt64Slice(key any) []int64 {
 	return getTyped[[]int64](c, key)
 }
 
 // GetUintSlice returns the value associated with the key as a slice of unsigned integers.
-func (c *Context) GetUintSlice(key any) (uis []uint) {
+func (c *Context) GetUintSlice(key any) []uint {
 	return getTyped[[]uint](c, key)
 }
 
 // GetUint8Slice returns the value associated with the key as a slice of uint8 integers.
-func (c *Context) GetUint8Slice(key any) (ui8s []uint8) {
+func (c *Context) GetUint8Slice(key any) []uint8 {
 	return getTyped[[]uint8](c, key)
 }
 
 // GetUint16Slice returns the value associated with the key as a slice of uint16 integers.
-func (c *Context) GetUint16Slice(key any) (ui16s []uint16) {
+func (c *Context) GetUint16Slice(key any) []uint16 {
 	return getTyped[[]uint16](c, key)
 }
 
 // GetUint32Slice returns the value associated with the key as a slice of uint32 integers.
-func (c *Context) GetUint32Slice(key any) (ui32s []uint32) {
+func (c *Context) GetUint32Slice(key any) []uint32 {
 	return getTyped[[]uint32](c, key)
 }
 
 // GetUint64Slice returns the value associated with the key as a slice of uint64 integers.
-func (c *Context) GetUint64Slice(key any) (ui64s []uint64) {
+func (c *Context) GetUint64Slice(key any) []uint64 {
 	return getTyped[[]uint64](c, key)
 }
 
 // GetFloat32Slice returns the value associated with the key as a slice of float32 numbers.
-func (c *Context) GetFloat32Slice(key any) (f32s []float32) {
+func (c *Context) GetFloat32Slice(key any) []float32 {
 	return getTyped[[]float32](c, key)
 }
 
 // GetFloat64Slice returns the value associated with the key as a slice of float64 numbers.
-func (c *Context) GetFloat64Slice(key any) (f64s []float64) {
+func (c *Context) GetFloat64Slice(key any) []float64 {
 	return getTyped[[]float64](c, key)
 }
 
 // GetStringSlice returns the value associated with the key as a slice of strings.
-func (c *Context) GetStringSlice(key any) (ss []string) {
+func (c *Context) GetStringSlice(key any) []string {
 	return getTyped[[]string](c, key)
 }
 
 // GetStringMap returns the value associated with the key as a map of interfaces.
-func (c *Context) GetStringMap(key any) (sm map[string]any) {
+func (c *Context) GetStringMap(key any) map[string]any {
 	return getTyped[map[string]any](c, key)
 }
 
 // GetStringMapString returns the value associated with the key as a map of strings.
-func (c *Context) GetStringMapString(key any) (sms map[string]string) {
+func (c *Context) GetStringMapString(key any) map[string]string {
 	return getTyped[map[string]string](c, key)
 }
 
 // GetStringMapStringSlice returns the value associated with the key as a map to a slice of strings.
-func (c *Context) GetStringMapStringSlice(key any) (smss map[string][]string) {
+func (c *Context) GetStringMapStringSlice(key any) map[string][]string {
 	return getTyped[map[string][]string](c, key)
 }
 


### PR DESCRIPTION
When dealing with a single return value, omit the return value name.
