### PR TITLE
fix: Remove deprecated `http.CloseNotifier`, use `Request.Context().Done()` in Stream

### DIFF
--- a/context.go
+++ b/context.go
@@ -1327,7 +1327,7 @@ func (c *Context) SSEvent(name string, message any) {
 // indicates "Is client disconnected in middle of stream"
 func (c *Context) Stream(step func(w io.Writer) bool) bool {
 	w := c.Writer
-	clientGone := w.CloseNotify()
+	clientGone := c.Request.Context().Done()
 	for {
 		select {
 		case <-clientGone:

--- a/context_test.go
+++ b/context_test.go
@@ -3023,27 +3023,26 @@ func TestContextRenderDataFromReaderNoHeaders(t *testing.T) {
 
 type TestResponseRecorder struct {
 	*httptest.ResponseRecorder
-	closeChannel chan bool
-}
-
-func (r *TestResponseRecorder) CloseNotify() <-chan bool {
-	return r.closeChannel
+	cancel context.CancelFunc
 }
 
 func (r *TestResponseRecorder) closeClient() {
-	r.closeChannel <- true
+	r.cancel()
 }
 
-func CreateTestResponseRecorder() *TestResponseRecorder {
+func CreateTestResponseRecorder() (*TestResponseRecorder, *http.Request) {
+	ctx, cancel := context.WithCancel(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
 	return &TestResponseRecorder{
 		httptest.NewRecorder(),
-		make(chan bool, 1),
-	}
+		cancel,
+	}, req
 }
 
 func TestContextStream(t *testing.T) {
-	w := CreateTestResponseRecorder()
+	w, req := CreateTestResponseRecorder()
 	c, _ := CreateTestContext(w)
+	c.Request = req
 
 	stopStream := true
 	c.Stream(func(w io.Writer) bool {
@@ -3061,8 +3060,9 @@ func TestContextStream(t *testing.T) {
 }
 
 func TestContextStreamWithClientGone(t *testing.T) {
-	w := CreateTestResponseRecorder()
+	w, req := CreateTestResponseRecorder()
 	c, _ := CreateTestContext(w)
+	c.Request = req
 
 	c.Stream(func(writer io.Writer) bool {
 		defer func() {
@@ -3079,7 +3079,7 @@ func TestContextStreamWithClientGone(t *testing.T) {
 }
 
 func TestContextResetInHandler(t *testing.T) {
-	w := CreateTestResponseRecorder()
+	w, _ := CreateTestResponseRecorder()
 	c, _ := CreateTestContext(w)
 
 	c.handlers = []HandlerFunc{

--- a/response_writer.go
+++ b/response_writer.go
@@ -24,7 +24,6 @@ type ResponseWriter interface {
 	http.ResponseWriter
 	http.Hijacker
 	http.Flusher
-	http.CloseNotifier
 
 	// Status returns the HTTP response status code of the current request.
 	Status() int
@@ -118,11 +117,6 @@ func (w *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 		w.size = 0
 	}
 	return w.ResponseWriter.(http.Hijacker).Hijack()
-}
-
-// CloseNotify implements the http.CloseNotifier interface.
-func (w *responseWriter) CloseNotify() <-chan bool {
-	return w.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 
 // Flush implements the http.Flusher interface.

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -26,7 +26,6 @@ var (
 	_ http.ResponseWriter = ResponseWriter(&responseWriter{})
 	_ http.Hijacker       = ResponseWriter(&responseWriter{})
 	_ http.Flusher        = ResponseWriter(&responseWriter{})
-	_ http.CloseNotifier  = ResponseWriter(&responseWriter{})
 )
 
 func init() {
@@ -118,10 +117,6 @@ func TestResponseWriterHijack(t *testing.T) {
 		require.NoError(t, err)
 	})
 	assert.True(t, w.Written())
-
-	assert.Panics(t, func() {
-		w.CloseNotify()
-	})
 
 	w.Flush()
 }


### PR DESCRIPTION
## Summary

Fixes #4586

- Remove `http.CloseNotifier` embedding from the `ResponseWriter` interface
- Replace `w.CloseNotify()` with `c.Request.Context().Done()` in the `Stream` method
- Update related tests accordingly

## Motivation

`http.CloseNotifier` has been officially deprecated since Go 1.11. The Go documentation recommends using `Request.Context()` instead:

> Deprecated: the CloseNotifier interface predates Go's context package. New code should use Request.Context instead.

`Request.Context().Done()` also covers a broader set of termination scenarios (timeout, cancellation) beyond just client disconnection.

## Changes

### `response_writer.go`
- Remove `http.CloseNotifier` embedding from the `ResponseWriter` interface
- Delete the `CloseNotify()` method from `responseWriter`

### `context.go`
- `Stream`: replace `clientGone := w.CloseNotify()` with `clientGone := c.Request.Context().Done()`

### `context_test.go`
- Replace `closeChannel chan bool` + `CloseNotify()` in `TestResponseRecorder` with `cancel context.CancelFunc`
- Update `closeClient()` to call `r.cancel()` instead of sending to a channel
- Update `CreateTestResponseRecorder()` to return `(*TestResponseRecorder, *http.Request)`
- Update call sites: `TestContextStream`, `TestContextStreamWithClientGone`, `TestContextResetInHandler`

### `response_writer_test.go`
- Remove compile-time interface check for `http.CloseNotifier`
- Remove `w.CloseNotify()` panic test block