### PR TITLE
Add .cursorrules for Cursor IDE developer experience

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,94 @@
+# Gin Web Framework — Cursor Rules
+
+You are working on **Gin**, a high-performance HTTP web framework for Go. It provides a Martini-like API with httprouter-based routing.
+
+## Project Structure
+
+This is a single Go module (`github.com/gin-gonic/gin`), not a monorepo.
+
+- Root package `gin` — core framework (router, context, engine, middleware)
+- `binding/` — request binding and validation (JSON, XML, YAML, TOML, Protobuf, BSON)
+- `render/` — response rendering (JSON, XML, HTML, YAML, Protobuf, etc.)
+- `internal/` — internal utilities (not exported)
+- `docs/` — extended documentation (`doc.md`)
+- `testdata/` — test fixtures
+
+## Go Conventions
+
+- Go 1.25+ is required. Use modern Go idioms and standard library features.
+- Every file starts with the copyright header:
+  ```go
+  // Copyright 2014 Manu Martinez-Almeida. All rights reserved.
+  // Use of this source code is governed by a MIT style
+  // license that can be found in the LICENSE file.
+  ```
+- Package name is `gin` for the root, matching subdirectory names for sub-packages.
+- Use `gofmt` / `goimports` formatting — this is non-negotiable.
+
+## Code Style
+
+- **Linter**: `golangci-lint` v2 with the config in `.golangci.yml`. Key enabled linters: `gosec`, `errorlint`, `revive`, `misspell`, `perfsprint`, `testifylint`.
+- Prefer `fmt.Errorf("...: %w", err)` for error wrapping (`errorlint`).
+- Use `errors.Is()` and `errors.As()` instead of direct error comparison.
+- Use standard library string/int conversion functions where possible (`perfsprint`).
+- Avoid naked returns (`nakedret` linter enabled).
+- All exported types, functions, and methods must have doc comments.
+
+## Core Patterns
+
+- **`gin.Context`** is the central type — it carries request, response, middleware chain, and metadata. Passed as `*gin.Context` (pointer).
+- **`gin.Engine`** embeds `RouterGroup` and is the top-level router.
+- **`gin.H`** is the shorthand for `map[string]any` — use it for quick JSON responses.
+- **Middleware** signature: `func(c *gin.Context)`. Call `c.Next()` to continue the chain, `c.Abort()` to stop.
+- **Handler** signature: `gin.HandlerFunc` which is `func(*gin.Context)`.
+- Route grouping via `router.Group("/api")` with group-scoped middleware.
+
+## Binding & Validation
+
+- Request binding uses struct tags: `json`, `xml`, `form`, `uri`, `header`, `yaml`, `toml`.
+- Validation uses `go-playground/validator/v10` with `binding:"required"` tags.
+- `ShouldBind*` methods return errors without aborting; `Bind*` methods abort on error (status 400).
+- Custom validators can be registered on the binding engine.
+
+## Rendering
+
+- Use `c.JSON()`, `c.XML()`, `c.YAML()`, `c.TOML()`, `c.ProtoBuf()` for structured responses.
+- Use `c.HTML()` for template rendering with `html/template`.
+- Use `c.String()` for plain text responses.
+- Always pass `http.Status*` constants for status codes, not raw integers.
+
+## Testing
+
+- Tests use the standard `testing` package with **`testify`** (`assert`, `require`).
+- Test files are `*_test.go` alongside source files in the same package.
+- Use `httptest.NewRecorder()` and `http.NewRequest()` for handler testing.
+- Run tests: `go test ./...`
+- Benchmarks are in `benchmarks_test.go` — performance-sensitive changes should include benchmarks.
+
+## Error Handling
+
+- Use `c.Error(err)` to attach errors to the context for middleware to handle.
+- Custom error types in `errors.go` — `gin.Error` wraps errors with metadata and type classification.
+- Never panic in handlers — use proper error returns or `c.AbortWithStatusJSON()`.
+
+## Naming Conventions
+
+- Files: `lowercase.go`, matching the primary type or concept they contain.
+- Types: `PascalCase` — e.g., `Context`, `Engine`, `RouterGroup`.
+- Constants: `PascalCase` for exported, `camelCase` for unexported. MIME types use `MIME` prefix (`MIMEJSON`).
+- Interfaces: verb-based names (e.g., `ResponseWriter`, `IRouter`, `IRoutes`).
+- Test functions: `TestTypeName_MethodName` pattern.
+
+## Performance
+
+- Gin is designed for zero-allocation routing — be mindful of heap allocations.
+- `Context` objects are pooled via `sync.Pool` — never store `*gin.Context` outside the handler lifecycle.
+- Prefer `strings.Builder` over string concatenation.
+- Use `context.go`'s built-in methods over reimplementing request parsing.
+
+## Contributing
+
+- PRs target the `master` branch.
+- Squash to no more than two commits.
+- All CI checks must pass (GitHub Actions).
+- New features must include tests. Document in `docs/doc.md`, not the README.


### PR DESCRIPTION
Closes #4558

## What is this?

A `.cursorrules` file that helps [Cursor IDE](https://cursor.sh/) generate code following Gin's specific conventions and patterns.

## What it covers

- **Go conventions** — copyright headers, `gofmt`/`goimports` formatting, Go 1.25+ idioms
- **Code style** — `golangci-lint` v2 rules (errorlint, gosec, revive, perfsprint, testifylint, etc.)
- **Core patterns** — `gin.Context` usage, `gin.H` shorthand, middleware/handler signatures, route grouping
- **Binding & validation** — struct tags (`json`, `form`, `uri`), `ShouldBind*` vs `Bind*` patterns, `go-playground/validator`
- **Rendering** — `c.JSON()`, `c.HTML()`, `c.String()` with `http.Status*` constants
- **Error handling** — `c.Error()`, `c.AbortWithStatusJSON()`, `errors.Is()`/`errors.As()` patterns
- **Testing** — `testify` assert/require, `httptest` patterns, benchmark conventions
- **Performance** — `sync.Pool` context recycling, zero-allocation routing awareness, `strings.Builder` preference
- **Naming** — file naming, type naming, constant patterns, test function naming

## Why this helps

When contributors use Cursor IDE to work on Gin, the AI will automatically follow project conventions like proper error wrapping with `%w`, using `http.Status*` constants, following the `Context`-centric architecture, and writing tests with `testify`. This reduces review friction from style issues and helps new contributors produce idiomatic Gin code from the start.

The rules were written by reviewing the actual codebase — `go.mod`, `.golangci.yml`, `context.go`, `CONTRIBUTING.md`, and the source file structure.