### PR TITLE
fix(render): improve JsonpJSON content type handling and simplify Context.JSONP

### DIFF
--- a/context.go
+++ b/context.go
@@ -1135,13 +1135,10 @@ func (c *Context) SecureJSON(code int, obj any) {
 // JSONP serializes the given struct as JSON into the response body.
 // It adds padding to response body to request data from a server residing in a different domain than the client.
 // It also sets the Content-Type as "application/javascript".
+//
+// When the callback parameter is empty, it behaves equivalently to Context.JSON.
 func (c *Context) JSONP(code int, obj any) {
-	callback := c.DefaultQuery("callback", "")
-	if callback == "" {
-		c.Render(code, render.JSON{Data: obj})
-		return
-	}
-	c.Render(code, render.JsonpJSON{Callback: callback, Data: obj})
+	c.Render(code, render.JsonpJSON{Callback: c.Query("callback"), Data: obj})
 }
 
 // JSON serializes the given struct as JSON into the response body.

--- a/render/json.go
+++ b/render/json.go
@@ -115,18 +115,16 @@ func (r SecureJSON) WriteContentType(w http.ResponseWriter) {
 
 // Render (JsonpJSON) marshals the given interface object and writes it and its callback with custom ContentType.
 func (r JsonpJSON) Render(w http.ResponseWriter) (err error) {
+	if r.Callback == "" {
+		return WriteJSON(w, r.Data)
+	}
+
+	r.WriteContentType(w)
+
 	ret, err := json.API.Marshal(r.Data)
 	if err != nil {
 		return err
 	}
-
-	if r.Callback == "" {
-		writeContentType(w, jsonContentType)
-		_, err = w.Write(ret)
-		return err
-	}
-
-	r.WriteContentType(w)
 
 	callback := template.JSEscapeString(r.Callback)
 	if _, err = w.Write(bytesconv.StringToBytes(callback)); err != nil {

--- a/render/json.go
+++ b/render/json.go
@@ -115,16 +115,18 @@ func (r SecureJSON) WriteContentType(w http.ResponseWriter) {
 
 // Render (JsonpJSON) marshals the given interface object and writes it and its callback with custom ContentType.
 func (r JsonpJSON) Render(w http.ResponseWriter) (err error) {
-	r.WriteContentType(w)
 	ret, err := json.API.Marshal(r.Data)
 	if err != nil {
 		return err
 	}
 
 	if r.Callback == "" {
+		writeContentType(w, jsonContentType)
 		_, err = w.Write(ret)
 		return err
 	}
+
+	r.WriteContentType(w)
 
 	callback := template.JSEscapeString(r.Callback)
 	if _, err = w.Write(bytesconv.StringToBytes(callback)); err != nil {


### PR DESCRIPTION
This PR makes several improvements to JSONP handling:

 **Content Type Correction for JsonpJSON**
   - Modified JsonpJSON.Render to use 'application/json; charset=utf-8' when callback is empty
   - This aligns with JSONP definition which requires a callback function wrapper
   - Ensures proper content type matching for the actual data format being returned

**Context.JSONP Method Simplification**
   - Refactored Context.JSONP to use a cleaner, one-line implementation
   - Removed duplicate code and redundant condition checking

 **Test Updates**
   - Added TestRenderJsonpJSONWithEmptyCallback to verify correct content type

These changes improve code maintainability 
while ensuring JSONP responses conform to proper standards. 
According to JSONP (JSON with Padding) definition, 
it is a technique for sending JSON data 
without worrying about cross-domain issues 
by wrapping the JSON response in a JavaScript function call.

Ref #1438