### PR TITLE
ci(lint): refactor test assertions and linter configuration

### DIFF
--- a/.github/workflows/gin.yml
+++ b/.github/workflows/gin.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.6
+          version: v2.6
           args: --verbose
   test:
     needs: lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,7 +68,6 @@ linters:
       - examples$
 formatters:
   enable:
-    - gci
     - gofmt
     - gofumpt
     - goimports
@@ -80,7 +79,4 @@ formatters:
   exclusions:
     generated: lax
     paths:
-      - third_party$
-      - builtin$
-      - examples$
       - gin.go

--- a/context_test.go
+++ b/context_test.go
@@ -292,7 +292,7 @@ func TestContextReset(t *testing.T) {
 	assert.Empty(t, c.Errors.Errors())
 	assert.Empty(t, c.Errors.ByType(ErrorTypeAny))
 	assert.Empty(t, c.Params)
-	assert.EqualValues(t, c.index, -1)
+	assert.EqualValues(t, -1, c.index)
 	assert.Equal(t, c.Writer.(*responseWriter), &c.writermem)
 }
 
@@ -384,7 +384,7 @@ func TestContextSetGetValues(t *testing.T) {
 	c.Set("intInterface", a)
 
 	assert.Exactly(t, "this is a string", c.MustGet("string").(string))
-	assert.Exactly(t, c.MustGet("int32").(int32), int32(-42))
+	assert.Exactly(t, int32(-42), c.MustGet("int32").(int32))
 	assert.Exactly(t, int64(42424242424242), c.MustGet("int64").(int64))
 	assert.Exactly(t, uint64(42), c.MustGet("uint64").(uint64))
 	assert.InDelta(t, float32(4.2), c.MustGet("float32").(float32), 0.01)

--- a/gin_integration_test.go
+++ b/gin_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -261,10 +262,11 @@ func TestUnixSocket(t *testing.T) {
 
 	fmt.Fprint(c, "GET /example HTTP/1.0\r\n\r\n")
 	scanner := bufio.NewScanner(c)
-	var response string
+	var responseBuilder strings.Builder
 	for scanner.Scan() {
-		response += scanner.Text()
+		responseBuilder.WriteString(scanner.Text())
 	}
+	response := responseBuilder.String()
 	assert.Contains(t, response, "HTTP/1.0 200", "should get a 200")
 	assert.Contains(t, response, "it worked", "resp body should match")
 }
@@ -322,10 +324,11 @@ func TestFileDescriptor(t *testing.T) {
 
 	fmt.Fprintf(c, "GET /example HTTP/1.0\r\n\r\n")
 	scanner := bufio.NewScanner(c)
-	var response string
+	var responseBuilder strings.Builder
 	for scanner.Scan() {
-		response += scanner.Text()
+		responseBuilder.WriteString(scanner.Text())
 	}
+	response := responseBuilder.String()
 	assert.Contains(t, response, "HTTP/1.0 200", "should get a 200")
 	assert.Contains(t, response, "it worked", "resp body should match")
 }
@@ -354,10 +357,11 @@ func TestListener(t *testing.T) {
 
 	fmt.Fprintf(c, "GET /example HTTP/1.0\r\n\r\n")
 	scanner := bufio.NewScanner(c)
-	var response string
+	var responseBuilder strings.Builder
 	for scanner.Scan() {
-		response += scanner.Text()
+		responseBuilder.WriteString(scanner.Text())
 	}
+	response := responseBuilder.String()
 	assert.Contains(t, response, "HTTP/1.0 200", "should get a 200")
 	assert.Contains(t, response, "it worked", "resp body should match")
 }


### PR DESCRIPTION
- Update golangci-lint GitHub Action version from v2.1.6 to v2.6
- Remove the gci formatter and exclusions for third_party, builtin, and examples from the linter config
- Fix argument order for assert.EqualValues and assert.Exactly in context tests for clarity
- Refactor integration tests to build response strings using strings.Builder instead of direct concatenation for improved performance and readability

