### PR TITLE
docs: document panic conditions in Handle, StaticFS, and Bind

### DIFF
--- a/routergroup.go
+++ b/routergroup.go
@@ -83,6 +83,8 @@ func (group *RouterGroup) BasePath() string {
 	return group.basePath
 }
 
+// Handle registers a new request handle and middleware with the given path and method.
+// It panics if httpMethod is not a valid HTTP method.
 func (group *RouterGroup) handle(httpMethod, relativePath string, handlers HandlersChain) IRoutes {
 	absolutePath := group.calculateAbsolutePath(relativePath)
 	handlers = group.combineHandlers(handlers)
@@ -200,6 +202,7 @@ func (group *RouterGroup) Static(relativePath, root string) IRoutes {
 
 // StaticFS works just like `Static()` but a custom `http.FileSystem` can be used instead.
 // Gin by default uses: gin.Dir()
+// It panics if relativePath contains URL parameters (: or *).
 func (group *RouterGroup) StaticFS(relativePath string, fs http.FileSystem) IRoutes {
 	if strings.Contains(relativePath, ":") || strings.Contains(relativePath, "*") {
 		panic("URL parameters can not be used when serving a static folder")

--- a/utils.go
+++ b/utils.go
@@ -26,6 +26,7 @@ const localhostIP = "127.0.0.1"
 const localhostIPv6 = "::1"
 
 // Bind is a helper function for given interface object and returns a Gin middleware.
+// It panics if val is a pointer; pass the struct value directly (e.g., Bind(Struct{}) not Bind(&Struct{})).
 func Bind(val any) HandlerFunc {
 	value := reflect.ValueOf(val)
 	if value.Kind() == reflect.Ptr {


### PR DESCRIPTION
# Pull Request Checklist

Please ensure your pull request meets the following requirements:

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [ ] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.

Thank you for contributing!

## What this PR does

Adds panic documentation to three exported functions whose doc comments
don't mention that they can panic on invalid input:

- `RouterGroup.Handle` — panics on invalid HTTP method
- `RouterGroup.StaticFS` — panics when relativePath contains `:` or `*`
- `Bind` — panics when val is a pointer

Callers relying on godoc have no way to discover these crash conditions
without reading the source.

## Changes

Documentation only — no behavior or logic changes.

- `routergroup.go`: added `// It panics if ...` to `Handle` and `StaticFS`
- `utils.go`: added `// It panics if ...` to `Bind`

## Why

Go convention (and the standard library itself) documents panic conditions
in doc comments. For example, `regexp.MustCompile` says
"It panics if the expression cannot be parsed." These three functions
follow the same pattern but lack the documentation.