### PR TITLE
docs: fix broken anchor link typo in table of contents

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -22,7 +22,7 @@
   - [How to write log file](#how-to-write-log-file)
   - [Custom Log Format](#custom-log-format)
   - [Controlling Log output coloring](#controlling-log-output-coloring)
-  - [Avoid logging query strings](#avoid-loging-query-strings)
+  - [Avoid logging query strings](#avoid-logging-query-strings)
   - [Model binding and validation](#model-binding-and-validation)
   - [Custom Validators](#custom-validators)
   - [Only Bind Query String](#only-bind-query-string)


### PR DESCRIPTION
The anchor link in the table of contents was pointing to
`#avoid-loging-query-strings` (missing letter 'g'), causing
the link to not navigate to the correct section.

Fixed: `#avoid-loging-query-strings` → `#avoid-logging-query-strings`
