### PR TITLE
fix: handle bracketed IPv6 and port notation in X-Forwarded-For

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -486,6 +486,14 @@ func (engine *Engine) validateHeader(header string) (clientIP string, valid bool
 	items := strings.Split(header, ",")
 	for i := len(items) - 1; i >= 0; i-- {
 		ipStr := strings.TrimSpace(items[i])
+		// Handle [IPv6]:port or IPv4:port notation (e.g., [::1]:38792, 192.168.1.1:38792)
+		if host, _, err := net.SplitHostPort(ipStr); err == nil {
+			ipStr = host
+		}
+		// Strip brackets around bare IPv6 addresses (e.g., [::1] -> ::1)
+		if len(ipStr) > 0 && ipStr[0] == '[' {
+			ipStr = strings.Trim(ipStr, "[]")
+		}
 		ip := net.ParseIP(ipStr)
 		if ip == nil {
 			break


### PR DESCRIPTION
Fixes #4572

`validateHeader` now correctly handles non-standard X-Forwarded-For formats including:
- `[IPv6]:port` (e.g., `[::1]:38792` — produced by IIS ARR)
- `IPv4:port` (e.g., `192.168.1.1:38792` — cloud load balancers)
- `[IPv6]` (e.g., `[::1]` — bare bracketed IPv6)

These formats are produced by some reverse proxies like IIS Application Request Routing and certain cloud load balancers.