### PR TITLE
docs: add module setup to gin quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,21 @@ func main() {
 **Running the application:**
 
 1. Save the code above as `main.go`
-2. Run the application:
+2. Initialize a Go module and download dependencies:
+
+   ```sh
+   go mod init example.com/gin-quickstart
+   go mod tidy
+   ```
+
+3. Run the application:
 
    ```sh
    go run main.go
    ```
 
-3. Open your browser and visit [`http://localhost:8080/ping`](http://localhost:8080/ping)
-4. You should see: `{"message":"pong"}`
+4. Open your browser and visit [`http://localhost:8080/ping`](http://localhost:8080/ping)
+5. You should see: `{"message":"pong"}`
 
 **What this example demonstrates:**
 


### PR DESCRIPTION
# Pull Request Checklist

Please ensure your pull request meets the following requirements:

- [ ×] Open your pull request against the `master` branch.
- [ ] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [ ] Tests are added or modified as needed to cover code changes.
- [ ] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.

Thank you for contributing!

## Summary

- Add Go module setup steps to the README quickstart.
- Keep the change limited to documentation.

## Why

New users following the quickstart from an empty directory need to initialize a Go module and resolve dependencies before running `go run main.go`.

## Changes

- Add `go mod init example.com/gin-quickstart`.
- Add `go mod tidy` before running the example.
- Renumber the quickstart steps accordingly.

## Testing

- Checked `go version`: go1.26.3 windows/amd64.
- Reproduced the README quickstart in a clean temporary directory.
- Ran `go mod init example.com/gin-quickstart`.
- Created `main.go` from the README example.
- Ran `go mod tidy`.
- Ran `go run main.go`.
- Verified `curl http://localhost:8080/ping` returns `{"message":"pong"}`.

## Known existing failures

`go test ./...` was run under the gin repository, but failed in existing tests unrelated to this README-only change:

- `TestSaveUploadedFileWithPermission`
- `TestFileDescriptor`
