### PR TITLE
refactor(path): optimization cleanPath

### DIFF
--- a/path_test.go
+++ b/path_test.go
@@ -27,6 +27,7 @@ var cleanTests = []cleanPathTest{
 
 	// missing root
 	{"", "/"},
+	{"a", "/a"},
 	{"a/", "/a/"},
 	{"abc", "/abc"},
 	{"abc/def", "/abc/def"},
@@ -140,6 +141,120 @@ func BenchmarkPathCleanLong(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, test := range cleanTests {
 			cleanPath(test.path)
+		}
+	}
+}
+
+func cleanPathOld(p string) string {
+	const stackBufSize = 128
+	// Turn empty string into "/"
+	if p == "" {
+		return "/"
+	}
+
+	// Reasonably sized buffer on stack to avoid allocations in the common case.
+	// If a larger buffer is required, it gets allocated dynamically.
+	buf := make([]byte, 0, stackBufSize)
+
+	n := len(p)
+
+	// Invariants:
+	//      reading from path; r is index of next byte to process.
+	//      writing to buf; w is index of next byte to write.
+
+	// path must start with '/'
+	r := 1
+	w := 1
+
+	if p[0] != '/' {
+		r = 0
+
+		if n+1 > stackBufSize {
+			buf = make([]byte, n+1)
+		} else {
+			buf = buf[:n+1]
+		}
+		buf[0] = '/'
+	}
+
+	trailing := n > 1 && p[n-1] == '/'
+
+	// A bit more clunky without a 'lazybuf' like the path package, but the loop
+	// gets completely inlined (bufApp calls).
+	// loop has no expensive function calls (except 1x make)		// So in contrast to the path package this loop has no expensive function
+	// calls (except make, if needed).
+
+	for r < n {
+		switch {
+		case p[r] == '/':
+			// empty path element, trailing slash is added after the end
+			r++
+
+		case p[r] == '.' && r+1 == n:
+			trailing = true
+			r++
+
+		case p[r] == '.' && p[r+1] == '/':
+			// . element
+			r += 2
+
+		case p[r] == '.' && p[r+1] == '.' && (r+2 == n || p[r+2] == '/'):
+			// .. element: remove to last /
+			r += 3
+
+			if w > 1 {
+				// can backtrack
+				w--
+
+				if len(buf) == 0 {
+					for w > 1 && p[w] != '/' {
+						w--
+					}
+				} else {
+					for w > 1 && buf[w] != '/' {
+						w--
+					}
+				}
+			}
+
+		default:
+			// Real path element.
+			// Add slash if needed
+			if w > 1 {
+				bufApp(&buf, p, w, '/')
+				w++
+			}
+
+			// Copy element
+			for r < n && p[r] != '/' {
+				bufApp(&buf, p, w, p[r])
+				w++
+				r++
+			}
+		}
+	}
+
+	// Re-append trailing slash
+	if trailing && w > 1 {
+		bufApp(&buf, p, w, '/')
+		w++
+	}
+
+	// If the original string was not modified (or only shortened at the end),
+	// return the respective substring of the original string.
+	// Otherwise return a new string from the buffer.
+	if len(buf) == 0 {
+		return p[:w]
+	}
+	return string(buf[:w])
+}
+
+func BenchmarkPathCleanOld(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		for _, test := range cleanTests {
+			cleanPathOld(test.path)
 		}
 	}
 }


### PR DESCRIPTION
1. Moved the definition of stackBufSize to reduce unnecessary resource consumption.
2. Special path handling: Handle simple cases first to reduce complex logic.
3. Modified trailing   remove n > 1 && p[n-1] == '/'
4. Modified the check within the for statement to reduce unnecessary variable comparisons.

<img width="3158" height="986" alt="image" src="https://github.com/user-attachments/assets/27039776-6030-40c9-bdfc-ca0ebdac4bee" />

