### PR TITLE
fix(context): only chmod newly created dirs in SaveUploadedFile (fixes #4622)

### DIFF
--- a/context.go
+++ b/context.go
@@ -728,11 +728,17 @@ func (c *Context) SaveUploadedFile(file *multipart.FileHeader, dst string, perm 
 		mode = perm[0]
 	}
 	dir := filepath.Dir(dst)
+	// Check if directory exists to only chmod newly created directories
+	_, statErr := os.Stat(dir)
+	dirExists := !os.IsNotExist(statErr)
 	if err = os.MkdirAll(dir, mode); err != nil {
 		return err
 	}
-	if err = os.Chmod(dir, mode); err != nil {
-		return err
+	// Only chmod if directory was newly created (fixes #4622)
+	if !dirExists {
+		if err = os.Chmod(dir, mode); err != nil {
+			return err
+		}
 	}
 
 	out, err := os.Create(dst)

--- a/context_test.go
+++ b/context_test.go
@@ -246,14 +246,19 @@ func TestSaveUploadedFileWithPermission(t *testing.T) {
 	f, err := c.FormFile("file")
 	require.NoError(t, err)
 	assert.Equal(t, "permission_test", f.Filename)
+
+	// Save into a not-yet-existing subdirectory so the requested mode is
+	// applied by MkdirAll/Chmod and the assertion is independent of the
+	// test runner's working-directory permissions.
+	parent := t.TempDir()
+	newDir := filepath.Join(parent, "perm_subdir")
+	dst := filepath.Join(newDir, "permission_test")
+
 	var mode fs.FileMode = 0o755
-	require.NoError(t, c.SaveUploadedFile(f, "permission_test", mode))
-	t.Cleanup(func() {
-		assert.NoError(t, os.Remove("permission_test"))
-	})
-	info, err := os.Stat(filepath.Dir("permission_test"))
+	require.NoError(t, c.SaveUploadedFile(f, dst, mode))
+	info, err := os.Stat(newDir)
 	require.NoError(t, err)
-	assert.Equal(t, info.Mode().Perm(), mode)
+	assert.Equal(t, mode, info.Mode().Perm())
 }
 
 func TestSaveUploadedFileWithPermissionFailed(t *testing.T) {
@@ -272,6 +277,39 @@ func TestSaveUploadedFileWithPermissionFailed(t *testing.T) {
 	assert.Equal(t, "permission_test", f.Filename)
 	var mode fs.FileMode = 0o644
 	require.Error(t, c.SaveUploadedFile(f, "test/permission_test", mode))
+}
+
+// TestSaveUploadedFileExistingDir verifies that SaveUploadedFile does not
+// alter permissions on a pre-existing target directory (regression test for
+// #4622, where chmod on a system dir like /tmp would fail).
+func TestSaveUploadedFileExistingDir(t *testing.T) {
+	buf := new(bytes.Buffer)
+	mw := multipart.NewWriter(buf)
+	w, err := mw.CreateFormFile("file", "existing_dir_test")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("existing_dir_test"))
+	require.NoError(t, err)
+	mw.Close()
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(http.MethodPost, "/", buf)
+	c.Request.Header.Set("Content-Type", mw.FormDataContentType())
+	f, err := c.FormFile("file")
+	require.NoError(t, err)
+
+	// Create a target directory with a non-default permission and
+	// confirm SaveUploadedFile leaves the existing perm untouched.
+	dir := t.TempDir()
+	var existingPerm fs.FileMode = 0o700
+	require.NoError(t, os.Chmod(dir, existingPerm))
+
+	dst := filepath.Join(dir, "existing_dir_test")
+	var mode fs.FileMode = 0o755
+	require.NoError(t, c.SaveUploadedFile(f, dst, mode))
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, existingPerm, info.Mode().Perm(),
+		"existing directory permissions must not be modified")
 }
 
 func TestContextReset(t *testing.T) {


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #4622 - SaveUploadedFile no longer attempts to modify permissions on existing directories.

### Problem
After upgrading from v1.10.1 to v1.12.0, `SaveUploadedFile` started failing when saving files directly into existing system directories like `/tmp`. The failure happens due to an attempt to call `os.Chmod` on the target directory, even if it already exists and is not owned by the process.

### Solution
Only apply `os.Chmod` when the directory is newly created:
1. Check if directory exists before `os.MkdirAll`
2. Only call `os.Chmod` if directory was newly created
3. Preserves backward compatibility for newly created dirs

### Impact
- ✅ Allows saving files to existing system directories (`/tmp`, etc.)
- ✅ Preserves chmod behavior for newly created directories
- ✅ Restores v1.10.1 behavior (fixes regression)
- ✅ No breaking changes for existing usage

### Testing
Tested manually:
- Saving to `/tmp/test.txt` (existing dir) ✅
- Saving to new dir with custom perms ✅
- Build passes: `go build ./...` ✅

### Code Changes
```go
// Before: Always chmod (breaks /tmp)
os.MkdirAll(dir, mode)
os.Chmod(dir, mode)

// After: Only chmod if newly created
dirExists := !os.IsNotExist(os.Stat(dir))
os.MkdirAll(dir, mode)
if !dirExists {
    os.Chmod(dir, mode)
}
```

---

Co-authored-by: Nghia Nguyen <nghiack7@users.noreply.github.com>