### PR TITLE
fix: pin 5 unpinned action(s)

### DIFF
--- a/.github/workflows/gin.yml
+++ b/.github/workflows/gin.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           go-version: "^1"
       - name: Setup golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: v2.11
           args: --verbose
@@ -78,6 +78,6 @@ jobs:
         run: make test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           flags: ${{ matrix.os }},go-${{ matrix.go }},${{ matrix.test-tags }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: "^1"
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Trivy vulnerability scanner (source code)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: "fs"
           scan-ref: "."
@@ -44,7 +44,7 @@ jobs:
           sarif_file: "trivy-results.sarif"
 
       - name: Run Trivy scanner (table output for logs)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         if: always()
         with:
           scan-type: "fs"


### PR DESCRIPTION
Re-submission of #4596. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags.

- Pin 5 unpinned actions to full 40-character SHAs
- Add version comments for readability

## How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3`, original version preserved as comment
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)