### PR TITLE
feat: add SkipMethodNotAllowedMiddleware option

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -271,14 +271,7 @@ func TestSaveUploadedFileWithPermissionFailed(t *testing.T) {
 	assert.Equal(t, "permission_test", f.Filename)
 	var mode fs.FileMode = 0o644
 	dst := filepath.Join(t.TempDir(), "test", "permission_test")
-	// The fix in #4702 only chmods the directory when it is newly created.
-	// When running as root, chmod on any directory succeeds, so this test
-	// cannot reliably assert failure. Instead, verify that the directory
-	// is created with the requested mode and the file is written correctly.
-	require.NoError(t, c.SaveUploadedFile(f, dst, mode))
-	info, err := os.Stat(filepath.Dir(dst))
-	require.NoError(t, err)
-	assert.Equal(t, mode, info.Mode().Perm())
+	require.Error(t, c.SaveUploadedFile(f, dst, mode))
 }
 
 // TestSaveUploadedFileToExistingDir is a regression test for issue #4622.

--- a/context_test.go
+++ b/context_test.go
@@ -271,7 +271,14 @@ func TestSaveUploadedFileWithPermissionFailed(t *testing.T) {
 	assert.Equal(t, "permission_test", f.Filename)
 	var mode fs.FileMode = 0o644
 	dst := filepath.Join(t.TempDir(), "test", "permission_test")
-	require.Error(t, c.SaveUploadedFile(f, dst, mode))
+	// The fix in #4702 only chmods the directory when it is newly created.
+	// When running as root, chmod on any directory succeeds, so this test
+	// cannot reliably assert failure. Instead, verify that the directory
+	// is created with the requested mode and the file is written correctly.
+	require.NoError(t, c.SaveUploadedFile(f, dst, mode))
+	info, err := os.Stat(filepath.Dir(dst))
+	require.NoError(t, err)
+	assert.Equal(t, mode, info.Mode().Perm())
 }
 
 // TestSaveUploadedFileToExistingDir is a regression test for issue #4622.

--- a/gin.go
+++ b/gin.go
@@ -122,6 +122,13 @@ type Engine struct {
 	// handler.
 	HandleMethodNotAllowed bool
 
+	// SkipMethodNotAllowedMiddleware if enabled, global middleware registered via Use()
+	// will not be executed for 405 Method Not Allowed responses. This allows
+	// NoMethod handlers to run without triggering middleware that may reject
+	// the request (e.g., authentication, checksum validation) before the 405
+	// response can be sent.
+	SkipMethodNotAllowedMiddleware bool
+
 	// ForwardedByClientIP if enabled, client IP will be parsed from the request's headers that
 	// match those stored at `(*gin.Engine).RemoteIPHeaders`. If no IP was
 	// fetched, it falls back to the IP obtained from
@@ -358,6 +365,10 @@ func (engine *Engine) rebuild404Handlers() {
 }
 
 func (engine *Engine) rebuild405Handlers() {
+	if engine.SkipMethodNotAllowedMiddleware {
+		engine.allNoMethod = engine.noMethod
+		return
+	}
 	engine.allNoMethod = engine.combineHandlers(engine.noMethod)
 }
 

--- a/gin_test.go
+++ b/gin_test.go
@@ -1156,3 +1156,62 @@ func TestUpdateRouteTreesCalledOnce(t *testing.T) {
 		assert.Equal(t, "ok", w.Body.String())
 	}
 }
+
+// Test the fix for https://github.com/gin-gonic/gin/issues/4189
+func TestSkipMethodNotAllowedMiddleware(t *testing.T) {
+	g := New()
+	g.HandleMethodNotAllowed = true
+	g.SkipMethodNotAllowedMiddleware = true
+
+	var middlewareCalled bool
+	middleware := func(c *Context) {
+		middlewareCalled = true
+		c.Next()
+	}
+	noMethodHandler := func(c *Context) {
+		c.String(http.StatusMethodNotAllowed, "method not allowed")
+	}
+
+	g.Use(middleware)
+	g.NoMethod(noMethodHandler)
+	g.POST("/test", func(c *Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	g.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	assert.Equal(t, "method not allowed", w.Body.String())
+	assert.False(t, middlewareCalled, "middleware should not be called when SkipMethodNotAllowedMiddleware is true")
+}
+
+func TestSkipMethodNotAllowedMiddlewareDisabled(t *testing.T) {
+	g := New()
+	g.HandleMethodNotAllowed = true
+	g.SkipMethodNotAllowedMiddleware = false
+
+	var middlewareCalled bool
+	middleware := func(c *Context) {
+		middlewareCalled = true
+		c.Next()
+	}
+	noMethodHandler := func(c *Context) {
+		c.String(http.StatusMethodNotAllowed, "method not allowed")
+	}
+
+	g.Use(middleware)
+	g.NoMethod(noMethodHandler)
+	g.POST("/test", func(c *Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	g.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	assert.Equal(t, "method not allowed", w.Body.String())
+	assert.True(t, middlewareCalled, "middleware should be called when SkipMethodNotAllowedMiddleware is false")
+}


### PR DESCRIPTION
Add `Engine.SkipMethodNotAllowedMiddleware` flag that, when enabled, prevents global middleware from running on 405 Method Not Allowed responses. This allows NoMethod handlers to respond correctly without being intercepted by middleware such as authentication or checksum validation that would otherwise reject the request first.

Fixes #4189