### PR TITLE
Wrap EOF with helpful message for empty JSON request body

### DIFF
--- a/binding/json.go
+++ b/binding/json.go
@@ -7,6 +7,7 @@ package binding
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -50,7 +51,11 @@ func decodeJSON(r io.Reader, obj any) error {
 		decoder.DisallowUnknownFields()
 	}
 	if err := decoder.Decode(obj); err != nil {
+		if err == io.EOF {
+			return fmt.Errorf("empty request body: %w", err)
+		}
 		return err
 	}
+
 	return validate(obj)
 }

--- a/binding/json.go
+++ b/binding/json.go
@@ -51,9 +51,10 @@ func decodeJSON(r io.Reader, obj any) error {
 		decoder.DisallowUnknownFields()
 	}
 	if err := decoder.Decode(obj); err != nil {
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return fmt.Errorf("empty request body: %w", err)
 		}
+
 		return err
 	}
 

--- a/binding/json_external_test.go
+++ b/binding/json_external_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJSONBindingEmptyBodyReturnsHelpfulError(t *testing.T) {
@@ -20,7 +21,7 @@ func TestJSONBindingEmptyBodyReturnsHelpfulError(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 
 	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewBuffer(nil))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
 	c.Request = req
@@ -28,11 +29,11 @@ func TestJSONBindingEmptyBodyReturnsHelpfulError(t *testing.T) {
 	var r Req
 	err = c.ShouldBindJSON(&r)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 
-	// Current behavior returns plain "EOF", which is not helpful.
-	assert.NotEqual(t, "EOF", err.Error(), "error message should not be plain EOF")
+	// Error message should be more descriptive than plain EOF,
+	// while still preserving io.EOF via wrapping.
+	assert.NotEqual(t, "EOF", err.Error())
 	assert.Contains(t, err.Error(), "empty request body")
 	assert.ErrorIs(t, err, io.EOF)
-
 }

--- a/binding/json_external_test.go
+++ b/binding/json_external_test.go
@@ -1,0 +1,38 @@
+package binding_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSONBindingEmptyBodyReturnsHelpfulError(t *testing.T) {
+	type Req struct {
+		Name string `json:"name" binding:"required"`
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewBuffer(nil))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	c.Request = req
+
+	var r Req
+	err = c.ShouldBindJSON(&r)
+
+	assert.Error(t, err)
+
+	// Current behavior returns plain "EOF", which is not helpful.
+	assert.NotEqual(t, "EOF", err.Error(), "error message should not be plain EOF")
+	assert.Contains(t, err.Error(), "empty request body")
+	assert.ErrorIs(t, err, io.EOF)
+
+}


### PR DESCRIPTION
This PR improves the error returned by ShouldBindJSON when the request
body is empty.

Previously, decoding an empty JSON body returned a plain io.EOF error.
This change wraps io.EOF with a clearer message ("empty request body")
while preserving the original error, so errors.Is(err, io.EOF) continues
to work.

An external test has been added to document and verify this behavior.
Happy to adjust the wording or approach if maintainers prefer.
