### PR TITLE
docs(recovery): clarify RecoveryWithWriter only uses the first RecoveryFunc

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -42,6 +42,7 @@ func CustomRecovery(handle RecoveryFunc) HandlerFunc {
 }
 
 // RecoveryWithWriter returns a middleware for a given writer that recovers from any panics and writes a 500 if there was one.
+// If recovery handlers are provided, only the first one is used.
 func RecoveryWithWriter(out io.Writer, recovery ...RecoveryFunc) HandlerFunc {
 	if len(recovery) > 0 {
 		return CustomRecoveryWithWriter(out, recovery[0])

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -256,6 +256,33 @@ func TestRecoveryWithWriterWithCustomRecovery(t *testing.T) {
 	SetMode(TestMode)
 }
 
+func TestRecoveryWithWriterUsesOnlyFirstRecoveryFunc(t *testing.T) {
+	buffer := new(strings.Builder)
+	router := New()
+
+	calls := 0
+	first := func(c *Context, err any) {
+		calls++
+		assert.Equal(t, "Oops, Houston, we have a problem", err)
+		c.AbortWithStatus(http.StatusBadRequest)
+	}
+	second := func(c *Context, err any) {
+		calls += 100
+		c.AbortWithStatus(http.StatusTeapot)
+	}
+
+	router.Use(RecoveryWithWriter(buffer, first, second))
+	router.GET("/recovery", func(_ *Context) {
+		panic("Oops, Houston, we have a problem")
+	})
+
+	w := PerformRequest(router, http.MethodGet, "/recovery")
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, 1, calls)
+	assert.Contains(t, buffer.String(), "panic recovered")
+}
+
 func TestSecureRequestDump(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
  ## Summary

  Clarify the `RecoveryWithWriter` behavior when multiple `RecoveryFunc` values
  are passed.

  Gin currently only uses the first recovery handler from the variadic argument
  list. This change documents that behavior and adds a test to prevent future
  confusion.

  ## Changes

  - update the exported comment on `RecoveryWithWriter`
  - add a test verifying only the first recovery handler is used

  Fixes #4044
  - gin/recovery.go:44
  - gin/recovery_test.go:259