### PR TITLE
fix: encode non-BMP characters as UTF-16 surrogate pairs in AsciiJSON

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -1263,6 +1263,18 @@ func TestContextRenderNoContentSecureJSON(t *testing.T) {
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
 }
 
+func TestContextAsciiJSONNonBMP(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	// Non-BMP characters (emoji) should be encoded as UTF-16 surrogate pairs
+	c.AsciiJSON(http.StatusOK, H{"emoji": "😀"})
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "{\"emoji\":\"\\ud83d\\ude00\"}", w.Body.String())
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+}
+
 func TestContextRenderNoContentAsciiJSON(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := CreateTestContext(w)

--- a/render/json.go
+++ b/render/json.go
@@ -10,6 +10,7 @@ import (
 	"html/template"
 	"net/http"
 	"unicode"
+	"unicode/utf16"
 
 	"github.com/gin-gonic/gin/codec/json"
 	"github.com/gin-gonic/gin/internal/bytesconv"
@@ -160,11 +161,16 @@ func (r AsciiJSON) Render(w http.ResponseWriter) error {
 	}
 
 	var buffer bytes.Buffer
-	escapeBuf := make([]byte, 0, 6) // Preallocate 6 bytes for Unicode escape sequences
+	escapeBuf := make([]byte, 0, 12) // Preallocate for up to two \uXXXX sequences
 
 	for _, r := range bytesconv.BytesToString(ret) {
 		if r > unicode.MaxASCII {
-			escapeBuf = fmt.Appendf(escapeBuf[:0], "\\u%04x", r) // Reuse escapeBuf
+			if r > 0xFFFF {
+				surrogates := utf16.Encode([]rune{r})
+				escapeBuf = fmt.Appendf(escapeBuf[:0], "\\u%04x\\u%04x", surrogates[0], surrogates[1])
+			} else {
+				escapeBuf = fmt.Appendf(escapeBuf[:0], "\\u%04x", r)
+			}
 			buffer.Write(escapeBuf)
 		} else {
 			buffer.WriteByte(byte(r))


### PR DESCRIPTION
## Description

The `AsciiJSON` `Render` method uses `fmt.Appendf(buf, "\\u%04x", r)` for all non-ASCII runes. For non-BMP characters (code points > 0xFFFF, e.g. emoji), this produces invalid JSON with raw 5+ hex digit sequences like \\u1f389.

This fix uses Go's `unicode/utf16.Encode` to convert non-BMP runes into UTF-16 surrogate pairs, producing valid JSON like \\ud83c\\udf89.

## Changes
- Import `unicode/utf16` in `render/json.go`
- For non-BMP runes (> 0xFFFF), encode as surrogate pair using `utf16.Encode`
- Adjust preallocation for escape buffer from 6 to 12 bytes to accommodate two `\\uXXXX` sequences
- BMP characters (0x0080-0xFFFF) continue to use the existing single `\\uXXXX` encoding

Fixes #4688