### PR TITLE
test(response_writer): add tests for Flush() with and without http.Flusher

### DIFF
--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -25,7 +25,7 @@ func TestResponseWriterFlushWithFlusher(t *testing.T) {
 
 // TestResponseWriterFlushWithNonFlusher verifies Flush() is a no-op
 // when the underlying ResponseWriter does not implement http.Flusher.
-// Reproduces the panic reported in https://github.com/gin-gonic/gin/issues/4460
+// Guards against the panic reported in https://github.com/gin-gonic/gin/issues/4460
 func TestResponseWriterFlushWithNonFlusher(t *testing.T) {
 	nonFlusher := &nonFlusherWriter{header: http.Header{}}
 	writer := &responseWriter{ResponseWriter: nonFlusher}
@@ -341,6 +341,3 @@ func TestPusherWithoutPusher(t *testing.T) {
 	pusher := w.Pusher()
 	assert.Nil(t, pusher, "Expected pusher to be nil")
 }
-
-// TestResponseWriterFlushWithFlusher verifies that Flush() delegates to
-// the underlying writer when it implements http.Flusher.

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -15,10 +15,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO
-// func (w *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-// func (w *responseWriter) CloseNotify() <-chan bool {
-// func (w *responseWriter) Flush() {
+// TestResponseWriterFlushWithFlusher verifies Flush() calls the underlying Flusher.
+func TestResponseWriterFlushWithFlusher(t *testing.T) {
+	testWriter := httptest.NewRecorder()
+	writer := &responseWriter{ResponseWriter: testWriter}
+	writer.Flush()
+	assert.True(t, testWriter.Flushed)
+}
+
+// TestResponseWriterFlushWithNonFlusher verifies Flush() is a no-op
+// when the underlying ResponseWriter does not implement http.Flusher.
+// Reproduces the panic reported in https://github.com/gin-gonic/gin/issues/4460
+func TestResponseWriterFlushWithNonFlusher(t *testing.T) {
+	nonFlusher := &nonFlusherWriter{header: http.Header{}}
+	writer := &responseWriter{ResponseWriter: nonFlusher}
+	require.NotPanics(t, func() {
+		writer.Flush()
+	})
+}
+
+// nonFlusherWriter is a minimal http.ResponseWriter that does NOT implement http.Flusher.
+type nonFlusherWriter struct {
+	header http.Header
+}
+
+func (w *nonFlusherWriter) Header() http.Header         { return w.header }
+func (w *nonFlusherWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (w *nonFlusherWriter) WriteHeader(code int)        {}
 
 var (
 	_ ResponseWriter      = &responseWriter{}
@@ -318,3 +341,6 @@ func TestPusherWithoutPusher(t *testing.T) {
 	pusher := w.Pusher()
 	assert.Nil(t, pusher, "Expected pusher to be nil")
 }
+
+// TestResponseWriterFlushWithFlusher verifies that Flush() delegates to
+// the underlying writer when it implements http.Flusher.


### PR DESCRIPTION
## What

Adds two missing unit tests for `responseWriter.Flush()`:

1. `TestResponseWriterFlushWithFlusher` — verifies that `Flush()` correctly
   delegates to the underlying `http.Flusher` when one is available.
2. `TestResponseWriterFlushWithNonFlusher` — verifies that `Flush()` is a
   no-op (no panic) when the underlying writer does not implement `http.Flusher`.

## Why

The test file has a `// TODO` comment explicitly noting `Flush()` as untested.
Issue #4460 reported a panic caused by the unchecked type assertion. The fix
is already in master but no regression test existed to prevent it recurring.

## Notes

`TestSaveUploadedFileWithPermission` and `TestFileDescriptor` fail on Windows
due to OS-level differences in file permission and descriptor handling — these
are pre-existing failures unrelated to this PR, reproducible on upstream master
before any changes.

Closes #4460