### PR TITLE
feat: add warning for multiple response writes

### DIFF
--- a/context.go
+++ b/context.go
@@ -1158,6 +1158,10 @@ func (c *Context) Render(code int, r render.Render) {
 		return
 	}
 
+	if c.Writer.Written() {
+		debugPrint("[WARNING] Response body already written. Attempting to write again with status code %d", code)
+	}
+
 	if err := r.Render(c.Writer); err != nil {
 		// Pushing error to c.Errors
 		_ = c.Error(err)

--- a/context_test.go
+++ b/context_test.go
@@ -3808,3 +3808,47 @@ func BenchmarkGetMapFromFormData(b *testing.B) {
 		})
 	}
 }
+
+func TestRenderMultipleWritesWarning(t *testing.T) {
+	// Test that a warning is printed when attempting to write response body multiple times
+	var w *httptest.ResponseRecorder
+	re := captureOutput(t, func() {
+		SetMode(DebugMode)
+		router := New()
+		router.GET("/test", func(c *Context) {
+			c.JSON(http.StatusOK, H{"first": "response"})
+			c.JSON(http.StatusOK, H{"second": "response"}) // Should trigger warning
+		})
+		w = httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		router.ServeHTTP(w, req)
+		SetMode(TestMode)
+	})
+
+	// Should contain the warning about multiple writes
+	assert.Contains(t, re, "[WARNING] Response body already written")
+	assert.Contains(t, re, "200")
+
+	// Verify the response body contains both responses (behavior unchanged)
+	assert.Contains(t, w.Body.String(), "first")
+	assert.Contains(t, w.Body.String(), "second")
+}
+
+func TestRenderMultipleWritesNoWarningInReleaseMode(t *testing.T) {
+	// Test that no warning is printed in release mode
+	re := captureOutput(t, func() {
+		SetMode(ReleaseMode)
+		router := New()
+		router.GET("/test", func(c *Context) {
+			c.JSON(http.StatusOK, H{"first": "response"})
+			c.JSON(http.StatusOK, H{"second": "response"})
+		})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		router.ServeHTTP(w, req)
+		SetMode(TestMode)
+	})
+
+	// Should not contain the warning in release mode
+	assert.NotContains(t, re, "[WARNING] Response body already written")
+}


### PR DESCRIPTION
## Summary

Adds a warning when attempting to write a response body multiple times. This helps developers debug issues where response bodies are written more than once.

## Problem

When calling response write methods multiple times (e.g., `c.Render()` followed by another write), the behavior can be confusing. Developers may not realize they're overwriting a previous response.

## Solution

- Added a check in `Context.Render()` to detect if response body was already written
- When detected, prints a warning using `debugPrint` in debug mode
- No behavior change in release mode

## Changes

- `context.go` (+4 lines) - Added multiple write detection
- `context_test.go` (+44 lines) - Added tests for debug and release modes

## Testing

- Added `TestRenderMultipleWritesWarning` - verifies warning in debug mode
- Added `TestRenderMultipleWritesNoWarningInReleaseMode` - verifies no warning in release mode

Fixes #4477