### PR TITLE
refactor(binding): use idiomatic range loop for SliceValidationError

### DIFF
--- a/binding/binding_nomsgpack.go
+++ b/binding/binding_nomsgpack.go
@@ -71,18 +71,18 @@ var Validator StructValidator = &defaultValidator{}
 // These implement the Binding interface and can be used to bind the data
 // present in the request to struct instances.
 var (
-	JSON          = jsonBinding{}
-	XML           = xmlBinding{}
-	Form          = formBinding{}
-	Query         = queryBinding{}
-	FormPost      = formPostBinding{}
-	FormMultipart = formMultipartBinding{}
-	ProtoBuf      = protobufBinding{}
-	YAML          = yamlBinding{}
-	Uri           = uriBinding{}
-	Header        = headerBinding{}
-	TOML          = tomlBinding{}
-	Plain         = plainBinding{}
+	JSON                      = jsonBinding{}
+	XML                       = xmlBinding{}
+	Form                      = formBinding{}
+	Query                     = queryBinding{}
+	FormPost                  = formPostBinding{}
+	FormMultipart             = formMultipartBinding{}
+	ProtoBuf                  = protobufBinding{}
+	YAML                      = yamlBinding{}
+	Uri                       = uriBinding{}
+	Header                    = headerBinding{}
+	TOML                      = tomlBinding{}
+	Plain                     = plainBinding{}
 	BSON          BindingBody = bsonBinding{}
 )
 

--- a/binding/default_validator.go
+++ b/binding/default_validator.go
@@ -28,13 +28,13 @@ func (err SliceValidationError) Error() string {
 
 	var b strings.Builder
 	for i, e := range err {
-	if e != nil {
-		if b.Len() > 0 {
-			b.WriteString("\n")
+		if e != nil {
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString("[" + strconv.Itoa(i) + "]: " + e.Error())
 		}
-		b.WriteString("[" + strconv.Itoa(i) + "]: " + e.Error())
 	}
-}
 	return b.String()
 }
 

--- a/binding/default_validator.go
+++ b/binding/default_validator.go
@@ -27,14 +27,14 @@ func (err SliceValidationError) Error() string {
 	}
 
 	var b strings.Builder
-	for i := range len(err) {
-		if err[i] != nil {
-			if b.Len() > 0 {
-				b.WriteString("\n")
-			}
-			b.WriteString("[" + strconv.Itoa(i) + "]: " + err[i].Error())
+	for i, e := range err {
+	if e != nil {
+		if b.Len() > 0 {
+			b.WriteString("\n")
 		}
+		b.WriteString("[" + strconv.Itoa(i) + "]: " + e.Error())
 	}
+}
 	return b.String()
 }
 


### PR DESCRIPTION
Replaced a non-idiomatic loop (`for i := range len(err)`) 
with a standard Go range loop (`for i, e := range err`).

This improves readability and aligns with Go best practices 
without changing behavior