### PR TITLE
refactor(binding): simplify tryToSetValue option handling

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -143,24 +143,23 @@ type setOptions struct {
 }
 
 func tryToSetValue(value reflect.Value, field reflect.StructField, setter setter, tag string) (bool, error) {
-	var tagValue string
 	var setOpt setOptions
 
-	tagValue = field.Tag.Get(tag)
-	tagValue, opts := head(tagValue, ",")
+	tagValue, opts := head(field.Tag.Get(tag), ",")
 
 	if tagValue == "" { // default value is FieldName
+		if field.Name == "" {
+			return false, nil
+		}
 		tagValue = field.Name
-	}
-	if tagValue == "" { // when field is "emptyField" variable
-		return false, nil
 	}
 
 	var opt string
 	for len(opts) > 0 {
 		opt, opts = head(opts, ",")
 
-		if k, v := head(opt, "="); k == "default" {
+		k, v := head(opt, "=")
+		if k == "default" {
 			setOpt.isDefaultExists = true
 			setOpt.defaultValue = v
 
@@ -171,7 +170,7 @@ func tryToSetValue(value reflect.Value, field reflect.StructField, setter setter
 					setOpt.defaultValue = strings.ReplaceAll(v, ";", ",")
 				}
 			}
-		} else if k, v = head(opt, "="); k == "parser" {
+		} else if k == "parser" {
 			setOpt.parser = v
 		}
 	}

--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -159,7 +159,8 @@ func tryToSetValue(value reflect.Value, field reflect.StructField, setter setter
 		opt, opts = head(opts, ",")
 
 		k, v := head(opt, "=")
-		if k == "default" {
+		switch k {
+		case "default":
 			setOpt.isDefaultExists = true
 			setOpt.defaultValue = v
 
@@ -170,7 +171,7 @@ func tryToSetValue(value reflect.Value, field reflect.StructField, setter setter
 					setOpt.defaultValue = strings.ReplaceAll(v, ";", ",")
 				}
 			}
-		} else if k == "parser" {
+		case "parser":
 			setOpt.parser = v
 		}
 	}


### PR DESCRIPTION
1. tagValue only needs to be assigned once, which removes an unnecessary step.
Removed a potentially unnecessary temporary variable.
(I'm not sure if it's a personal preference, because this issue is completely negligible.)

2. This reduces a redundant check. When tagValue is empty, we can first check whether field.Name is empty before assigning it.With this approach, the comment in the second block can also be removed.

3. The second invocation of k, v := head(opt, "=") in the original code appears to be unnecessary and can be removed.

Some of these changes may be too minor to provide any meaningful benefit, and the actual optimization is very limited. Please feel free to ignore any suggestions that do not seem worthwhile.

The order of the line numbers of the modified content corresponds to the points above.