### PR TITLE
perf(path): replace regex with custom functions in redirectTrailingSlash

### DIFF
--- a/gin_test.go
+++ b/gin_test.go
@@ -1012,34 +1012,3 @@ func TestUpdateRouteTreesCalledOnce(t *testing.T) {
 		assert.Equal(t, "ok", w.Body.String())
 	}
 }
-
-func TestRemoveRepeatedSlash(t *testing.T) {
-	testCases := []struct {
-		name string
-		str  string
-		want string
-	}{
-		{
-			name: "noSlash",
-			str:  "abc",
-			want: "abc",
-		},
-		{
-			name: "withSlash",
-			str:  "/a/b/c/",
-			want: "/a/b/c/",
-		},
-		{
-			name: "withRepeatedSlash",
-			str:  "/a//b///c////",
-			want: "/a/b/c/",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			res := removeRepeatedSlash(tc.str)
-			assert.Equal(t, tc.want, res)
-		})
-	}
-}

--- a/path_test.go
+++ b/path_test.go
@@ -143,3 +143,50 @@ func BenchmarkPathCleanLong(b *testing.B) {
 		}
 	}
 }
+
+func TestRemoveRepeatedChar(t *testing.T) {
+	testCases := []struct {
+		name string
+		str  string
+		char byte
+		want string
+	}{
+		{
+			name: "empty",
+			str:  "",
+			char: 'a',
+			want: "",
+		},
+		{
+			name: "noSlash",
+			str:  "abc",
+			char: ',',
+			want: "abc",
+		},
+		{
+			name: "withSlash",
+			str:  "/a/b/c/",
+			char: '/',
+			want: "/a/b/c/",
+		},
+		{
+			name: "withRepeatedSlashes",
+			str:  "/a//b///c////",
+			char: '/',
+			want: "/a/b/c/",
+		},
+		{
+			name: "threeSlashes",
+			str:  "///",
+			char: '/',
+			want: "/",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := removeRepeatedChar(tc.str, tc.char)
+			assert.Equal(t, tc.want, res)
+		})
+	}
+}


### PR DESCRIPTION
Replace regex operations with custom functions (sanitizePathChars and removeRepeatedChar) to improve performance.