### PR TITLE
fix(engine): accept bracketed IPv6 and port-suffixed entries in X-Forwarded-For

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -485,8 +485,8 @@ func (engine *Engine) validateHeader(header string) (clientIP string, valid bool
 	}
 	items := strings.Split(header, ",")
 	for i := len(items) - 1; i >= 0; i-- {
-		ipStr := strings.TrimSpace(items[i])
-		ip := net.ParseIP(ipStr)
+		item := strings.TrimSpace(items[i])
+		ipStr, ip := parseForwardedForItem(item)
 		if ip == nil {
 			break
 		}
@@ -498,6 +498,35 @@ func (engine *Engine) validateHeader(header string) (clientIP string, valid bool
 		}
 	}
 	return "", false
+}
+
+// parseForwardedForItem normalizes a single X-Forwarded-For entry and parses it.
+// It accepts the four common forms emitted by reverse proxies:
+//
+//   - "1.2.3.4"
+//   - "2001:db8::1"
+//   - "[2001:db8::1]"             (IIS/ARR style)
+//   - "1.2.3.4:12345"             (with port, some LBs)
+//   - "[2001:db8::1]:12345"       (IIS/ARR + port)
+//
+// The returned string is the IP without brackets or port, so callers see a
+// consistent form regardless of which proxy produced the header.
+func parseForwardedForItem(item string) (string, net.IP) {
+	// Try host:port form first (handles "ip:port" and "[ipv6]:port").
+	if host, _, err := net.SplitHostPort(item); err == nil {
+		if ip := net.ParseIP(host); ip != nil {
+			return host, ip
+		}
+	}
+	// Strip optional surrounding brackets for bare "[ipv6]" with no port.
+	unbracketed := item
+	if strings.HasPrefix(unbracketed, "[") && strings.HasSuffix(unbracketed, "]") {
+		unbracketed = unbracketed[1 : len(unbracketed)-1]
+	}
+	if ip := net.ParseIP(unbracketed); ip != nil {
+		return unbracketed, ip
+	}
+	return "", nil
 }
 
 // updateRouteTree do update to the route tree recursively

--- a/gin_test.go
+++ b/gin_test.go
@@ -1156,3 +1156,35 @@ func TestUpdateRouteTreesCalledOnce(t *testing.T) {
 		assert.Equal(t, "ok", w.Body.String())
 	}
 }
+
+func TestValidateHeaderForwardedForForms(t *testing.T) {
+	engine := New()
+	// Disable trusted proxies so the rightmost parseable entry is returned.
+	require.NoError(t, engine.SetTrustedProxies(nil))
+
+	tests := []struct {
+		name   string
+		header string
+		wantIP string
+		wantOK bool
+	}{
+		{"plain IPv4", "192.168.8.39", "192.168.8.39", true},
+		{"plain IPv6", "240e:318:2f4a:de56::240", "240e:318:2f4a:de56::240", true},
+		{"bracketed IPv6 (IIS/ARR)", "[240e:318:2f4a:de56::240]", "240e:318:2f4a:de56::240", true},
+		{"IPv4 with port", "192.168.8.39:38792", "192.168.8.39", true},
+		{"bracketed IPv6 with port", "[240e:318:2f4a:de56::240]:38792", "240e:318:2f4a:de56::240", true},
+		{"IPv6 loopback bracketed", "[::1]", "::1", true},
+		{"chain with port on last entry", "1.2.3.4, 5.6.7.8:9000", "5.6.7.8", true},
+		{"empty", "", "", false},
+		{"garbage", "not-an-ip", "", false},
+		{"bracketed garbage", "[not-an-ip]", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIP, gotOK := engine.validateHeader(tt.header)
+			assert.Equal(t, tt.wantOK, gotOK)
+			assert.Equal(t, tt.wantIP, gotIP)
+		})
+	}
+}


### PR DESCRIPTION
## What

`Context.ClientIP()` now parses `X-Forwarded-For` entries in the bracketed and port-suffixed forms produced by IIS/ARR and several cloud load balancers.

Closes #4572.

## Why

`validateHeader` in `gin.go` handed each comma-split item straight to `net.ParseIP`, which silently rejects anything other than a bare `1.2.3.4` or `2001:db8::1`. In practice proxies often emit:

| Input header | v1.12.0 `ClientIP()` | After this PR |
|---|---|---|
| `X-Forwarded-For: 192.168.8.39` | `192.168.8.39` | `192.168.8.39` (unchanged) |
| `X-Forwarded-For: 240e:318:2f4a:de56::240` | `240e:318:2f4a:de56::240` | `240e:318:2f4a:de56::240` (unchanged) |
| `X-Forwarded-For: [240e:318:2f4a:de56::240]` | falls back to `RemoteAddr` | `240e:318:2f4a:de56::240` |
| `X-Forwarded-For: 192.168.8.39:38792` | falls back to `RemoteAddr` | `192.168.8.39` |
| `X-Forwarded-For: [240e:318:2f4a:de56::240]:38792` | falls back to `RemoteAddr` | `240e:318:2f4a:de56::240` |

The last three rows are the failure modes from the report.

## How

A small `parseForwardedForItem` helper:

1. Tries `net.SplitHostPort` first — this handles `ip:port` and `[ipv6]:port` and already strips the brackets for us.
2. Falls back to stripping optional surrounding `[]` and calling `net.ParseIP` — covers the bare `[ipv6]` case.
3. Returns the normalised IP string (no brackets, no port) so `ClientIP()`'s output shape is identical across all proxy flavours.

`validateHeader`'s trusted-proxy reverse-walk logic is untouched — only the per-item parse changes.

## Test plan

Table-driven test `TestValidateHeaderForwardedForForms` covers:

- [x] All four forms the reporter listed
- [x] `[::1]` (bracketed loopback)
- [x] Mixed chain with a port on the rightmost entry
- [x] Empty / garbage / `[garbage]` negative cases

Also verified:

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (whole tree green, including `TestContextClientIP*`)
- [x] `golangci-lint run --verbose` (v2.11.4, matches CI) — 0 issues