### PR TITLE
feat(binding): NewStructValidator for go-playground/validator options

### DIFF
--- a/binding/default_validator.go
+++ b/binding/default_validator.go
@@ -16,6 +16,18 @@ import (
 type defaultValidator struct {
 	once     sync.Once
 	validate *validator.Validate
+	opts     []validator.Option
+}
+
+// NewStructValidator returns a StructValidator backed by go-playground/validator
+// with the given options applied at construction time.
+//
+// This is needed for options that can only be set via validator.New, such as
+// validator.WithRequiredStructEnabled(). Example:
+//
+//	binding.Validator = binding.NewStructValidator(validator.WithRequiredStructEnabled())
+func NewStructValidator(opts ...validator.Option) StructValidator {
+	return &defaultValidator{opts: opts}
 }
 
 type SliceValidationError []error
@@ -92,7 +104,7 @@ func (v *defaultValidator) Engine() any {
 
 func (v *defaultValidator) lazyinit() {
 	v.once.Do(func() {
-		v.validate = validator.New()
+		v.validate = validator.New(v.opts...)
 		v.validate.SetTagName("binding")
 	})
 }

--- a/binding/default_validator_test.go
+++ b/binding/default_validator_test.go
@@ -7,6 +7,8 @@ package binding
 import (
 	"errors"
 	"testing"
+
+	"github.com/go-playground/validator/v10"
 )
 
 func TestSliceValidationError(t *testing.T) {
@@ -86,5 +88,32 @@ func TestDefaultValidator(t *testing.T) {
 				t.Errorf("defaultValidator.Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestNewStructValidatorRequiredStruct(t *testing.T) {
+	type myUUID struct {
+		S string
+	}
+	type createReq struct {
+		ID myUUID `binding:"required"`
+	}
+
+	// without the option, required is a no-op on non-pointer struct fields
+	if err := (&defaultValidator{}).ValidateStruct(createReq{}); err != nil {
+		t.Fatalf("default validator: unexpected error: %v", err)
+	}
+
+	v := NewStructValidator(validator.WithRequiredStructEnabled())
+	if err := v.ValidateStruct(createReq{}); err == nil {
+		t.Fatal("WithRequiredStructEnabled: expected required error on zero struct field")
+	}
+	if err := v.ValidateStruct(createReq{ID: myUUID{S: "x"}}); err != nil {
+		t.Fatalf("WithRequiredStructEnabled: unexpected error for non-zero field: %v", err)
+	}
+
+	engine, ok := v.Engine().(*validator.Validate)
+	if !ok || engine == nil {
+		t.Fatalf("Engine() = %T, want *validator.Validate", v.Engine())
 	}
 }


### PR DESCRIPTION
Fixes #4733

`validator.WithRequiredStructEnabled()` (and other constructor-only options) can't be applied through the current default validator — `lazyinit` always calls `validator.New()` with no args, and `Engine()` is already too late.

Adds `binding.NewStructValidator(opts ...validator.Option)` so you can do:

```go
binding.Validator = binding.NewStructValidator(validator.WithRequiredStructEnabled())
```

without reimplementing `ValidateStruct`. Default `binding.Validator` behavior is unchanged.

Test covers the required-on-struct-field case from the issue.