### PR TITLE
Optimize radix route fallback matching

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -121,6 +121,14 @@ func Benchmark404Many(B *testing.B) {
 	runRequest(B, router, http.MethodGet, "/viewfake")
 }
 
+func BenchmarkStaticRouteWithParamFallback(B *testing.B) {
+	router := New()
+	router.GET("/users/:id", func(c *Context) {})
+	router.GET("/users/new", func(c *Context) {})
+	router.GET("/users/:id/profile", func(c *Context) {})
+	runRequest(B, router, http.MethodGet, "/users/new")
+}
+
 type mockWriter struct {
 	headers http.Header
 }

--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -1403,6 +1403,26 @@ func TestPlainBinding(t *testing.T) {
 	require.NoError(t, p.Bind(req, ptr))
 }
 
+func TestPlainBindingBindBody(t *testing.T) {
+	p := Plain
+
+	var s string
+	require.NoError(t, p.BindBody([]byte("test string"), &s))
+	assert.Equal(t, "test string", s)
+
+	var bs []byte
+	require.NoError(t, p.BindBody([]byte("test []byte"), &bs))
+	assert.Equal(t, []byte("test []byte"), bs)
+
+	var i int
+	require.Error(t, p.BindBody([]byte("test fail"), &i))
+
+	require.NoError(t, p.BindBody(nil, nil))
+
+	var ptr *string
+	require.NoError(t, p.BindBody(nil, ptr))
+}
+
 func testProtoBodyBindingFail(t *testing.T, b Binding, name, path, badPath, body, badBody string) {
 	assert.Equal(t, name, b.Name())
 

--- a/codec/json/json_test.go
+++ b/codec/json/json_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Gin Core Team. All rights reserved.
+// Use of this source code is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAPI(t *testing.T) {
+	if API == nil {
+		t.Fatal("API is nil")
+	}
+	if Package == "" {
+		t.Fatal("Package is empty")
+	}
+}
+
+func TestAPIMarshalAndUnmarshal(t *testing.T) {
+	type payload struct {
+		Name string `json:"name"`
+	}
+
+	data, err := API.Marshal(payload{Name: "gin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"name":"gin"}` {
+		t.Fatalf("unexpected marshal output: %s", data)
+	}
+
+	var decoded payload
+	if err := API.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Name != "gin" {
+		t.Fatalf("unexpected decoded payload: %#v", decoded)
+	}
+}
+
+func TestAPIMarshalIndent(t *testing.T) {
+	data, err := API.MarshalIndent(map[string]string{"name": "gin"}, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(data, []byte("\n  ")) {
+		t.Fatalf("expected indented JSON, got %q", data)
+	}
+}
+
+func TestAPIEncoder(t *testing.T) {
+	var buf bytes.Buffer
+	encoder := API.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode("<gin>"); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "\"<gin>\"\n" {
+		t.Fatalf("unexpected encoded JSON: %q", got)
+	}
+}
+
+func TestAPIDecoder(t *testing.T) {
+	decoder := API.NewDecoder(strings.NewReader(`{"known": 1, "extra": 2}`))
+	decoder.UseNumber()
+	decoder.DisallowUnknownFields()
+
+	var dst struct {
+		Known json.Number `json:"known"`
+	}
+	if err := decoder.Decode(&dst); err == nil {
+		t.Fatal("expected unknown field error")
+	}
+}

--- a/ginS/gins_test.go
+++ b/ginS/gins_test.go
@@ -8,10 +8,13 @@ import (
 	"html/template"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -214,6 +217,24 @@ func TestSetHTMLTemplate(t *testing.T) {
 	assert.NotNil(t, engine())
 }
 
+func TestLoadHTMLGlob(t *testing.T) {
+	LoadHTMLGlob("../testdata/template/*")
+
+	assert.NotNil(t, engine())
+}
+
+func TestLoadHTMLFiles(t *testing.T) {
+	LoadHTMLFiles("../testdata/template/hello.tmpl", "../testdata/template/raw.tmpl")
+
+	assert.NotNil(t, engine())
+}
+
+func TestLoadHTMLFS(t *testing.T) {
+	LoadHTMLFS(http.Dir("../testdata"), "template/hello.tmpl", "template/raw.tmpl")
+
+	assert.NotNil(t, engine())
+}
+
 func TestStaticFile(t *testing.T) {
 	StaticFile("/static-file", "../testdata/test_file.txt")
 
@@ -222,6 +243,33 @@ func TestStaticFile(t *testing.T) {
 	engine().ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRunReturnsListenError(t *testing.T) {
+	err := Run("127.0.0.1:bad-port")
+
+	require.Error(t, err)
+}
+
+func TestRunTLSReturnsListenError(t *testing.T) {
+	err := RunTLS("127.0.0.1:bad-port", "../testdata/certificate/cert.pem", "../testdata/certificate/key.pem")
+
+	require.Error(t, err)
+}
+
+func TestRunUnixReturnsListenError(t *testing.T) {
+	err := RunUnix(filepath.Join(t.TempDir(), "missing", "gin.sock"))
+
+	require.Error(t, err)
+}
+
+func TestRunFdReturnsListenerError(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "gin-fd")
+	require.NoError(t, err)
+
+	err = RunFd(int(file.Fd()))
+
+	require.Error(t, err)
 }
 
 func TestStatic(t *testing.T) {

--- a/tree.go
+++ b/tree.go
@@ -417,41 +417,38 @@ type skippedNode struct {
 // given path.
 func (n *node) getValue(path string, params *Params, skippedNodes *[]skippedNode, unescape bool) (value nodeValue) {
 	var globalParamsCount int16
+	var skipStatic bool
 
 walk: // Outer loop for walking the tree
 	for {
 		prefix := n.path
 		if len(path) > len(prefix) {
 			if path[:len(prefix)] == prefix {
+				fullPath := path
 				path = path[len(prefix):]
 
 				// Try all the non-wildcard children first by matching the indices
 				idxc := path[0]
-				for i, c := range []byte(n.indices) {
-					if c == idxc {
-						//  strings.HasPrefix(n.children[len(n.children)-1].path, ":") == n.wildChild
-						if n.wildChild {
-							index := len(*skippedNodes)
-							*skippedNodes = (*skippedNodes)[:index+1]
-							(*skippedNodes)[index] = skippedNode{
-								path: prefix + path,
-								node: &node{
-									path:      n.path,
-									wildChild: n.wildChild,
-									nType:     n.nType,
-									priority:  n.priority,
-									children:  n.children,
-									handlers:  n.handlers,
-									fullPath:  n.fullPath,
-								},
-								paramsCount: globalParamsCount,
+				if !skipStatic {
+					for i, c := range []byte(n.indices) {
+						if c == idxc {
+							//  strings.HasPrefix(n.children[len(n.children)-1].path, ":") == n.wildChild
+							if n.wildChild {
+								index := len(*skippedNodes)
+								*skippedNodes = (*skippedNodes)[:index+1]
+								(*skippedNodes)[index] = skippedNode{
+									path:        fullPath,
+									node:        n,
+									paramsCount: globalParamsCount,
+								}
 							}
-						}
 
-						n = n.children[i]
-						continue walk
+							n = n.children[i]
+							continue walk
+						}
 					}
 				}
+				skipStatic = false
 
 				if !n.wildChild {
 					// If the path at the end of the loop is not equal to '/' and the current node has no child nodes
@@ -467,6 +464,7 @@ walk: // Outer loop for walking the tree
 									*value.params = (*value.params)[:skippedNode.paramsCount]
 								}
 								globalParamsCount = skippedNode.paramsCount
+								skipStatic = true
 								continue walk
 							}
 						}
@@ -598,6 +596,7 @@ walk: // Outer loop for walking the tree
 							*value.params = (*value.params)[:skippedNode.paramsCount]
 						}
 						globalParamsCount = skippedNode.paramsCount
+						skipStatic = true
 						continue walk
 					}
 				}
@@ -655,6 +654,7 @@ walk: // Outer loop for walking the tree
 						*value.params = (*value.params)[:skippedNode.paramsCount]
 					}
 					globalParamsCount = skippedNode.paramsCount
+					skipStatic = true
 					continue walk
 				}
 			}

--- a/tree_test.go
+++ b/tree_test.go
@@ -939,6 +939,40 @@ func TestTreeExpandParamsCapacity(t *testing.T) {
 	}
 }
 
+func TestTreeFindCaseInsensitivePathWithWildcardChildAndBufferedRune(t *testing.T) {
+	tree := &node{
+		path:      "/",
+		indices:   "x",
+		wildChild: true,
+		children: []*node{
+			{path: "x", handlers: fakeHandler("/x"), fullPath: "/x"},
+			{path: ":id", nType: param, handlers: fakeHandler("/:id"), fullPath: "/:id"},
+		},
+	}
+
+	out := tree.findCaseInsensitivePathRec("/x", nil, [4]byte{0, 'x'}, false)
+	if string(out) != "/x" {
+		t.Fatalf("Wrong result: got %s, want /x", string(out))
+	}
+}
+
+func TestTreeFindCaseInsensitivePathWithWildcardChildAndUppercaseStatic(t *testing.T) {
+	tree := &node{
+		path:      "/",
+		indices:   "A",
+		wildChild: true,
+		children: []*node{
+			{path: "A", handlers: fakeHandler("/A"), fullPath: "/A"},
+			{path: ":id", nType: param, handlers: fakeHandler("/:id"), fullPath: "/:id"},
+		},
+	}
+
+	out := tree.findCaseInsensitivePathRec("/a", nil, [4]byte{}, false)
+	if string(out) != "/A" {
+		t.Fatalf("Wrong result: got %s, want /A", string(out))
+	}
+}
+
 func TestTreeWildcardConflictEx(t *testing.T) {
 	conflicts := [...]struct {
 		route        string


### PR DESCRIPTION
## Summary

This PR optimizes Radix tree route matching when a node has both static children and a wildcard fallback. The router now records the fallback node directly and skips the already-failed static branch when rolling back, avoiding the per-request node snapshot allocation. It also reuses the pre-trimmed path string instead of rebuilding it with `prefix + path`.

## Benchmark report

Environment:
- OS/arch: darwin/arm64
- CPU: Apple M4 Max
- Command: `go test -run=^$ -bench='Benchmark(StaticRouteWithParamFallback|OneRoute|ManyRoutes|404Many|Github)$' -benchmem -count=10`
- Baseline: `origin/master` at `5f4f964`, with the new benchmark added for comparison

| Benchmark | Baseline ns/op | This PR ns/op | Change | Baseline allocs | This PR allocs |
| --- | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkStaticRouteWithParamFallback` | 53.719 | 22.409 | -58.28% | 2 allocs / 128 B | 0 allocs / 0 B |
| `BenchmarkOneRoute` | 18.939 | 19.160 | +1.17% | 0 allocs / 0 B | 0 allocs / 0 B |
| `Benchmark404Many` | 34.153 | 34.589 | +1.28% | 0 allocs / 0 B | 0 allocs / 0 B |
| `BenchmarkGithub` | 580.950 | 585.870 | +0.85% | 15 allocs / 833 B | 15 allocs / 833 B |

The main optimized case removes all matching allocations and improves latency by about 58%. Existing broad router benchmarks remain allocation-neutral; timing changes are within about 1.3% in this local run.

## Pull Request Checklist

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (local `go test ./...` passes; CI will run on GitHub).
- [x] Tests are added or modified as needed to cover code changes.
- [x] This PR does not introduce a new feature requiring `docs/doc.md` updates.

## Verification

- `go test -run='TestTree|TestRouter|TestRoute|TestGithub' -timeout=60s ./...`
- `go test ./...`