### PR TITLE
docs: add panic conditions documentation for Handle, StaticFS, and Bind

### DIFF
--- a/routergroup.go
+++ b/routergroup.go
@@ -100,6 +100,8 @@ func (group *RouterGroup) handle(httpMethod, relativePath string, handlers Handl
 // This function is intended for bulk loading and to allow the usage of less
 // frequently used, non-standardized or custom methods (e.g. for internal
 // communication with a proxy).
+//
+// It panics if httpMethod is not a valid HTTP method (uppercase ASCII letters only).
 func (group *RouterGroup) Handle(httpMethod, relativePath string, handlers ...HandlerFunc) IRoutes {
 	if matched := regEnLetter.MatchString(httpMethod); !matched {
 		panic("http method " + httpMethod + " is not valid")
@@ -200,6 +202,8 @@ func (group *RouterGroup) Static(relativePath, root string) IRoutes {
 
 // StaticFS works just like `Static()` but a custom `http.FileSystem` can be used instead.
 // Gin by default uses: gin.Dir()
+//
+// It panics if relativePath contains URL parameters (: or *).
 func (group *RouterGroup) StaticFS(relativePath string, fs http.FileSystem) IRoutes {
 	if strings.Contains(relativePath, ":") || strings.Contains(relativePath, "*") {
 		panic("URL parameters can not be used when serving a static folder")

--- a/utils.go
+++ b/utils.go
@@ -26,6 +26,7 @@ const localhostIP = "127.0.0.1"
 const localhostIPv6 = "::1"
 
 // Bind is a helper function for given interface object and returns a Gin middleware.
+// It panics if val is a pointer; pass the struct value directly (e.g., Bind(Struct{}) not Bind(&Struct{})).
 func Bind(val any) HandlerFunc {
 	value := reflect.ValueOf(val)
 	if value.Kind() == reflect.Ptr {


### PR DESCRIPTION
## Summary

This PR adds documentation for panic conditions in three exported functions:

- **Handle**: panics if httpMethod is not a valid HTTP method (uppercase ASCII letters only)
- **StaticFS**: panics if relativePath contains URL parameters (: or *)
- **Bind**: panics if val is a pointer

## Motivation

Three exported public API functions contain panic() calls on invalid input, but none of the doc comments mention the panic conditions. Callers cannot discover the crash risk without reading the source. This is a documentation gap — the panics themselves are reasonable startup-time guards, but they should be documented.

## Changes

Added panic condition documentation to each function's doc comment:

1. `RouterGroup.Handle` in routergroup.go
2. `RouterGroup.StaticFS` in routergroup.go
3. `Bind` in utils.go

## Related Issue

Fixes #4594

## Testing

This is a documentation-only change. No functional code changes were made.

- [x] Documentation builds correctly
- [x] No test changes needed (documentation only)

## Checklist

- [x] Documentation added/updated
- [x] Commit message follows conventional commits
- [x] PR title clearly describes the change