### PR TITLE
Use http.StatusContinue constant instead of magic number 100

### DIFF
--- a/context.go
+++ b/context.go
@@ -1058,7 +1058,7 @@ func (c *Context) requestHeader(key string) string {
 // bodyAllowedForStatus is a copy of http.bodyAllowedForStatus non-exported function.
 func bodyAllowedForStatus(status int) bool {
 	switch {
-	case status >= 100 && status <= 199:
+	case status >= http.StatusContinue && status <= 199:
 		return false
 	case status == http.StatusNoContent:
 		return false


### PR DESCRIPTION
Replace magic number \`100\` with \`http.StatusContinue\` constant for better code clarity and maintainability in \`bodyAllowedForStatus\` function.

**Changes:**
- Replace \`status >= 100\` with \`status >= http.StatusContinue\`
- This makes code more self-documenting and easier to understand
- Follows Go best practices of using named constants instead of magic numbers

**Fixes:** #4489