### PR TITLE
feat(context): warn on multiple response writes

### DIFF
--- a/context.go
+++ b/context.go
@@ -1208,6 +1208,10 @@ func (c *Context) Render(code int, r render.Render) {
 		return
 	}
 
+	if c.Writer.Written() {
+		debugPrint("[WARNING] Response body has already been written. Wanted to override response.")
+	}
+
 	if err := r.Render(c.Writer); err != nil {
 		// Pushing error to c.Errors
 		_ = c.Error(err)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -251,3 +251,16 @@ func TestMiddlewareWrite(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, strings.ReplaceAll("hola\n<map><foo>bar</foo></map>{\"foo\":\"bar\"}{\"foo\":\"bar\"}event:test\ndata:message\n\n", " ", ""), strings.ReplaceAll(w.Body.String(), " ", ""))
 }
+
+func TestMultipleResponseWritesWarning(t *testing.T) {
+	router := New()
+	router.GET("/", func(c *Context) {
+		c.String(http.StatusOK, "first\n")
+		c.String(http.StatusOK, "second\n")
+	})
+
+	w := PerformRequest(router, http.MethodGet, "/")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "first\nsecond\n", w.Body.String())
+}


### PR DESCRIPTION
## Summary

Adds a debug-mode warning in `Context.Render()` when the response body has already been written. Matches the existing warning pattern in `response_writer.go` for duplicate header writes.

Before, calling `c.JSON()` twice silently concatenated output with no indication. Now:
```
[GIN-debug] [WARNING] Response body has already been written. Wanted to override response.
```

## Motivation

Fixes #4477. Gin warns about duplicate header writes but not duplicate body writes, making debugging difficult when middleware or handlers accidentally write multiple responses.

## Test plan

- [x] `TestMiddlewareWrite` — existing test continues to pass
- [x] `TestMultipleResponseWritesWarning` — verifies multiple writes still produce concatenated output (behavior unchanged)