### PR TITLE
refactor: replace magic numbers with named constants in bodyAllowedForStatus

### DIFF
--- a/context.go
+++ b/context.go
@@ -1058,7 +1058,7 @@ func (c *Context) requestHeader(key string) string {
 // bodyAllowedForStatus is a copy of http.bodyAllowedForStatus non-exported function.
 func bodyAllowedForStatus(status int) bool {
 	switch {
-	case status >= 100 && status <= 199:
+	case status >= http.StatusContinue && status < http.StatusOK:
 		return false
 	case status == http.StatusNoContent:
 		return false


### PR DESCRIPTION
## Summary
- Replace hardcoded `100` and `199` with `http.StatusContinue` and `http.StatusOK` in the `bodyAllowedForStatus` function
- Uses `status >= http.StatusContinue && status < http.StatusOK` instead of `status >= 100 && status <= 199`
- Consistent with the pattern already used in `logger.go` line 93

Fixes #4489

## Test plan
- All existing tests pass (`go test ./...`)
- `bodyAllowedForStatus` test cases in `context_test.go` cover `http.StatusProcessing` (1xx), `http.StatusNoContent`, `http.StatusNotModified`, and `http.StatusInternalServerError`