### PR TITLE
fix(gin): use octal literals for month and day in time.Date arguments

### DIFF
--- a/gin_test.go
+++ b/gin_test.go
@@ -46,7 +46,7 @@ func setupHTMLFiles(t *testing.T, mode string, tls bool, loadMethod func(*Engine
 		})
 		router.GET("/raw", func(c *Context) {
 			c.HTML(http.StatusOK, "raw.tmpl", map[string]any{
-				"now": time.Date(2017, 07, 01, 0, 0, 0, 0, time.UTC), //nolint:gofumpt
+				"now": time.Date(2017, 0o7, 0o1, 0, 0, 0, 0, time.UTC),
 			})
 		})
 	})


### PR DESCRIPTION
- Replace decimal literals with octal literals for month and day in the time.Date function argument


