### PR TITLE
Use http.StatusContinue constant instead of magic number 100

### DIFF
--- a/context.go
+++ b/context.go
@@ -1056,9 +1056,10 @@ func (c *Context) requestHeader(key string) string {
 /************************************/
 
 // bodyAllowedForStatus is a copy of http.bodyAllowedForStatus non-exported function.
+// Use http.StatusContinue constant for better code clarity
 func bodyAllowedForStatus(status int) bool {
 	switch {
-	case status >= 100 && status <= 199:
+	case status >= http.StatusContinue && status <= 199:
 		return false
 	case status == http.StatusNoContent:
 		return false

--- a/context_test.go
+++ b/context_test.go
@@ -1033,6 +1033,7 @@ func TestContextGetCookie(t *testing.T) {
 func TestContextBodyAllowedForStatus(t *testing.T) {
 	assert.False(t, bodyAllowedForStatus(http.StatusProcessing))
 	assert.False(t, bodyAllowedForStatus(http.StatusNoContent))
+	assert.False(t, bodyAllowedForStatus(http.StatusContinue))
 	assert.False(t, bodyAllowedForStatus(http.StatusNotModified))
 	assert.True(t, bodyAllowedForStatus(http.StatusInternalServerError))
 }


### PR DESCRIPTION
Replace magic number `100` with `http.StatusContinue` constant for better code clarity and maintainability in `bodyAllowedForStatus` function.

Fixes #4489

