### PR TITLE
fix(recovery): fix stale source line in stack trace for same-file frames

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -118,6 +118,7 @@ func stack(skip int) []byte {
 	var (
 		nLine    string
 		lastFile string
+		lastLine int
 		err      error
 	)
 	for i := skip; ; i++ { // Skip the expected number of frames
@@ -127,12 +128,13 @@ func stack(skip int) []byte {
 		}
 		// Print this much at least.  If we can't find the source, it won't show.
 		fmt.Fprintf(buf, "%s:%d (0x%x)\n", file, line, pc)
-		if file != lastFile {
+		if file != lastFile || line != lastLine {
 			nLine, err = readNthLine(file, line-1)
 			if err != nil {
 				continue
 			}
 			lastFile = file
+			lastLine = line
 		}
 		fmt.Fprintf(buf, "\t%s: %s\n", function(pc), cmp.Or(nLine, dunno))
 	}


### PR DESCRIPTION
## Summary

- PR #4466 refactored `stack()` to read one line at a time (`readNthLine`) instead of loading the entire file into memory.
- However, it only refreshed `nLine` when the **file** changed, not when the **line number** changed within the same file.
- Result: two consecutive stack frames from different functions in the same file would both display the source line of the *first* frame.

## Root cause

```go
// Before fix: only checks file change
if file != lastFile {
    nLine, err = readNthLine(file, line-1)
    ...
}
```

If `foo()` at line 10 and `bar()` at line 50 are both in `foo.go`, the frame for `bar()` would display line 10's source instead of line 50's.