### PR TITLE
fix(binding): add explicit interface types in `binding_nomsgpack.go`

### DIFF
--- a/binding/binding_nomsgpack.go
+++ b/binding/binding_nomsgpack.go
@@ -70,18 +70,18 @@ var Validator StructValidator = &defaultValidator{}
 // These implement the Binding interface and can be used to bind the data
 // present in the request to struct instances.
 var (
-	JSON          = jsonBinding{}
-	XML           = xmlBinding{}
-	Form          = formBinding{}
-	Query         = queryBinding{}
-	FormPost      = formPostBinding{}
-	FormMultipart = formMultipartBinding{}
-	ProtoBuf      = protobufBinding{}
-	YAML          = yamlBinding{}
-	Uri           = uriBinding{}
-	Header        = headerBinding{}
-	TOML          = tomlBinding{}
-	Plain         = plainBinding{}
+	JSON          BindingBody = jsonBinding{}
+	XML           BindingBody = xmlBinding{}
+	Form          Binding     = formBinding{}
+	Query         Binding     = queryBinding{}
+	FormPost      Binding     = formPostBinding{}
+	FormMultipart Binding     = formMultipartBinding{}
+	ProtoBuf      BindingBody = protobufBinding{}
+	YAML          BindingBody = yamlBinding{}
+	Uri           BindingUri  = uriBinding{}
+	Header        Binding     = headerBinding{}
+	Plain         BindingBody = plainBinding{}
+	TOML          BindingBody = tomlBinding{}
 )
 
 // Default returns the appropriate Binding instance based on the HTTP method


### PR DESCRIPTION
This PR adds explicit interface types to variable declarations in `binding_nomsgpack.go` to allow third-party libraries to reassign bindings with custom implementations. [`binding.go`](https://github.com/gin-gonic/gin/blob/d1a15347b1e45a8ee816193d3578a93bfd73b70f/binding/binding.go#L75-L89) has explicit interface types.

## Related Issue
Without explicit interface types, variables like `binding.JSON` are typed as their concrete struct (e.g., `jsonBinding`) rather than the `BindingBody` interface. This prevents libraries from reassigning these variables with wrapper types that implement the same interface. [Source](https://github.com/DataDog/dd-trace-go/blob/e744f8a3ad333ce670f33398432eeb2551365e41/contrib/gin-gonic/gin/appsec.go#L53-L60).                                                                                                                                                            
  This allows to fix [DataDog/dd-trace-go#4114](https://github.com/DataDog/dd-trace-go/issues/4114) where the missing explicit types prevent compilation when using the `nomsgpack` build tag.

# Pull Request Checklist

Please ensure your pull request meets the following requirements:

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [x] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.

Thank you for contributing!
