### PR TITLE
feat(context): add ShouldBindBodyWithProtoBuf shortcut

### DIFF
--- a/context.go
+++ b/context.go
@@ -967,6 +967,11 @@ func (c *Context) ShouldBindBodyWithPlain(obj any) error {
 	return c.ShouldBindBodyWith(obj, binding.Plain)
 }
 
+// ShouldBindBodyWithProtoBuf is a shortcut for c.ShouldBindBodyWith(obj, binding.ProtoBuf).
+func (c *Context) ShouldBindBodyWithProtoBuf(obj any) error {
+	return c.ShouldBindBodyWith(obj, binding.ProtoBuf)
+}
+
 // ClientIP implements one best effort algorithm to return the real client IP.
 // It calls c.RemoteIP() under the hood, to check if the remote IP is a trusted proxy or not.
 // If it is it will then try to parse the headers defined in Engine.RemoteIPHeaders (defaulting to [X-Forwarded-For, X-Real-IP]).

--- a/context_test.go
+++ b/context_test.go
@@ -2916,6 +2916,21 @@ func TestContextShouldBindBodyWithPlain(t *testing.T) {
 	}
 }
 
+func TestContextShouldBindBodyWithProtoBuf(t *testing.T) {
+	label := "FOO"
+	protoBody, err := proto.Marshal(&testdata.Test{Label: &label})
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(protoBody))
+
+	obj := testdata.Test{}
+	require.NoError(t, c.ShouldBindBodyWithProtoBuf(&obj))
+	require.NotNil(t, obj.Label)
+	assert.Equal(t, "FOO", *obj.Label)
+}
+
 func TestContextGolangContext(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Request, _ = http.NewRequest(http.MethodPost, "/", strings.NewReader(`{"foo":"bar", "bar":"foo"}`))

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -1576,6 +1576,7 @@ For this, you can use `c.ShouldBindBodyWith` or shortcuts.
 - `c.ShouldBindBodyWithXML` is a shortcut for c.ShouldBindBodyWith(obj, binding.XML).
 - `c.ShouldBindBodyWithYAML` is a shortcut for c.ShouldBindBodyWith(obj, binding.YAML).
 - `c.ShouldBindBodyWithTOML` is a shortcut for c.ShouldBindBodyWith(obj, binding.TOML).
+- `c.ShouldBindBodyWithProtoBuf` is a shortcut for c.ShouldBindBodyWith(obj, binding.ProtoBuf).
 
 ```go
 func SomeHandler(c *gin.Context) {


### PR DESCRIPTION
Add `Context.ShouldBindBodyWithProtoBuf` as a shortcut for `c.ShouldBindBodyWith(obj, binding.ProtoBuf)`, consistent with existing helpers such as `ShouldBindBodyWithJSON`, `ShouldBindBodyWithXML`, `ShouldBindBodyWithYAML`, `ShouldBindBodyWithTOML`, and `ShouldBindBodyWithPlain`.
