### PR TITLE
feat(binding): add support for binding whole request at once

### DIFF
--- a/binding/all.go
+++ b/binding/all.go
@@ -1,0 +1,43 @@
+package binding
+
+import (
+	"net/http"
+	"strings"
+)
+
+type allBinding struct{}
+
+var _ BindingMany = allBinding{}
+
+func (allBinding) Name() string {
+	return "all"
+}
+
+func (allBinding) BindMany(req *http.Request, uriParams map[string][]string, obj any) error {
+	// from binding.Header
+	if err := mapHeader(obj, req.Header); err != nil {
+		return err
+	}
+
+	// from binding.Uri
+	if err := mapURI(obj, uriParams); err != nil {
+		return err
+	}
+
+	// from binding.Query
+	values := req.URL.Query()
+	if err := mapForm(obj, values); err != nil {
+		return err
+	}
+
+	// from context.Bind (for body/post-form/anything else)
+	contentType := req.Header.Get("Content-Type")
+	// trim contentType parameters, e.g. "application/json; charset=utf-8" -> "application/json"
+	contentTypeLastIdx := strings.IndexAny(contentType, " ;")
+	if contentTypeLastIdx != -1 {
+		contentType = contentType[:contentTypeLastIdx]
+	}
+	b := Default(req.Method, contentType)
+	// final validation done by whatever binding is selected here
+	return b.Bind(req, obj)
+}

