### PR TITLE
docs: fix grammar in package and Error doc comments

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 /*
-Package gin implements a HTTP web framework called gin.
+Package gin implements an HTTP web framework called gin.
 
 See https://gin-gonic.com/ for more information about gin.
 

--- a/errors.go
+++ b/errors.go
@@ -28,7 +28,7 @@ const (
 	ErrorTypeAny ErrorType = 1<<64 - 1
 )
 
-// Error represents a error's specification.
+// Error represents an error's specification.
 type Error struct {
 	Err  error
 	Type ErrorType


### PR DESCRIPTION

**Repo:** gin-gonic/gin (⭐ 76000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Fixes two minor grammar mistakes in public-facing GoDoc comments. The package-level doc in `doc.go` said "a HTTP web framework" and the `Error` type doc in `errors.go` said "a error's specification". Both should use "an" since the following words begin with a vowel sound.

## Why
These doc comments are surfaced on pkg.go.dev and are the first thing users read about the package and the `Error` type. The fix is purely cosmetic but improves the polish of the public API documentation. No code or behavior changes.

## Testing
No code paths are touched; only comments. `go vet` is unaffected. The repo's test suite is not exercised by these changes.

## Risk
Low — comment-only change to two lines.
