### PR TITLE
docs: fix `BindXML` comment referencing nonexistent `binding.BindXML`

### DIFF
--- a/context.go
+++ b/context.go
@@ -787,7 +787,7 @@ func (c *Context) BindJSON(obj any) error {
 	return c.MustBindWith(obj, binding.JSON)
 }
 
-// BindXML is a shortcut for c.MustBindWith(obj, binding.BindXML).
+// BindXML is a shortcut for c.MustBindWith(obj, binding.XML).
 func (c *Context) BindXML(obj any) error {
 	return c.MustBindWith(obj, binding.XML)
 }


### PR DESCRIPTION
## What

The doc comment for `BindXML` in `context.go` (line 790) reads:

```go
// BindXML is a shortcut for c.MustBindWith(obj, binding.BindXML).
```

`binding.BindXML` does not exist. The correct symbol is `binding.XML`, which is defined in `binding/binding.go` and is also what the implementation already uses:

```go
func (c *Context) BindXML(obj any) error {
	return c.MustBindWith(obj, binding.XML)  // ← correct
}
```

## Fix

Change `binding.BindXML` → `binding.XML` in the comment. One character change, comment only.

## Verification

Every sibling method already has a correct comment:
- `BindJSON` → `binding.JSON` ✓
- `BindYAML` → `binding.YAML` ✓  
- `BindTOML` → `binding.TOML` ✓
- `ShouldBindXML` → `binding.XML` ✓ (the `ShouldBind` variant is already correct)

Only `BindXML`'s comment had the stale `BindXML` suffix.