### PR TITLE
fix(context): Allow Context.Value to properly support any key type

### DIFF
--- a/context.go
+++ b/context.go
@@ -1436,10 +1436,8 @@ func (c *Context) Value(key any) any {
 	if key == ContextKey {
 		return c
 	}
-	if keyAsString, ok := key.(string); ok {
-		if val, exists := c.Get(keyAsString); exists {
-			return val
-		}
+	if val, exists := c.Get(key); exists {
+		return val
 	}
 	if !c.hasRequestContext() {
 		return nil

--- a/context_test.go
+++ b/context_test.go
@@ -2859,6 +2859,10 @@ func TestContextGolangContext(t *testing.T) {
 	c.Set("foo", "bar")
 	assert.Equal(t, "bar", c.Value("foo"))
 	assert.Nil(t, c.Value(1))
+
+	type contextKey struct{}
+	c.Set(contextKey{}, "value")
+	assert.Equal(t, "value", c.Value(contextKey{}))
 }
 
 func TestWebsocketsRequired(t *testing.T) {


### PR DESCRIPTION
# Description

Fix an inconsistency in the Context.Value method where it accepted keys of any type in its signature but internally restricted them to strings when pass to Context.Get.

# Motivation

The Context.Value method had a signature accepting any for keys, but its implementation only worked with string keys due to a type assertion when pass to Context.Get. This was inconsistent with Context.Set which properly support any comparable key type. I using custom types as context keys (a common Go pattern to avoid key collisions) would find that Value didn't work while Set did.

# Changes

- modified Context.Value method in context.go
- add a test using a custom struct type in context_test.go

# Pull Request Checklist

Please ensure your pull request meets the following requirements:

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [x] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.
