### PR TITLE
fix: safe type assertions in CloseNotify() and Hijack()

### DIFF
--- a/context.go
+++ b/context.go
@@ -1328,9 +1328,15 @@ func (c *Context) SSEvent(name string, message any) {
 func (c *Context) Stream(step func(w io.Writer) bool) bool {
 	w := c.Writer
 	clientGone := w.CloseNotify()
+	var requestGone <-chan struct{}
+	if c.Request != nil {
+		requestGone = c.Request.Context().Done()
+	}
 	for {
 		select {
 		case <-clientGone:
+			return true
+		case <-requestGone:
 			return true
 		default:
 			keepOpen := step(w)

--- a/context_test.go
+++ b/context_test.go
@@ -3078,6 +3078,25 @@ func TestContextStreamWithClientGone(t *testing.T) {
 	assert.Equal(t, "test", w.Body.String())
 }
 
+func TestContextStreamWithRequestContextDone(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(reqCtx)
+
+	disconnected := c.Stream(func(writer io.Writer) bool {
+		_, err := writer.Write([]byte("test"))
+		require.NoError(t, err)
+
+		return true
+	})
+
+	assert.True(t, disconnected)
+	assert.Empty(t, w.Body.String())
+}
+
 func TestContextResetInHandler(t *testing.T) {
 	w := CreateTestResponseRecorder()
 	c, _ := CreateTestContext(w)

--- a/response_writer.go
+++ b/response_writer.go
@@ -17,7 +17,10 @@ const (
 	defaultStatus = http.StatusOK
 )
 
-var errHijackAlreadyWritten = errors.New("gin: response body already written")
+var (
+	errHijackAlreadyWritten = errors.New("gin: response body already written")
+	errHijackNotSupported   = errors.New("gin: underlying ResponseWriter does not support hijacking")
+)
 
 // ResponseWriter ...
 type ResponseWriter interface {
@@ -109,20 +112,25 @@ func (w *responseWriter) Written() bool {
 
 // Hijack implements the http.Hijacker interface.
 func (w *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	// Allow hijacking before any data is written (size == -1) or after headers are written (size == 0),
-	// but not after body data is written (size > 0). For compatibility with websocket libraries (e.g., github.com/coder/websocket)
 	if w.size > 0 {
 		return nil, nil, errHijackAlreadyWritten
+	}
+	hijacker, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, errHijackNotSupported
 	}
 	if w.size < 0 {
 		w.size = 0
 	}
-	return w.ResponseWriter.(http.Hijacker).Hijack()
+	return hijacker.Hijack()
 }
 
 // CloseNotify implements the http.CloseNotifier interface.
 func (w *responseWriter) CloseNotify() <-chan bool {
-	return w.ResponseWriter.(http.CloseNotifier).CloseNotify()
+	if cn, ok := w.ResponseWriter.(http.CloseNotifier); ok {
+		return cn.CloseNotify()
+	}
+	return nil
 }
 
 // Flush implements the http.Flusher interface.

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -115,7 +115,7 @@ func TestResponseWriterHijack(t *testing.T) {
 
 	// Hijack on a non-hijacker writer returns an error without panicking.
 	_, _, err := w.Hijack()
-	assert.Error(t, err)
+	require.Error(t, err)
 	// Capability check happens before state mutation, so Written() stays false on failure.
 	assert.False(t, w.Written())
 
@@ -352,7 +352,7 @@ func TestResponseWriterOptionalInterfaceFallbacks(t *testing.T) {
 			conn, buf, err := rw.Hijack()
 			assert.Nil(t, conn)
 			assert.Nil(t, buf)
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.Contains(t, err.Error(), "does not support hijacking")
 		})
 		// Capability check happens before state mutation, so Written() stays false on failure.

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -113,17 +113,13 @@ func TestResponseWriterHijack(t *testing.T) {
 	writer.reset(testWriter)
 	w := ResponseWriter(writer)
 
-	assert.Panics(t, func() {
-		_, _, err := w.Hijack()
-		require.NoError(t, err)
-	})
-	assert.True(t, w.Written())
+	// Hijack on a non-hijacker writer returns an error without panicking.
+	_, _, err := w.Hijack()
+	assert.Error(t, err)
+	// Capability check happens before state mutation, so Written() stays false on failure.
+	assert.False(t, w.Written())
 
-	assert.Panics(t, func() {
-		w.CloseNotify()
-	})
-
-	w.Flush()
+	assert.NotPanics(t, func() { w.Flush() })
 }
 
 type mockHijacker struct {
@@ -314,4 +310,52 @@ func TestPusherWithoutPusher(t *testing.T) {
 
 	pusher := w.Pusher()
 	assert.Nil(t, pusher, "Expected pusher to be nil")
+}
+
+// mockNonHijackerWriter implements only http.ResponseWriter.
+// It intentionally does NOT implement http.Hijacker, http.Flusher, or http.CloseNotifier.
+type mockNonHijackerWriter struct {
+	headers http.Header
+}
+
+func (m *mockNonHijackerWriter) Header() http.Header {
+	if m.headers == nil {
+		m.headers = make(http.Header)
+	}
+	return m.headers
+}
+
+func (m *mockNonHijackerWriter) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func (m *mockNonHijackerWriter) WriteHeader(statusCode int) {}
+
+func TestResponseWriterOptionalInterfaceFallbacks(t *testing.T) {
+	w := &mockNonHijackerWriter{}
+	rw := &responseWriter{}
+	rw.reset(w)
+
+	t.Run("Flush does not panic without Flusher", func(t *testing.T) {
+		assert.NotPanics(t, func() { rw.Flush() })
+	})
+
+	t.Run("CloseNotify returns nil without CloseNotifier", func(t *testing.T) {
+		var ch <-chan bool
+		assert.NotPanics(t, func() { ch = rw.CloseNotify() })
+		assert.Nil(t, ch)
+	})
+
+	t.Run("Hijack returns error without Hijacker", func(t *testing.T) {
+		rw.reset(w) // reset state so Written() starts false
+		assert.NotPanics(t, func() {
+			conn, buf, err := rw.Hijack()
+			assert.Nil(t, conn)
+			assert.Nil(t, buf)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "does not support hijacking")
+		})
+		// Capability check happens before state mutation, so Written() stays false on failure.
+		assert.False(t, rw.Written())
+	})
 }


### PR DESCRIPTION
## Problem                                                                                                                                                                                  
         
Similar to #4460 (fixed for `Flush()` in #4479), `Hijack()` and `CloseNotify()` perform direct type assertions that panic when the underlying writer doesn't implement the interface.
                                                                                                                                                                                     
When gin is used with `http.TimeoutHandler` or any middleware that wraps `http.ResponseWriter` with a type that doesn't implement `http.Hijacker` or `http.CloseNotifier`, calling `Hijack()` or `CloseNotify()` causes a runtime panic:                                                                                                                                       
                                                                                                                                                                                              
  ```go                                                  
  // panics if underlying writer is not http.CloseNotifier                                                                                                                                    
  return w.ResponseWriter.(http.CloseNotifier).CloseNotify()                       
                                                            
  // panics if underlying writer is not http.Hijacker       
  return w.ResponseWriter.(http.Hijacker).Hijack()                                                                                                                                            
  ```                                                              
                                                                                                                                                                                              
## Fix                                                                                                                                                                                      
                                                                                                                                                                                              
Replace direct assertions with checked assertions - the same pattern already used in `Flush()`:                                                                                             
                                                                                                 
 - `CloseNotify()` returns `nil` when unsupported (`http.CloseNotifier` is deprecated since Go 1.11; callers should use `Request.Context().Done()`)
 -  `Hijack()` returns `errHijackNotSupported`, consistent with the existing `errHijackAlreadyWritten` pattern                                      
                                                                                                                                                                                              
The capability check in `Hijack()` now runs before mutating `w.size`, so `Written()` stays `false` on the error path.
                                                                                                                                                                                              
## Tests                                                                         
                                                                                                                                                                                              
Added `TestResponseWriterOptionalInterfaceFallbacks` with a `mockNonHijackerWriter` (implements only `http.ResponseWriter`) verifying that `Flush()`, `CloseNotify()`, and `Hijack()` all degrade gracefully without panicking. 

Closes #4638.