### PR TITLE
refactor: optimize error message concatenation in default_validator

### DIFF
--- a/binding/default_validator.go
+++ b/binding/default_validator.go
@@ -32,7 +32,10 @@ func (err SliceValidationError) Error() string {
 			if b.Len() > 0 {
 				b.WriteString("\n")
 			}
-			b.WriteString("[" + strconv.Itoa(i) + "]: " + err[i].Error())
+			b.WriteString("[")
+			b.WriteString(strconv.Itoa(i))
+			b.WriteString("]: ")
+			b.WriteString(err[i].Error())
 		}
 	}
 	return b.String()


### PR DESCRIPTION

refactor: optimize error message concatenation in default_validator

Use separate WriteString calls instead of '+' operator for building
error messages in SliceValidationError to reduce memory allocations.