### PR TITLE
docs(context): fix Param example annotation in context.go

### DIFF
--- a/context.go
+++ b/context.go
@@ -507,8 +507,11 @@ func (c *Context) Delete(key any) {
 //	router.GET("/user/:id", func(c *gin.Context) {
 //	    // a GET request to /user/john
 //	    id := c.Param("id") // id == "john"
-//	    // a GET request to /user/john/
-//	    id := c.Param("id") // id == "/john/"
+//	})
+//
+//	router.GET("/user/*action", func(c *gin.Context) {
+//	    // a GET request to /user/john/send
+//	    action := c.Param("action") // action == "/john/send"
 //	})
 func (c *Context) Param(key string) string {
 	return c.Params.ByName(key)


### PR DESCRIPTION
The existing Param comment contains an incorrect example.

In Gin, a named parameter route such as "/user/:id" matches exactly one path
segment. That means c.Param("id") should return "john" for "/user/john", not
"/john/". Values containing slashes are associated with catch-all parameters
like "/user/*action", not named parameters.

This change updates the comment to reflect the actual behavior of Param and to
avoid conflating named params with catch-all params.
