### PR TITLE
refactor(benchmark): use b.Loop() to simplify the code

### DIFF
--- a/binding/default_validator_benchmark_test.go
+++ b/binding/default_validator_benchmark_test.go
@@ -18,9 +18,8 @@ func BenchmarkSliceValidationError(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if len(e.Error()) == 0 {
 			b.Errorf("error")
 		}

--- a/binding/form_mapping_benchmark_test.go
+++ b/binding/form_mapping_benchmark_test.go
@@ -31,7 +31,7 @@ type structFull struct {
 
 func BenchmarkMapFormFull(b *testing.B) {
 	var s structFull
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		err := mapForm(&s, form)
 		if err != nil {
 			b.Fatalf("Error on a form mapping")
@@ -54,7 +54,7 @@ type structName struct {
 
 func BenchmarkMapFormName(b *testing.B) {
 	var s structName
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		err := mapForm(&s, form)
 		if err != nil {
 			b.Fatalf("Error on a form mapping")

--- a/path_test.go
+++ b/path_test.go
@@ -94,7 +94,7 @@ func TestPathCleanMallocs(t *testing.T) {
 func BenchmarkPathClean(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, test := range cleanTests {
 			cleanPath(test.path)
 		}
@@ -134,10 +134,10 @@ func TestPathCleanLong(t *testing.T) {
 
 func BenchmarkPathCleanLong(b *testing.B) {
 	cleanTests := genLongPaths()
-	b.ResetTimer()
+
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, test := range cleanTests {
 			cleanPath(test.path)
 		}

--- a/utils_test.go
+++ b/utils_test.go
@@ -19,7 +19,7 @@ func init() {
 }
 
 func BenchmarkParseAccept(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		parseAccept("text/html , application/xhtml+xml,application/xml;q=0.9,  */* ;q=0.8")
 	}
 }


### PR DESCRIPTION
# Pull Request Checklist

Please ensure your pull request meets the following requirements:

- [x] Open your pull request against the `master` branch.
- [ ] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [ ] Tests are added or modified as needed to cover code changes.
- [ ] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.



replace `for i := range b.N` or `for range b.N` in a benchmark with `for b.Loop()`, and remove any preceding calls to `b.StopTimer`,` b.StartTimer`, and `b.ResetTimer`.

Supported by Go Team, more info: https://go.dev/blog/testing-b-loop


Before:

```shell
goos: darwin
goarch: arm64
pkg: github.com/gin-gonic/gin/binding
cpu: Apple M4
BenchmarkSliceValidationError-10    	  627850	      1907 ns/op	    1912 B/op	       8 allocs/op
BenchmarkMapFormFull-10             	 1385667	       873.1 ns/op
BenchmarkMapFormName-10             	10485808	       108.4 ns/op
PASS
ok  	github.com/gin-gonic/gin/binding	5.891s
```


After:

```shell
go test -run=^$ -bench=. ./binding           
goos: darwin
goarch: arm64
pkg: github.com/gin-gonic/gin/binding
cpu: Apple M4
BenchmarkSliceValidationError-10    	  607466	      1958 ns/op	    1912 B/op	       8 allocs/op
BenchmarkMapFormFull-10             	 1359453	       881.2 ns/op
BenchmarkMapFormName-10             	10900568	       110.4 ns/op
PASS
ok  	github.com/gin-gonic/gin/binding	4.242s

```
