### PR TITLE
feat(context): add AbortedByHandler() and AbortedBy() to track abort origin

### DIFF
--- a/context.go
+++ b/context.go
@@ -66,7 +66,9 @@ type Context struct {
 	Params   Params
 	handlers HandlersChain
 	index    int8
-	fullPath string
+	// abortedBy is the index of the handler that called Abort(), if any.
+	abortedBy int8
+	fullPath  string
 
 	engine       *Engine
 	params       *Params
@@ -105,6 +107,7 @@ func (c *Context) reset() {
 	c.Params = c.Params[:0]
 	c.handlers = nil
 	c.index = -1
+	c.abortedBy = -1
 
 	c.fullPath = ""
 	c.Keys = nil
@@ -129,6 +132,7 @@ func (c *Context) Copy() *Context {
 	cp.writermem.ResponseWriter = nil
 	cp.Writer = &cp.writermem
 	cp.index = abortIndex
+	cp.abortedBy = c.abortedBy
 	cp.handlers = nil
 	cp.fullPath = c.fullPath
 
@@ -205,7 +209,27 @@ func (c *Context) IsAborted() bool {
 // If the authorization fails (ex: the password does not match), call Abort to ensure the remaining handlers
 // for this request are not called.
 func (c *Context) Abort() {
+	if !c.IsAborted() {
+		c.abortedBy = c.index
+	}
 	c.index = abortIndex
+}
+
+// AbortedByHandler returns the handler that called Abort(), if available.
+func (c *Context) AbortedByHandler() HandlerFunc {
+	if c.abortedBy < 0 || int(c.abortedBy) >= len(c.handlers) {
+		return nil
+	}
+	return c.handlers[c.abortedBy]
+}
+
+// AbortedBy returns the handler name that called Abort().
+func (c *Context) AbortedBy() string {
+	h := c.AbortedByHandler()
+	if h == nil {
+		return ""
+	}
+	return nameOfFunction(h)
 }
 
 // AbortWithStatus calls `Abort()` and writes the headers with the specified status code.

--- a/context_test.go
+++ b/context_test.go
@@ -714,6 +714,18 @@ func handlerNameTest(c *Context) {
 func handlerNameTest2(c *Context) {
 }
 
+func abortedByMiddleware1(c *Context) {
+	c.Next()
+}
+
+func abortedByMiddleware2(c *Context) {
+	c.Abort()
+}
+
+func abortedByMiddleware3(c *Context) {
+	c.Abort()
+}
+
 var handlerTest HandlerFunc = func(c *Context) {
 }
 
@@ -722,6 +734,42 @@ func TestContextHandler(t *testing.T) {
 	c.handlers = HandlersChain{func(c *Context) {}, handlerTest}
 
 	assert.Equal(t, reflect.ValueOf(handlerTest).Pointer(), reflect.ValueOf(c.Handler()).Pointer())
+}
+
+func TestContextAbortedByWithoutHandler(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+
+	assert.Nil(t, c.AbortedByHandler())
+	assert.Empty(t, c.AbortedBy())
+
+	c.Abort()
+
+	assert.True(t, c.IsAborted())
+	assert.Nil(t, c.AbortedByHandler())
+	assert.Empty(t, c.AbortedBy())
+}
+
+func TestContextAbortedByHandler(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.handlers = HandlersChain{abortedByMiddleware1, abortedByMiddleware2, abortedByMiddleware3}
+
+	c.Next()
+
+	assert.True(t, c.IsAborted())
+	assert.Equal(t, reflect.ValueOf(abortedByMiddleware2).Pointer(), reflect.ValueOf(c.AbortedByHandler()).Pointer())
+	assert.Regexp(t, "^(.*/vendor/)?github.com/gin-gonic/gin.abortedByMiddleware2$", c.AbortedBy())
+}
+
+func TestContextAbortedByPreserveFirstAborter(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.handlers = HandlersChain{abortedByMiddleware2}
+
+	c.Next()
+	firstAborter := c.AbortedByHandler()
+	c.Abort()
+
+	assert.True(t, c.IsAborted())
+	assert.Equal(t, reflect.ValueOf(firstAborter).Pointer(), reflect.ValueOf(c.AbortedByHandler()).Pointer())
 }
 
 func TestContextQuery(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds two new methods to `Context` that expose which handler in the chain called `Abort()`, enabling better observability and conditional logic in middleware.

## New API

```go
// AbortedByHandler returns the HandlerFunc that called Abort(), or nil if not aborted by a handler.
func (c *Context) AbortedByHandler() HandlerFunc

// AbortedBy returns the name of the handler that called Abort(), or "" if not applicable.
func (c *Context) AbortedBy() string
```

## Behavior

- **First-abort-wins**: if `Abort()` is called multiple times, only the first caller is recorded.
- Returns `nil`/`""` when the context was not aborted
- `Copy()` preserves the tracked abort origin.
- `reset()` clears it on context reuse.

## Use Cases

```go
// Logging
func Logger() gin.HandlerFunc {
    return func(c *gin.Context) {
        c.Next()
        if c.IsAborted() {
            log.Printf("request aborted by: %s", c.AbortedBy())
        }
    }
}

// Observability
span.SetAttribute("gin.aborted_by", c.AbortedBy())

// Conditional error handling
if c.IsAborted() && c.AbortedBy() == "authMiddleware" {
    // handle auth rejections differently
}
```
