### PR TITLE
fix(render): correctly escape non-BMP Unicode in AsciiJSON

### DIFF
--- a/render/ascii_nonbmp_test.go
+++ b/render/ascii_nonbmp_test.go
@@ -1,0 +1,42 @@
+package render
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRenderAsciiJSONNonBMP is a regression test for AsciiJSON corrupting
+// non-BMP Unicode characters (code points above U+FFFF, such as emoji).
+//
+// It asserts only AsciiJSON's two user-visible contracts: the output must be
+// ASCII-only, and it must decode back to the original value. The exact escape
+// sequence used (a UTF-16 surrogate pair, a raw rune, etc.) is an
+// implementation detail and is intentionally not asserted.
+func TestRenderAsciiJSONNonBMP(t *testing.T) {
+	const grinningFace = "😀" // U+1F600 GRINNING FACE, a non-BMP code point
+
+	w := httptest.NewRecorder()
+	require.NoError(t, (AsciiJSON{map[string]string{"msg": grinningFace}}).Render(w))
+
+	out := w.Body.String()
+
+	// Contract 1: AsciiJSON must emit ASCII-only output.
+	for i := 0; i < len(out); i++ {
+		require.LessOrEqualf(t, out[i], byte(unicode.MaxASCII),
+			"AsciiJSON must emit ASCII-only output, got non-ASCII byte at %d in %q", i, out)
+	}
+
+	// Contract 2 (the bug): the rendered output must round-trip back to the
+	// original value. The buggy output {"msg":"ὠ0"} is valid JSON but
+	// decodes to "ὠ0" instead of "😀".
+	var decoded map[string]string
+	require.NoErrorf(t, json.Unmarshal([]byte(out), &decoded),
+		"AsciiJSON output is not valid JSON: %q", out)
+	assert.Equalf(t, grinningFace, decoded["msg"],
+		"AsciiJSON corrupted a non-BMP character; rendered output was %q", out)
+}

--- a/render/json.go
+++ b/render/json.go
@@ -10,6 +10,7 @@ import (
 	"html/template"
 	"net/http"
 	"unicode"
+	"unicode/utf16"
 
 	"github.com/gin-gonic/gin/codec/json"
 	"github.com/gin-gonic/gin/internal/bytesconv"
@@ -160,11 +161,17 @@ func (r AsciiJSON) Render(w http.ResponseWriter) error {
 	}
 
 	var buffer bytes.Buffer
-	escapeBuf := make([]byte, 0, 6) // Preallocate 6 bytes for Unicode escape sequences
+	escapeBuf := make([]byte, 0, 12) // Preallocate for a \uXXXX\uXXXX surrogate pair
 
 	for _, r := range bytesconv.BytesToString(ret) {
 		if r > unicode.MaxASCII {
-			escapeBuf = fmt.Appendf(escapeBuf[:0], "\\u%04x", r) // Reuse escapeBuf
+			if r > 0xFFFF {
+				// Non-BMP code points must be escaped as a UTF-16 surrogate pair.
+				r1, r2 := utf16.EncodeRune(r)
+				escapeBuf = fmt.Appendf(escapeBuf[:0], "\\u%04x\\u%04x", r1, r2)
+			} else {
+				escapeBuf = fmt.Appendf(escapeBuf[:0], "\\u%04x", r) // Reuse escapeBuf
+			}
 			buffer.Write(escapeBuf)
 		} else {
 			buffer.WriteByte(byte(r))


### PR DESCRIPTION
## Description

`AsciiJSON` silently corrupts Unicode code points above U+FFFF (emoji, CJK Extension B, etc.). The escape loop formats every non-ASCII rune with `"\u%04x"`, which only produces a valid escape for the Basic Multilingual Plane (U+0000-U+FFFF). For a rune like the grinning face (U+1F600) it emits six hex digits:

```
{"msg":"\u1f600"}
```

A JSON parser reads `\u` as *exactly* four hex digits, so it consumes `\u1f60` and treats the trailing `0` as a literal character. The result is a valid-but-wrong string instead of the original code point.

Per RFC 8259 section 7, code points above U+FFFF must be written as a UTF-16 surrogate pair (two `\uXXXX` escapes). This PR detects `r > 0xFFFF` and emits the pair via the standard library `unicode/utf16.EncodeRune`:

```
{"msg":"\ud83d\ude00"}
```

which round-trips back to the original character. ASCII and BMP paths are unchanged.

Fixes #4688

## Changes

- `render/json.go`: escape non-BMP runes as a UTF-16 surrogate pair.
- `render/ascii_nonbmp_test.go`: regression test asserting AsciiJSON output is ASCII-only and round-trips back to the original value.

## Notes

- No public API change.
- Behavior for ASCII (U+0000-U+007F) and BMP (U+0080-U+FFFF) is byte-for-byte identical to before.
- This changes the bytes emitted for non-BMP input from a malformed single `\uXXXX` escape to a correct surrogate pair. The previous output was invalid for these inputs, so no correct consumer could have depended on it.

## Checklist

- [x] PR opened against `master`.
- [x] Tests pass locally (`go test ./render/`); gofmt + go vet clean.
- [x] Test added covering the change.
- [x] No new feature, so `docs/doc.md` not applicable.