--- a/binding/all.go
+++ b/binding/all.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Gin Core Team. All rights reserved.
+// Use of this source code is governed by a MIT style
+// license that can be found in the LICENSE file.
+
 package binding
 
 import (

--- a/binding/all.go
+++ b/binding/all.go
@@ -28,25 +28,22 @@ func (allBinding) BindMany(req *http.Request, uriParams map[string][]string, obj
 		return err
 	}
 
-	// from binding.Query
-	values := req.URL.Query()
-	if err := mapForm(obj, values); err != nil {
-		return err
-	}
-
 	// from context.Bind (for body/post-form/anything else)
 	contentType := req.Header.Get("Content-Type")
 	contentTypeLastIdx := strings.IndexAny(contentType, " ;") // trim "application/json; charset=utf-8" -> "application/json"
 	if contentTypeLastIdx != -1 {
 		contentType = contentType[:contentTypeLastIdx]
 	}
+	b := Default(req.Method, contentType)
 
-	// if no Content-Type, assume request has no body. This avoids binding query params again in binding.Default
-	if contentType == "" {
-		return validate(obj)
+	// Since req.ParseForm() reads body and query, check whether the selected binding includes query parsing before parsing query values explicitly.
+	if !bindingIncludesQueryParsing(b) {
+		// from binding.Query
+		if err := mapForm(obj, req.URL.Query()); err != nil {
+			return err
+		}
 	}
 
-	b := Default(req.Method, contentType)
-	// final validation done by whatever binding is selected here
+	// final validation done by whatever binding was selected by Default
 	return b.Bind(req, obj)
 }

--- a/binding/all.go
+++ b/binding/all.go
@@ -36,11 +36,16 @@ func (allBinding) BindMany(req *http.Request, uriParams map[string][]string, obj
 
 	// from context.Bind (for body/post-form/anything else)
 	contentType := req.Header.Get("Content-Type")
-	// trim contentType parameters, e.g. "application/json; charset=utf-8" -> "application/json"
-	contentTypeLastIdx := strings.IndexAny(contentType, " ;")
+	contentTypeLastIdx := strings.IndexAny(contentType, " ;") // trim "application/json; charset=utf-8" -> "application/json"
 	if contentTypeLastIdx != -1 {
 		contentType = contentType[:contentTypeLastIdx]
 	}
+
+	// if no Content-Type, assume request has no body. This avoids binding query params again in binding.Default
+	if contentType == "" {
+		return validate(obj)
+	}
+
 	b := Default(req.Method, contentType)
 	// final validation done by whatever binding is selected here
 	return b.Bind(req, obj)

--- a/binding/binding.go
+++ b/binding/binding.go
@@ -6,7 +6,9 @@
 
 package binding
 
-import "net/http"
+import (
+	"net/http"
+)
 
 // Content-Type MIME of the most common data formats.
 const (
@@ -48,6 +50,15 @@ type BindingUri interface {
 	BindUri(map[string][]string, any) error
 }
 
+// BindingMany adds BindMany method to Binding. BindingMany is similar to Binding,
+// but it has full access to all request aspects to bind multiple parts simultaneously.
+//
+// NOTE: External projects should NOT depend on this interface as it is for Gin's internal binding logic
+type BindingMany interface {
+	Name() string
+	BindMany(req *http.Request, uriParams map[string][]string, obj any) error
+}
+
 // StructValidator is the minimal interface which needs to be implemented in
 // order for it to be used as the validator engine for ensuring the correctness
 // of the request. Gin provides a default implementation for this using
@@ -74,6 +85,7 @@ var Validator StructValidator = &defaultValidator{}
 // These implement the Binding interface and can be used to bind the data
 // present in the request to struct instances.
 var (
+	All           BindingMany = allBinding{} // NOTE: This combines other bindings and doesn't have its own Content-Type
 	JSON          BindingBody = jsonBinding{}
 	XML           BindingBody = xmlBinding{}
 	Form          Binding     = formBinding{}

--- a/binding/binding.go
+++ b/binding/binding.go
@@ -131,6 +131,16 @@ func Default(method, contentType string) Binding {
 	}
 }
 
+// bindingIncludesQueryParsing reports whether a binding parses URL query values as part of Bind.
+func bindingIncludesQueryParsing(binding Binding) bool {
+	switch binding {
+	case Form, FormPost, FormMultipart:
+		return true
+	default:
+		return false
+	}
+}
+
 func validate(obj any) error {
 	if Validator == nil {
 		return nil

--- a/binding/binding_nomsgpack.go
+++ b/binding/binding_nomsgpack.go
@@ -46,6 +46,15 @@ type BindingUri interface {
 	BindUri(map[string][]string, any) error
 }
 
+// BindingMany adds BindMany method to Binding. BindingMany is similar to Binding,
+// but it has full access to all request aspects to bind multiple parts simultaneously.
+//
+// NOTE: External projects should NOT depend on this interface as it is for Gin's internal binding logic
+type BindingMany interface {
+	Name() string
+	BindMany(req *http.Request, uriParams map[string][]string, obj any) error
+}
+
 // StructValidator is the minimal interface which needs to be implemented in
 // order for it to be used as the validator engine for ensuring the correctness
 // of the request. Gin provides a default implementation for this using
@@ -71,18 +80,19 @@ var Validator StructValidator = &defaultValidator{}
 // These implement the Binding interface and can be used to bind the data
 // present in the request to struct instances.
 var (
-	JSON          = jsonBinding{}
-	XML           = xmlBinding{}
-	Form          = formBinding{}
-	Query         = queryBinding{}
-	FormPost      = formPostBinding{}
-	FormMultipart = formMultipartBinding{}
-	ProtoBuf      = protobufBinding{}
-	YAML          = yamlBinding{}
-	Uri           = uriBinding{}
-	Header        = headerBinding{}
-	TOML          = tomlBinding{}
-	Plain         = plainBinding{}
+	All           BindingMany = allBinding{} // NOTE: This combines other bindings and doesn't have its own Content-Type
+	JSON                      = jsonBinding{}
+	XML                       = xmlBinding{}
+	Form                      = formBinding{}
+	Query                     = queryBinding{}
+	FormPost                  = formPostBinding{}
+	FormMultipart             = formMultipartBinding{}
+	ProtoBuf                  = protobufBinding{}
+	YAML                      = yamlBinding{}
+	Uri                       = uriBinding{}
+	Header                    = headerBinding{}
+	TOML                      = tomlBinding{}
+	Plain                     = plainBinding{}
 	BSON          BindingBody = bsonBinding{}
 )
 

--- a/binding/binding_nomsgpack.go
+++ b/binding/binding_nomsgpack.go
@@ -123,6 +123,16 @@ func Default(method, contentType string) Binding {
 	}
 }
 
+// bindingIncludesQueryParsing reports whether a binding parses URL query values as part of Bind.
+func bindingIncludesQueryParsing(binding Binding) bool {
+	switch binding {
+	case Form, FormPost, FormMultipart:
+		return true
+	default:
+		return false
+	}
+}
+
 func validate(obj any) error {
 	if Validator == nil {
 		return nil

--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -154,6 +154,10 @@ type FooStructForMapPtrType struct {
 	PtrBar *map[string]any `form:"ptr_bar"`
 }
 
+type FooStructForAllFormPrecedence struct {
+	Count int `form:"count" binding:"required"`
+}
+
 func TestBindingDefault(t *testing.T) {
 	assert.Equal(t, Form, Default(http.MethodGet, ""))
 	assert.Equal(t, Form, Default(http.MethodGet, MIMEJSON))
@@ -1498,6 +1502,13 @@ func TestBindingAllQuery(t *testing.T) {
 	req = requestWithBody(http.MethodGet, "/?bool_foo=fasl", "")
 	err = b.BindMany(req, nil, &obj2)
 	require.Error(t, err)
+
+	// fail case 2
+	obj3 := FooStructForBoolType{}
+	req = requestWithBody(http.MethodPost, "/?bool_foo=fasl", "{}")
+	req.Header.Set("Content-Type", MIMEJSON)
+	err = b.BindMany(req, nil, &obj3)
+	require.Error(t, err)
 }
 
 func TestBindingAllBody(t *testing.T) {
@@ -1516,6 +1527,19 @@ func TestBindingAllBody(t *testing.T) {
 	req.Header.Set("Content-Type", MIMEJSON)
 	err = b.BindMany(req, nil, &obj2)
 	require.Error(t, err)
+}
+
+// TestBindingAllFormBodyOverridesInvalidQuery. Since req.ParseForm() reads body and query, invalid queries are replaced
+// by valid values in body
+func TestBindingAllFormBodyOverridesInvalidQuery(t *testing.T) {
+	b := All
+
+	obj := FooStructForAllFormPrecedence{}
+	req := requestWithBody(http.MethodPost, "/?count=invalid", "count=7")
+	req.Header.Set("Content-Type", MIMEPOSTForm)
+	err := b.BindMany(req, nil, &obj)
+	require.NoError(t, err)
+	assert.Equal(t, 7, obj.Count)
 }
 
 func TestBindingAllHeaderUriQueryBody(t *testing.T) {

--- a/context.go
+++ b/context.go
@@ -836,8 +836,19 @@ func (c *Context) BindUri(obj any) error {
 // - Caller must provide Content-Type header to select the correct body binding (eg "application/json" for JSON binding)
 // - Binding validation tags are verified after all request parts have been bound
 func (c *Context) BindAll(obj any) error {
-	if err := c.ShouldBindAll(obj); err != nil {
-		c.AbortWithError(http.StatusBadRequest, err).SetType(ErrorTypeBind) //nolint: errcheck
+	err := c.ShouldBindAll(obj)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+
+		// Note: When using sonic or go-json as JSON encoder, they do not propagate the http.MaxBytesError error
+		// https://github.com/goccy/go-json/issues/485
+		// https://github.com/bytedance/sonic/issues/800
+		switch {
+		case errors.As(err, &maxBytesErr):
+			c.AbortWithError(http.StatusRequestEntityTooLarge, err).SetType(ErrorTypeBind) //nolint: errcheck
+		default:
+			c.AbortWithError(http.StatusBadRequest, err).SetType(ErrorTypeBind) //nolint: errcheck
+		}
 		return err
 	}
 	return nil

--- a/context.go
+++ b/context.go
@@ -832,9 +832,9 @@ func (c *Context) BindUri(obj any) error {
 //
 // Note:
 //   - Caller must tag struct fields appropriately for the desired binding (eg `header:"xxx"` vs `uri:"xxx"`)
-//   - Caller must ensure no duplication between field names (else use separate binding engines instead)
+//   - Caller must ensure no duplication between field names. Duplication may result in undefined behavior. (use separate binding engines instead)
 //   - Caller must provide Content-Type header to select the correct body binding (eg "application/json" for JSON binding).
-//     A request without Content-Type will result in no body binding
+//     A request without Content-Type will fallback to gin's default behavior for body binding (see ShouldBind)
 //   - Binding validation tags are verified after all request parts have been bound
 func (c *Context) BindAll(obj any) error {
 	err := c.ShouldBindAll(obj)
@@ -970,9 +970,9 @@ func (c *Context) ShouldBindUri(obj any) error {
 //
 // Note:
 //   - Caller must tag struct fields appropriately for the desired binding (eg `header:"xxx"` vs `uri:"xxx"`)
-//   - Caller must ensure no duplication between field names (else use separate binding engines instead)
+//   - Caller must ensure no duplication between field names. Duplicate fields may result in undefined behavior. (use separate binding engines instead)
 //   - Caller must provide Content-Type header to select the correct body binding (eg "application/json" for JSON binding).
-//     A request without Content-Type will result in no body binding
+//     A request without Content-Type will fallback to gin's default behavior for body binding (see ShouldBind)
 //   - Binding validation tags are verified after all request parts have been bound
 func (c *Context) ShouldBindAll(obj any) error {
 	uriParams := make(map[string][]string, len(c.Params))

--- a/context.go
+++ b/context.go
@@ -831,10 +831,11 @@ func (c *Context) BindUri(obj any) error {
 // It will abort the request with HTTP 400 if any error occurs.
 //
 // Note:
-// - Caller must tag struct fields appropriately for the desired binding (eg `header:"xxx"` vs `uri:"xxx"`)
-// - Caller must ensure no duplication between field names (else use separate binding engines instead)
-// - Caller must provide Content-Type header to select the correct body binding (eg "application/json" for JSON binding)
-// - Binding validation tags are verified after all request parts have been bound
+//   - Caller must tag struct fields appropriately for the desired binding (eg `header:"xxx"` vs `uri:"xxx"`)
+//   - Caller must ensure no duplication between field names (else use separate binding engines instead)
+//   - Caller must provide Content-Type header to select the correct body binding (eg "application/json" for JSON binding).
+//     A request without Content-Type will result in no body binding
+//   - Binding validation tags are verified after all request parts have been bound
 func (c *Context) BindAll(obj any) error {
 	err := c.ShouldBindAll(obj)
 	if err != nil {
@@ -968,10 +969,11 @@ func (c *Context) ShouldBindUri(obj any) error {
 // Like c.Bind() but this method does not set the response status code to 400 or abort if input is not valid.
 //
 // Note:
-// - Caller must tag struct fields appropriately for the desired binding (eg `header:"xxx"` vs `uri:"xxx"`)
-// - Caller must ensure no duplication between field names (else use separate binding engines instead)
-// - Caller must provide Content-Type header to select the correct body binding (eg "application/json" for JSON binding)
-// - Binding validation tags are verified after all request parts have been bound
+//   - Caller must tag struct fields appropriately for the desired binding (eg `header:"xxx"` vs `uri:"xxx"`)
+//   - Caller must ensure no duplication between field names (else use separate binding engines instead)
+//   - Caller must provide Content-Type header to select the correct body binding (eg "application/json" for JSON binding).
+//     A request without Content-Type will result in no body binding
+//   - Binding validation tags are verified after all request parts have been bound
 func (c *Context) ShouldBindAll(obj any) error {
 	uriParams := make(map[string][]string, len(c.Params))
 	for _, v := range c.Params {

--- a/context.go
+++ b/context.go
@@ -827,6 +827,22 @@ func (c *Context) BindUri(obj any) error {
 	return nil
 }
 
+// BindAll binds the passed struct pointer using all available binding engines.
+// It will abort the request with HTTP 400 if any error occurs.
+//
+// Note:
+// - Caller must tag struct fields appropriately for the desired binding (eg `header:"xxx"` vs `uri:"xxx"`)
+// - Caller must ensure no duplication between field names (else use separate binding engines instead)
+// - Caller must provide Content-Type header to select the correct body binding (eg "application/json" for JSON binding)
+// - Binding validation tags are verified after all request parts have been bound
+func (c *Context) BindAll(obj any) error {
+	if err := c.ShouldBindAll(obj); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err).SetType(ErrorTypeBind) //nolint: errcheck
+		return err
+	}
+	return nil
+}
+
 // MustBindWith binds the passed struct pointer using the specified binding engine.
 // It will abort the request with HTTP 400 if any error occurs.
 // See the binding package.
@@ -935,6 +951,22 @@ func (c *Context) ShouldBindUri(obj any) error {
 		m[v.Key] = []string{v.Value}
 	}
 	return binding.Uri.BindUri(m, obj)
+}
+
+// ShouldBindAll binds the passed struct pointer using all the available binding engines.
+// Like c.Bind() but this method does not set the response status code to 400 or abort if input is not valid.
+//
+// Note:
+// - Caller must tag struct fields appropriately for the desired binding (eg `header:"xxx"` vs `uri:"xxx"`)
+// - Caller must ensure no duplication between field names (else use separate binding engines instead)
+// - Caller must provide Content-Type header to select the correct body binding (eg "application/json" for JSON binding)
+// - Binding validation tags are verified after all request parts have been bound
+func (c *Context) ShouldBindAll(obj any) error {
+	uriParams := make(map[string][]string, len(c.Params))
+	for _, v := range c.Params {
+		uriParams[v.Key] = []string{v.Value}
+	}
+	return binding.All.BindMany(c.Request, uriParams, obj)
 }
 
 // ShouldBindWith binds the passed struct pointer using the specified binding engine.

--- a/context_test.go
+++ b/context_test.go
@@ -2400,6 +2400,47 @@ func TestContextBindWithTOML(t *testing.T) {
 	assert.Equal(t, 0, w.Body.Len())
 }
 
+func TestContextBindAll(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest(http.MethodPost, "/1234?foo=true", strings.NewReader(`{"bar":"spam"}`))
+	c.Params = []Param{{Key: "id", Value: "1234"}}
+	c.Request.Header.Add("Content-Type", MIMEJSON) // set fake content-type
+	c.Request.Header.Add("Limit", "100")
+
+	var obj struct {
+		Limit int    `header:"limit" binding:"required"`
+		ID    string `uri:"id" binding:"required,numeric"`
+		Foo   bool   `form:"foo" binding:"required"`
+		Bar   string `form:"bar" xml:"bar" binding:"required"`
+	}
+	require.NoError(t, c.BindAll(&obj))
+	assert.Equal(t, 100, obj.Limit)
+	assert.Equal(t, "1234", obj.ID)
+	assert.Equal(t, "true", c.Request.FormValue("foo"))
+	assert.Equal(t, "spam", obj.Bar)
+	assert.Empty(t, c.Errors)
+}
+
+func TestContextBindAll_400OnError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest(http.MethodPost, "/1234?foo=true", strings.NewReader(`{"bar":"spam"}`))
+	c.Request.Header.Add("Content-Type", MIMEJSON) // set fake content-type
+	c.Request.Header.Add("Limit", "100")
+
+	var obj struct {
+		Limit int    `header:"limit" binding:"required"`
+		ID    string `uri:"id" binding:"required,numeric"`
+		Foo   bool   `form:"foo" binding:"required"`
+		Bar   string `form:"bar" xml:"bar" binding:"required"`
+	}
+	err := c.BindAll(&obj)
+	require.ErrorContains(t, err, "Field validation for 'ID' failed")
+}
+
 func TestContextBadAutoBind(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := CreateTestContext(w)
@@ -2572,6 +2613,29 @@ func TestContextShouldBindWithTOML(t *testing.T) {
 	assert.Equal(t, "foo", obj.Bar)
 	assert.Equal(t, "bar", obj.Foo)
 	assert.Equal(t, 0, w.Body.Len())
+}
+
+func TestContextShouldBindAll(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest(http.MethodPost, "/1234?foo=true", strings.NewReader(`{"bar":"spam"}`))
+	c.Params = []Param{{Key: "id", Value: "1234"}}
+	c.Request.Header.Add("Content-Type", MIMEJSON) // set fake content-type
+	c.Request.Header.Add("Limit", "100")
+
+	var obj struct {
+		Limit int    `header:"limit" binding:"required"`
+		ID    string `uri:"id" binding:"required,numeric"`
+		Foo   bool   `form:"foo" binding:"required"`
+		Bar   string `form:"bar" xml:"bar" binding:"required"`
+	}
+	require.NoError(t, c.ShouldBindAll(&obj))
+	assert.Equal(t, 100, obj.Limit)
+	assert.Equal(t, "1234", obj.ID)
+	assert.Equal(t, "true", c.Request.FormValue("foo"))
+	assert.Equal(t, "spam", obj.Bar)
+	assert.Empty(t, c.Errors)
 }
 
 func TestContextBadAutoShouldBind(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -2406,7 +2406,7 @@ func TestContextBindAll(t *testing.T) {
 
 	c.Request, _ = http.NewRequest(http.MethodPost, "/1234?foo=true", strings.NewReader(`{"bar":"spam"}`))
 	c.Params = []Param{{Key: "id", Value: "1234"}}
-	c.Request.Header.Add("Content-Type", MIMEJSON) // set fake content-type
+	c.Request.Header.Add("Content-Type", MIMEJSON)
 	c.Request.Header.Add("Limit", "100")
 
 	var obj struct {
@@ -2428,7 +2428,7 @@ func TestContextBindAll_400OnError(t *testing.T) {
 	c, _ := CreateTestContext(w)
 
 	c.Request, _ = http.NewRequest(http.MethodPost, "/1234?foo=true", strings.NewReader(`{"bar":"spam"}`))
-	c.Request.Header.Add("Content-Type", MIMEJSON) // set fake content-type
+	c.Request.Header.Add("Content-Type", MIMEJSON)
 	c.Request.Header.Add("Limit", "100")
 
 	var obj struct {
@@ -2439,6 +2439,45 @@ func TestContextBindAll_400OnError(t *testing.T) {
 	}
 	err := c.BindAll(&obj)
 	require.ErrorContains(t, err, "Field validation for 'ID' failed")
+}
+
+func TestContextBindAll_413MaxBytes(t *testing.T) {
+	// When using go-json as JSON encoder, they do not propagate the http.MaxBytesError error
+	// The response will fail with a generic 400 instead of 413
+	// https://github.com/goccy/go-json/issues/485
+	var expectedCode int
+	switch json.Package {
+	case "github.com/goccy/go-json":
+		expectedCode = http.StatusBadRequest
+	default:
+		expectedCode = http.StatusRequestEntityTooLarge
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest(http.MethodPost, "/1234?foo=true", strings.NewReader(`{"bar":"spam"}`))
+	c.Params = []Param{{Key: "id", Value: "1234"}}
+	c.Request.Header.Add("Content-Type", MIMEJSON)
+	c.Request.Header.Add("Limit", "100")
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 10)
+
+	var obj struct {
+		Limit int    `header:"limit" binding:"required"`
+		ID    string `uri:"id" binding:"required,numeric"`
+		Foo   bool   `form:"foo" binding:"required"`
+		Bar   string `form:"bar" xml:"bar" binding:"required"`
+	}
+	err := c.BindAll(&obj)
+	require.Error(t, err)
+	if json.Package != "github.com/goccy/go-json" {
+		var maxBytesErr *http.MaxBytesError
+		require.ErrorAs(t, err, &maxBytesErr)
+	}
+	c.Writer.WriteHeaderNow()
+
+	assert.Equal(t, expectedCode, w.Code)
+	assert.True(t, c.IsAborted())
 }
 
 func TestContextBadAutoBind(t *testing.T) {

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -44,6 +44,7 @@
   - [Bind HTML checkboxes](#bind-html-checkboxes)
   - [Multipart/Urlencoded binding](#multiparturlencoded-binding)
   - [Bind form-data request with custom struct](#bind-form-data-request-with-custom-struct)
+  - [Bind All](#bind-all)
   - [Try to bind body into different structs](#try-to-bind-body-into-different-structs)
   - [Bind form-data request with custom struct and custom tag](#bind-form-data-request-with-custom-struct-and-custom-tag)
 - [Response Rendering](#response-rendering)
@@ -1539,6 +1540,50 @@ $ curl "http://localhost:8080/getc?field_a=hello&field_c=world"
 {"a":{"FieldA":"hello"},"c":"world"}
 $ curl "http://localhost:8080/getd?field_x=hello&field_d=world"
 {"d":"world","x":{"FieldX":"hello"}}
+```
+
+### Bind All
+
+BindAll will bind header, uri, query parameters, and body in one call. Validation is only applied after request parts are bound.
+
+```go
+package main
+
+import (
+  "net/http"
+
+  "github.com/gin-gonic/gin"
+)
+
+type Person struct {
+  Age       int       `header:"x-age" binding:"required"`
+  ID        string    `uri:"id" binding:"required,uuid"`
+  Name      string    `form:"name" binding:"required"`
+  Addresses [2]string `json:"addresses" binding:"required"`
+}
+
+func main() {
+  route := gin.Default()
+  route.POST("/:id", func(c *gin.Context) {
+    var person Person
+    if err := c.ShouldBindAll(&person); err != nil {
+      c.JSON(http.StatusBadRequest, gin.H{"msg": err.Error()})
+      return
+    }
+    c.JSON(http.StatusOK, person)
+  })
+  route.Run(":8080")
+}
+```
+
+Test it with:
+
+```sh
+curl -X POST -H "x-age:25" -H "Content-Type: application/json" -d '{"addresses":["foo","bar"]}' 'http://localhost:8080/987fbc97-4bed-5078-9f07-9141ba07c9f3?name=Bob'
+# {"Age":25,"ID":"987fbc97-4bed-5078-9f07-9141ba07c9f3","Name":"Bob","addresses":["foo","bar"]}
+
+curl -X POST -H "x-age:25" -H "Content-Type: application/json" -d '{"addresses":["foo","bar"]}' 'http://localhost:8080/not-uuid'
+# {"msg":"Key: 'Person.ID' Error:Field validation for 'ID' failed on the 'uuid' tag\nKey: 'Person.Name' Error:Field validation for 'Name' failed on the 'required' tag"}
 ```
 
 ### Try to bind body into different structs


### PR DESCRIPTION
With this PR, users can now call `c.BindAll` to allow Gin to bind headers, request path params, query params, and body in a single call. This resolves a number of tickets regarding this functionality:

relates to #1824
relates to #2309
closes #2535
closes #2758
closes #2919
closes #4338
closes #3095
closes #4510

MVE:
```go
package main

import (
  "net/http"

  "github.com/gin-gonic/gin"
)

type Person struct {
  Age       int       `header:"x-age" binding:"required"`
  ID        string    `uri:"id" binding:"required,uuid"`
  Name      string    `form:"name" binding:"required"`
  Addresses [2]string `json:"addresses" binding:"required"`
}

func main() {
  route := gin.Default()
  route.POST("/:id", func(c *gin.Context) {
    var person Person
    if err := c.ShouldBindAll(&person); err != nil {
      c.JSON(http.StatusBadRequest, gin.H{"msg": err.Error()})
      return
    }
    c.JSON(http.StatusOK, person)
  })
  route.Run(":8080")
}
```

Test it with:

```sh
curl -X POST -H "x-age:25" -H "Content-Type: application/json" -d '{"addresses":["foo","bar"]}' 'http://localhost:8080/987fbc97-4bed-5078-9f07-9141ba07c9f3?name=Bob'
# {"Age":25,"ID":"987fbc97-4bed-5078-9f07-9141ba07c9f3","Name":"Bob","addresses":["foo","bar"]}
```


# Pull Request Checklist

Please ensure your pull request meets the following requirements:

- [x] Open your pull request against the `master` branch.
- [ ] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [x] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.

Thank you for contributing!
