### PR TITLE
fix: handle IPv6 brackets and port in X-Forwarded-For parsing

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -486,6 +486,17 @@ func (engine *Engine) validateHeader(header string) (clientIP string, valid bool
 	items := strings.Split(header, ",")
 	for i := len(items) - 1; i >= 0; i-- {
 		ipStr := strings.TrimSpace(items[i])
+
+		// Handle IPv6 with brackets and/or port: [::1], [::1]:8080, 192.168.1.1:8080
+		// net.SplitHostPort handles all these cases and strips brackets
+		if host, _, err := net.SplitHostPort(ipStr); err == nil {
+			ipStr = host
+		} else {
+			// No port present, just strip brackets if any (bare IPv6 like [::1])
+			ipStr = strings.TrimPrefix(ipStr, "[")
+			ipStr = strings.TrimSuffix(ipStr, "]")
+		}
+
 		ip := net.ParseIP(ipStr)
 		if ip == nil {
 			break


### PR DESCRIPTION
## Summary

Fixes #4572 — `validateHeader` fails to parse X-Forwarded-For values with IPv6 brackets or port numbers.

### Problem

Some reverse proxies (IIS, cloud load balancers) send X-Forwarded-For with:
- IPv6 in brackets: `[240e:318:2f4a:de56::240]`
- Port numbers: `192.168.8.39:38792`  
- Both: `[240e:318:2f4a:de56::240]:38792`

`net.ParseIP` returns `nil` for all of these, causing `ClientIP()` to fall back to `RemoteAddr`.

### Fix

Use `net.SplitHostPort` to properly strip brackets and port, with fallback to manual bracket removal for bare bracketed IPv6.

### Test Cases

```
"192.168.8.39"                    → 192.168.8.39 ✅
"[::1]"                           → ::1 ✅
"192.168.8.39:38792"              → 192.168.8.39 ✅
"[::1]:8080"                      → ::1 ✅
"[240e:318:2f4a:de56::240]"       → 240e:318:2f4a:de56::240 ✅
"[240e:318:2f4a:de56::240]:38792" → 240e:318:2f4a:de56::240 ✅
```

Fixes #4572