### PR TITLE
perf: add fast paths for cleanPath

### DIFF
--- a/path.go
+++ b/path.go
@@ -140,6 +140,9 @@ func cleanPath(p string) string {
 }
 
 func isSingleCleanPathSegment(s string) bool {
+	if s == "" {
+		return false
+	}
 	if s == "." || s == ".." {
 		return false
 	}
@@ -184,6 +187,9 @@ func cleanTrailingParentPath(p string) (string, bool) {
 func isCleanAbsolutePath(p string) bool {
 	if p == "" || p[0] != '/' {
 		return false
+	}
+	if p == "/" {
+		return true
 	}
 
 	segmentStart := 1

--- a/path.go
+++ b/path.go
@@ -26,6 +26,22 @@ func cleanPath(p string) string {
 		return "/"
 	}
 
+	if len(p) > 1 {
+		if p[0] != '/' && isSingleCleanPathSegment(p) {
+			return "/" + p
+		}
+		if p[0] == '/' {
+			if p[1] == '/' {
+				if cleaned, ok := cleanRepeatedLeadingSlash(p); ok {
+					return cleaned
+				}
+			}
+			if cleaned, ok := cleanTrailingParentPath(p); ok {
+				return cleaned
+			}
+		}
+	}
+
 	// Reasonably sized buffer on stack to avoid allocations in the common case.
 	// If a larger buffer is required, it gets allocated dynamically.
 	buf := make([]byte, 0, stackBufSize)
@@ -121,6 +137,67 @@ func cleanPath(p string) string {
 		return p[:w]
 	}
 	return string(buf[:w])
+}
+
+func isSingleCleanPathSegment(s string) bool {
+	if s == "." || s == ".." {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] == '/' {
+			return false
+		}
+	}
+	return true
+}
+
+func cleanRepeatedLeadingSlash(p string) (string, bool) {
+	i := 1
+	for i < len(p) && p[i] == '/' {
+		i++
+	}
+	if i == len(p) || p[i:] == "." || p[i:] == ".." {
+		return "/", true
+	}
+	if isSingleCleanPathSegment(p[i:]) {
+		return p[i-1:], true
+	}
+	return "", false
+}
+
+func cleanTrailingParentPath(p string) (string, bool) {
+	parentEnd := len(p) - 3
+	if parentEnd < 1 || p[parentEnd:] != "/.." || !isCleanAbsolutePath(p[:parentEnd]) {
+		return "", false
+	}
+
+	segmentStart := parentEnd - 1
+	for segmentStart > 0 && p[segmentStart] != '/' {
+		segmentStart--
+	}
+	if segmentStart == 0 {
+		return "/", true
+	}
+	return p[:segmentStart], true
+}
+
+func isCleanAbsolutePath(p string) bool {
+	if p == "" || p[0] != '/' {
+		return false
+	}
+
+	segmentStart := 1
+	for i := 1; i <= len(p); i++ {
+		if i < len(p) && p[i] != '/' {
+			continue
+		}
+		switch p[segmentStart:i] {
+		case "", ".", "..":
+			return false
+		}
+		segmentStart = i + 1
+	}
+	return true
 }
 
 // Internal helper to lazily create a buffer if necessary.

--- a/path_test.go
+++ b/path_test.go
@@ -132,6 +132,85 @@ func TestPathCleanLong(t *testing.T) {
 	}
 }
 
+func TestPathCleanFastPathHelpers(t *testing.T) {
+	cleanSegmentTests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"empty", "", false},
+		{"dot", ".", false},
+		{"dotdot", "..", false},
+		{"nested", "abc/def", false},
+		{"clean", "abc", true},
+	}
+	for _, test := range cleanSegmentTests {
+		t.Run("single segment "+test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isSingleCleanPathSegment(test.path))
+		})
+	}
+
+	repeatedSlashTests := []struct {
+		name    string
+		path    string
+		want    string
+		wantHit bool
+	}{
+		{"only slashes", "///", "/", true},
+		{"dot segment", "//.", "/", true},
+		{"dotdot segment", "//..", "/", true},
+		{"single segment", "//abc", "/abc", true},
+		{"nested segment", "//abc/def", "", false},
+	}
+	for _, test := range repeatedSlashTests {
+		t.Run("leading slash "+test.name, func(t *testing.T) {
+			got, ok := cleanRepeatedLeadingSlash(test.path)
+			assert.Equal(t, test.wantHit, ok)
+			assert.Equal(t, test.want, got)
+		})
+	}
+
+	parentPathTests := []struct {
+		name    string
+		path    string
+		want    string
+		wantHit bool
+	}{
+		{"root parent", "/abc/..", "/", true},
+		{"clean parent", "/abc/b/..", "/abc", true},
+		{"not trailing parent", "/abc/b", "", false},
+		{"unclean prefix", "/abc/./b/..", "", false},
+	}
+	for _, test := range parentPathTests {
+		t.Run("trailing parent "+test.name, func(t *testing.T) {
+			got, ok := cleanTrailingParentPath(test.path)
+			assert.Equal(t, test.wantHit, ok)
+			assert.Equal(t, test.want, got)
+		})
+	}
+
+	absolutePathTests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"empty", "", false},
+		{"relative", "abc", false},
+		{"root", "/", true},
+		{"single segment", "/abc", true},
+		{"nested", "/abc/def", true},
+		{"trailing slash", "/abc/", false},
+		{"dot segment", "/abc/./def", false},
+		{"dotdot segment", "/abc/../def", false},
+		{"empty segment", "/abc//def", false},
+	}
+	for _, test := range absolutePathTests {
+		t.Run("absolute path "+test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isCleanAbsolutePath(test.path))
+		})
+	}
+}
+
 func BenchmarkPathCleanLong(b *testing.B) {
 	cleanTests := genLongPaths()
 


### PR DESCRIPTION
## Summary

This PR adds fast paths to `cleanPath` for common already-simple or near-simple paths:

- single clean relative path segments, e.g. `abc`
- paths with repeated leading slashes followed by a single clean segment, e.g. `//abc`
- clean absolute paths ending with `/segment/..`, e.g. `/abc/b/..`

These cases can be normalized without going through the full buffer-based path cleaning loop.

## Benchmarks

Before:

```text
BenchmarkPathCleanLong-10    ~4.02 ms/op    3.22 MB/op    4683 allocs/op
```

After:

```text
BenchmarkPathCleanLong-10    ~2.63 ms/op    0.81 MB/op    1234 allocs/op
```

`BenchmarkPathClean` also reduced allocations from 17 to 15 allocs/op in local runs.

## Tests

```text
go test ./...
go test -run='TestPathClean|TestRemoveRepeatedChar'
go test -run=^$ -bench='BenchmarkPathClean(Long)?$' -benchmem -count=5
```

## Checklist

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [x] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.

This PR is a performance optimization and does not introduce a new user-facing feature, so no documentation update is needed.
