### PR TITLE
perf(binding): avoid unnecessary strconv.Parse calls for empty form values

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -361,7 +361,8 @@ func setWithProperType(val string, value reflect.Value, field reflect.StructFiel
 
 func setIntField(val string, bitSize int, field reflect.Value) error {
 	if val == "" {
-		val = "0"
+		field.SetInt(0)
+		return nil
 	}
 	intVal, err := strconv.ParseInt(val, 10, bitSize)
 	if err == nil {
@@ -372,7 +373,8 @@ func setIntField(val string, bitSize int, field reflect.Value) error {
 
 func setUintField(val string, bitSize int, field reflect.Value) error {
 	if val == "" {
-		val = "0"
+		field.SetUint(0)
+		return nil
 	}
 	uintVal, err := strconv.ParseUint(val, 10, bitSize)
 	if err == nil {
@@ -383,7 +385,8 @@ func setUintField(val string, bitSize int, field reflect.Value) error {
 
 func setBoolField(val string, field reflect.Value) error {
 	if val == "" {
-		val = "false"
+		field.SetBool(false)
+		return nil
 	}
 	boolVal, err := strconv.ParseBool(val)
 	if err == nil {
@@ -394,7 +397,8 @@ func setBoolField(val string, field reflect.Value) error {
 
 func setFloatField(val string, bitSize int, field reflect.Value) error {
 	if val == "" {
-		val = "0.0"
+		field.SetFloat(0)
+		return nil
 	}
 	floatVal, err := strconv.ParseFloat(val, bitSize)
 	if err == nil {
@@ -481,7 +485,8 @@ func setSlice(vals []string, value reflect.Value, field reflect.StructField) err
 
 func setTimeDuration(val string, value reflect.Value) error {
 	if val == "" {
-		val = "0"
+		value.Set(reflect.ValueOf(time.Duration(0)))
+		return nil
 	}
 
 	d, err := time.ParseDuration(val)


### PR DESCRIPTION
Optimize form value parsing by setting zero values directly when input is empty.