### PR TITLE
docs: add panic conditions documentation for SetMode and Redirect.Render

### DIFF
--- a/mode.go
+++ b/mode.go
@@ -55,6 +55,7 @@ func init() {
 }
 
 // SetMode sets gin mode according to input string.
+// It panics if the value is not a valid gin mode (debug, release, or test).
 func SetMode(value string) {
 	if value == "" {
 		if flag.Lookup("test.v") != nil {

--- a/render/redirect.go
+++ b/render/redirect.go
@@ -17,6 +17,7 @@ type Redirect struct {
 }
 
 // Render (Redirect) redirects the http request to new location and writes redirect response.
+// It panics if the status code is not a valid redirect status code (300-308, except 201).
 func (r Redirect) Render(w http.ResponseWriter) error {
 	if (r.Code < http.StatusMultipleChoices || r.Code > http.StatusPermanentRedirect) && r.Code != http.StatusCreated {
 		panic(fmt.Sprintf("Cannot redirect with status code %d", r.Code))


### PR DESCRIPTION
This PR adds documentation for panic conditions in the following functions:

1. **SetMode** (mode.go): Documents that it panics if the value is not a valid gin mode (debug, release, or test).

2. **Redirect.Render** (render/redirect.go): Documents that it panics if the status code is not a valid redirect status code (300-308, except 201).

This is a continuation of the panic conditions documentation effort started in the previous PR.