### PR TITLE
refactor(context): replace hardcoded localhost IPs with constants

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -1910,7 +1910,7 @@ func TestContextClientIP(t *testing.T) {
 	resetContextForClientIPTests(c)
 
 	// IPv6 support
-	c.Request.RemoteAddr = "[::1]:12345"
+	c.Request.RemoteAddr = fmt.Sprintf("[%s]:12345", localhostIPv6)
 	assert.Equal(t, "20.20.20.20", c.ClientIP())
 
 	resetContextForClientIPTests(c)
@@ -3212,7 +3212,7 @@ func TestContextCopyShouldNotCancel(t *testing.T) {
 	}()
 
 	addr := strings.Split(l.Addr().String(), ":")
-	res, err := http.Get(fmt.Sprintf("http://127.0.0.1:%s/", addr[len(addr)-1]))
+	res, err := http.Get(fmt.Sprintf("http://%s:%s/", localhostIP, addr[len(addr)-1]))
 	if err != nil {
 		t.Error(fmt.Errorf("request error: %w", err))
 		return

--- a/gin_test.go
+++ b/gin_test.go
@@ -83,7 +83,7 @@ func TestLoadHTMLGlobDebugMode(t *testing.T) {
 }
 
 func TestH2c(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", localhostIP+":0")
 	if err != nil {
 		t.Error(err)
 	}

--- a/utils.go
+++ b/utils.go
@@ -19,6 +19,12 @@ import (
 // BindKey indicates a default bind key.
 const BindKey = "_gin-gonic/gin/bindkey"
 
+// localhostIP indicates the default localhost IP address.
+const localhostIP = "127.0.0.1"
+
+// localhostIPv6 indicates the default localhost IPv6 address.
+const localhostIPv6 = "::1"
+
 // Bind is a helper function for given interface object and returns a Gin middleware.
 func Bind(val any) HandlerFunc {
 	value := reflect.ValueOf(val)


### PR DESCRIPTION
## Description
Following the suggestion in #4473, this PR replaces hardcoded "127.0.0.1" and "::1" strings with package-level constants `localhostIP` and `localhostIPv6` in `utils.go`.

## Motivation
- **Single Source of Truth:** Centralizes loopback addresses, avoiding "magic strings" across test files.
- **Maintainability:** Simplifies future changes if the default testing loopback needs to be updated or configured.
- **Consistency:** Aligns with Gin's existing pattern of defining internal keys and defaults as constants.

## Changes
- Added `localhostIP` and `localhostIPv6` constants to `utils.go`.
- Updated `context_test.go` and `gin_test.go` to use these constants.
- Verified that all tests pass (`go test -v .`).

Closes #4473
---
## Pull Request Checklist
- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [ ] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.