### PR TITLE
fix(context): skip chmod on pre-existing dirs in SaveUploadedFile

### DIFF
--- a/context.go
+++ b/context.go
@@ -716,6 +716,10 @@ func (c *Context) MultipartForm() (*multipart.Form, error) {
 }
 
 // SaveUploadedFile uploads the form file to specific dst.
+// An optional perm argument allows specifying the permission bits for any
+// newly created directories. If not provided, the default is 0750.
+// Note: permissions are only applied to directories created by this call;
+// pre-existing directories (e.g. /tmp) are not modified.
 func (c *Context) SaveUploadedFile(file *multipart.FileHeader, dst string, perm ...fs.FileMode) error {
 	src, err := file.Open()
 	if err != nil {
@@ -728,11 +732,20 @@ func (c *Context) SaveUploadedFile(file *multipart.FileHeader, dst string, perm 
 		mode = perm[0]
 	}
 	dir := filepath.Dir(dst)
+	// Check if the directory already exists before calling MkdirAll so we
+	// know whether to apply chmod. We must not chmod pre-existing directories
+	// (e.g. /tmp) because the process may not own them.
+	_, statErr := os.Stat(dir)
 	if err = os.MkdirAll(dir, mode); err != nil {
 		return err
 	}
-	if err = os.Chmod(dir, mode); err != nil {
-		return err
+	// Only apply chmod when the directory was freshly created by MkdirAll.
+	// If the directory already existed, os.Stat returned nil, so we skip
+	// the chmod to avoid "operation not permitted" on unowned directories.
+	if errors.Is(statErr, os.ErrNotExist) {
+		if err = os.Chmod(dir, mode); err != nil {
+			return err
+		}
 	}
 
 	out, err := os.Create(dst)

--- a/context.go
+++ b/context.go
@@ -726,10 +726,11 @@ func (c *Context) MultipartForm() (*multipart.Form, error) {
 }
 
 // SaveUploadedFile uploads the form file to specific dst.
-// An optional perm argument allows specifying the permission bits for any
-// newly created directories. If not provided, the default is 0750.
-// Note: permissions are only applied to directories created by this call;
-// pre-existing directories (e.g. /tmp) are not modified.
+// An optional perm argument specifies the permission bits used when creating
+// the destination directory. If not provided, the default is 0750. The exact
+// permission is enforced only on the destination directory and only when it is
+// newly created by this call; pre-existing directories (e.g. /tmp) are not
+// modified.
 func (c *Context) SaveUploadedFile(file *multipart.FileHeader, dst string, perm ...fs.FileMode) error {
 	src, err := file.Open()
 	if err != nil {
@@ -742,16 +743,15 @@ func (c *Context) SaveUploadedFile(file *multipart.FileHeader, dst string, perm 
 		mode = perm[0]
 	}
 	dir := filepath.Dir(dst)
-	// Check if the directory already exists before calling MkdirAll so we
-	// know whether to apply chmod. We must not chmod pre-existing directories
-	// (e.g. /tmp) because the process may not own them.
+	// Record whether the destination directory exists before MkdirAll, so we
+	// only chmod a directory we just created. Chmod'ing a pre-existing directory
+	// the process does not own (e.g. /tmp) fails with "operation not permitted"
+	// (#4622). A non-ErrNotExist stat error also skips chmod and lets MkdirAll
+	// surface the underlying failure.
 	_, statErr := os.Stat(dir)
 	if err = os.MkdirAll(dir, mode); err != nil {
 		return err
 	}
-	// Only apply chmod when the directory was freshly created by MkdirAll.
-	// If the directory already existed, os.Stat returned nil, so we skip
-	// the chmod to avoid "operation not permitted" on unowned directories.
 	if errors.Is(statErr, os.ErrNotExist) {
 		if err = os.Chmod(dir, mode); err != nil {
 			return err

--- a/context_test.go
+++ b/context_test.go
@@ -276,7 +276,11 @@ func TestSaveUploadedFileWithPermissionFailed(t *testing.T) {
 
 // TestSaveUploadedFileToExistingDir is a regression test for issue #4622.
 // SaveUploadedFile must not call os.Chmod on a directory that already exists,
-// because the process may not own it (e.g. /tmp on Linux/macOS).
+// because the process may not own it (e.g. /tmp on Linux/macOS), where chmod
+// fails with "operation not permitted". This asserts the behavioral contract
+// directly — a pre-existing directory's permissions are left unchanged — so it
+// catches the regression on every platform, including environments (root/CI,
+// user-owned $TMPDIR) where chmod on the temp dir would otherwise succeed.
 func TestSaveUploadedFileToExistingDir(t *testing.T) {
 	buf := new(bytes.Buffer)
 	mw := multipart.NewWriter(buf)
@@ -292,17 +296,23 @@ func TestSaveUploadedFileToExistingDir(t *testing.T) {
 	f, err := c.FormFile("file")
 	require.NoError(t, err)
 
-	// Use os.TempDir() which is guaranteed to already exist and may not be
-	// owned by the current process — this is exactly the scenario from #4622.
-	dst := filepath.Join(os.TempDir(), "gin_save_uploaded_regression_test.txt")
-	t.Cleanup(func() {
-		_ = os.Remove(dst)
-	})
+	// A pre-existing directory owned by this process, set to a known mode.
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0o700))
 
-	// Must not fail with "chmod ...: operation not permitted"
-	require.NoError(t, c.SaveUploadedFile(f, dst))
+	// Pass a perm that differs from the directory's current mode. The fix must
+	// not apply it to the pre-existing directory; the old code chmod'd it
+	// unconditionally, which also failed outright on unowned dirs like /tmp.
+	dst := filepath.Join(dir, "existing_dir_test.txt")
+	require.NoError(t, c.SaveUploadedFile(f, dst, 0o755))
 
-	// Verify the file was actually written with correct content
+	// The pre-existing directory's permissions must be unchanged.
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(),
+		"permissions of a pre-existing directory must not be modified")
+
+	// The file must still be written with the correct content.
 	content, err := os.ReadFile(dst)
 	require.NoError(t, err)
 	assert.Equal(t, "existing_dir_test", string(content))

--- a/context_test.go
+++ b/context_test.go
@@ -275,6 +275,40 @@ func TestSaveUploadedFileWithPermissionFailed(t *testing.T) {
 	require.Error(t, c.SaveUploadedFile(f, "test/permission_test", mode))
 }
 
+// TestSaveUploadedFileToExistingDir is a regression test for issue #4622.
+// SaveUploadedFile must not call os.Chmod on a directory that already exists,
+// because the process may not own it (e.g. /tmp on Linux/macOS).
+func TestSaveUploadedFileToExistingDir(t *testing.T) {
+	buf := new(bytes.Buffer)
+	mw := multipart.NewWriter(buf)
+	w, err := mw.CreateFormFile("file", "existing_dir_test")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("existing_dir_test"))
+	require.NoError(t, err)
+	mw.Close()
+
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(http.MethodPost, "/", buf)
+	c.Request.Header.Set("Content-Type", mw.FormDataContentType())
+	f, err := c.FormFile("file")
+	require.NoError(t, err)
+
+	// Use os.TempDir() which is guaranteed to already exist and may not be
+	// owned by the current process — this is exactly the scenario from #4622.
+	dst := filepath.Join(os.TempDir(), "gin_save_uploaded_regression_test.txt")
+	t.Cleanup(func() {
+		_ = os.Remove(dst)
+	})
+
+	// Must not fail with "chmod ...: operation not permitted"
+	require.NoError(t, c.SaveUploadedFile(f, dst))
+
+	// Verify the file was actually written with correct content
+	content, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "existing_dir_test", string(content))
+}
+
 func TestContextReset(t *testing.T) {
 	router := New()
 	c := router.allocateContext(0)


### PR DESCRIPTION
## Summary

Fixes #4622

After upgrading to v1.12.0, `SaveUploadedFile` started failing when saving files into pre-existing system directories like `/tmp` with:
```
chmod /tmp: operation not permitted
```

## Root Cause

`os.Chmod(dir, mode)` was called **unconditionally** after `os.MkdirAll`, even when the target directory already existed and was not owned by the process.

## Fix

Stat the directory before calling `MkdirAll`. Only apply `os.Chmod` when the directory was **freshly created** by this call. Pre-existing directories are left untouched.

```go
_, statErr := os.Stat(dir)
if err = os.MkdirAll(dir, mode); err != nil {
    return err
}
if errors.Is(statErr, os.ErrNotExist) {
    if err = os.Chmod(dir, mode); err != nil {
        return err
    }
}
```

This restores the v1.10.1 behaviour for existing directories while preserving the custom permission feature introduced in v1.12.0.

## Testing

- All existing `SaveUploadedFile` tests continue to pass
- Added regression test `TestSaveUploadedFileToExistingDir` that saves a file into `os.TempDir()` (a pre-existing system directory) and asserts no error is returned