### PR TITLE
feat(context): implemented Delete method

### DIFF
--- a/context.go
+++ b/context.go
@@ -465,6 +465,16 @@ func (c *Context) GetStringMapStringSlice(key any) (smss map[string][]string) {
 	return getTyped[map[string][]string](c, key)
 }
 
+// Delete deletes the key from the Context's Key map, if it exists.
+// This operation is safe to be used by concurrent go-routines
+func (c *Context) Delete(key any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.Keys != nil {
+		delete(c.Keys, key)
+	}
+}
+
 /************************************/
 /************ INPUT DATA ************/
 /************************************/

--- a/context_test.go
+++ b/context_test.go
@@ -404,6 +404,19 @@ func TestContextSetGetBool(t *testing.T) {
 	assert.True(t, c.GetBool("bool"))
 }
 
+func TestSetGetDelete(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	key := "example-key"
+	value := "example-value"
+	c.Set(key, value)
+	val, exists := c.Get(key)
+	assert.True(t, exists)
+	assert.Equal(t, val, value)
+	c.Delete(key)
+	_, exists = c.Get(key)
+	assert.False(t, exists)
+}
+
 func TestContextGetInt(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Set("int", 1)


### PR DESCRIPTION

### Feature

This pull request introduces a Delete method to the Metadata-management part of Gin Context struct. The method allows safely removing a key from the context's internal Keys map. It ensures thread safety by locking the mutex before deleting the key, mirroring the approach used in existing Set and Get methods.

What Changed
 - Added Delete(key any) method to Context.
 - The method checks if Keys map is initialized, then removes the key if present.
 -  Protects access with sync.RWMutex to avoid data races.
 -  Added unit tests to verify Set, Get, and Delete behavior.

### Testing

 Added TestSetGetDelete function to cover:
 - Setting a key-value pair.
 -  Retrieving the value.
 - Deleting the key.
 - Confirming deletion by verifying the key no longer exists.
 
 Related Issues
 Closes #4397