### PR TITLE
feat(context): unwrap joined errors in Context.Error()

### DIFF
--- a/context.go
+++ b/context.go
@@ -264,6 +264,17 @@ func (c *Context) Error(err error) *Error {
 		panic("err is nil")
 	}
 
+	// Unwrap joined errors (e.g. from errors.Join), adding each individually
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		if errs := joined.Unwrap(); len(errs) > 0 {
+			var last *Error
+			for _, e := range errs {
+				last = c.Error(e)
+			}
+			return last
+		}
+	}
+
 	var parsedError *Error
 	ok := errors.As(err, &parsedError)
 	if !ok {

--- a/context_test.go
+++ b/context_test.go
@@ -2100,8 +2100,8 @@ func TestContextErrorWithEmptyUnwrap(t *testing.T) {
 
 type emptyJoinError struct{ err error }
 
-func (e emptyJoinError) Error() string     { return e.err.Error() }
-func (e emptyJoinError) Unwrap() []error   { return nil }
+func (e emptyJoinError) Error() string   { return e.err.Error() }
+func (e emptyJoinError) Unwrap() []error { return nil }
 
 func TestContextAbortWithError(t *testing.T) {
 	w := httptest.NewRecorder()

--- a/context_test.go
+++ b/context_test.go
@@ -2048,6 +2048,61 @@ func TestContextTypedError(t *testing.T) {
 	assert.Equal(t, []string{"externo 0", "interno 0"}, c.Errors.Errors())
 }
 
+func TestContextErrorWithJoinedErrors(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	assert.Empty(t, c.Errors)
+
+	firstErr := errors.New("first error")
+	secondErr := errors.New("second error")
+	c.Error(errors.Join(firstErr, secondErr)) //nolint: errcheck
+
+	assert.Len(t, c.Errors, 2)
+	assert.Equal(t, firstErr, c.Errors[0].Err)
+	assert.Equal(t, secondErr, c.Errors[1].Err)
+	assert.Equal(t, ErrorTypePrivate, c.Errors[0].Type)
+	assert.Equal(t, ErrorTypePrivate, c.Errors[1].Type)
+}
+
+func TestContextErrorWithNestedJoinedErrors(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+
+	c.Error(errors.Join( //nolint: errcheck
+		errors.New("first"),
+		errors.Join(errors.New("second"), errors.New("third")),
+		errors.New("fourth"),
+	))
+
+	assert.Len(t, c.Errors, 4)
+	assert.Equal(t, []string{"first", "second", "third", "fourth"}, c.Errors.Errors())
+}
+
+func TestContextErrorJoinPreservesGinErrorType(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+
+	ginErr := &Error{Err: errors.New("typed"), Type: ErrorTypePublic}
+	c.Error(errors.Join(ginErr, errors.New("plain"))) //nolint: errcheck
+
+	assert.Len(t, c.Errors, 2)
+	assert.Equal(t, ErrorTypePublic, c.Errors[0].Type)
+	assert.Equal(t, ErrorTypePrivate, c.Errors[1].Type)
+}
+
+func TestContextErrorWithEmptyUnwrap(t *testing.T) {
+	// Custom error that implements Unwrap() []error but returns empty slice
+	c, _ := CreateTestContext(httptest.NewRecorder())
+
+	emptyJoinErr := emptyJoinError{errors.New("wrapped")}
+	c.Error(emptyJoinErr) //nolint: errcheck
+
+	assert.Len(t, c.Errors, 1)
+	assert.Equal(t, ErrorTypePrivate, c.Errors[0].Type)
+}
+
+type emptyJoinError struct{ err error }
+
+func (e emptyJoinError) Error() string     { return e.err.Error() }
+func (e emptyJoinError) Unwrap() []error   { return nil }
+
 func TestContextAbortWithError(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := CreateTestContext(w)


### PR DESCRIPTION
## Summary

- `Context.Error()` now detects errors implementing `Unwrap() []error` (like those from `errors.Join`) and stores each unwrapped error as an individual entry in `c.Errors`
- Preserves `*gin.Error` type metadata when a joined error contains one
- Falls through to the normal single-error path when `Unwrap()` returns an empty slice

## Motivation

Fixes #4237. When `errors.Join(e1, e2)` is passed to `c.Error()`, the joined error was stored as a single entry. This produced confusing output in `errorMsgs.String()` where the joined error's own `\n`-separated format mixed with Gin's numbered format:

```
Error #01 gin error
Error #02 service error
store error          <--- part of a joined error, not numbered
Error #03 other error
```

Now each joined error becomes its own numbered entry.

## Test plan

- [x] Basic `errors.Join(err1, err2)` unwraps into two entries
- [x] Nested `errors.Join` recursively unwraps
- [x] `*gin.Error` type preserved inside a join
- [x] Empty `Unwrap() []error` degrades to single wrapped entry
- [x] All existing tests pass
- [x] Race detector clean