### PR TITLE
Avoid response writer panics for unsupported Hijack and CloseNotify

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -114,15 +114,22 @@ func (w *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if w.size > 0 {
 		return nil, nil, errHijackAlreadyWritten
 	}
+	hijacker, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, http.ErrNotSupported
+	}
 	if w.size < 0 {
 		w.size = 0
 	}
-	return w.ResponseWriter.(http.Hijacker).Hijack()
+	return hijacker.Hijack()
 }
 
 // CloseNotify implements the http.CloseNotifier interface.
 func (w *responseWriter) CloseNotify() <-chan bool {
-	return w.ResponseWriter.(http.CloseNotifier).CloseNotify()
+	if notifier, ok := w.ResponseWriter.(http.CloseNotifier); ok {
+		return notifier.CloseNotify()
+	}
+	return nil
 }
 
 // Flush implements the http.Flusher interface.

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,17 +114,34 @@ func TestResponseWriterHijack(t *testing.T) {
 	writer.reset(testWriter)
 	w := ResponseWriter(writer)
 
-	assert.Panics(t, func() {
-		_, _, err := w.Hijack()
-		require.NoError(t, err)
-	})
-	assert.True(t, w.Written())
+	_, _, err := w.Hijack()
+	require.ErrorIs(t, err, http.ErrNotSupported)
+	assert.False(t, w.Written())
 
-	assert.Panics(t, func() {
-		w.CloseNotify()
-	})
+	assert.Nil(t, w.CloseNotify())
 
 	w.Flush()
+}
+
+func TestResponseWriterHijackWithTimeoutHandler(t *testing.T) {
+	var hijackErr error
+	var closeNotify <-chan bool
+	var written bool
+
+	handler := http.TimeoutHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writer := &responseWriter{}
+		writer.reset(w)
+
+		_, _, hijackErr = writer.Hijack()
+		closeNotify = writer.CloseNotify()
+		written = writer.Written()
+	}), time.Second, "")
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.ErrorIs(t, hijackErr, http.ErrNotSupported)
+	assert.Nil(t, closeNotify)
+	assert.False(t, written)
 }
 
 type mockHijacker struct {


### PR DESCRIPTION
Fixes https://github.com/gin-gonic/gin/issues/4638

This makes `Hijack` and `CloseNotify` handle wrapped response writers, such as
`http.TimeoutHandler`'s writer, that do not implement those optional
interfaces. `Hijack` now returns `http.ErrNotSupported` when the wrapped writer
cannot hijack, and `CloseNotify` returns nil instead of panicking.

I updated the response writer regression test and ran the focused response
writer tests plus the full suite in a Go 1.25 Docker container.

# Pull Request Checklist

Please ensure your pull request meets the following requirements:

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [ ] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.

Thank you for contributing!