### PR TITLE
fix(context): avoid ClientIP "<nil>" and parse multi-value Scheme headers

### DIFF
--- a/context.go
+++ b/context.go
@@ -1043,6 +1043,12 @@ func (c *Context) ClientIP() string {
 			}
 		}
 	}
+	// Unix listeners mark the request as trusted without parsing RemoteAddr.
+	// When no client IP header is present, remoteIP stays nil — return empty
+	// instead of the net.IP nil string "<nil>".
+	if remoteIP == nil {
+		return ""
+	}
 	return remoteIP.String()
 }
 
@@ -1073,28 +1079,38 @@ func (c *Context) IsWebsocket() bool {
 // Scheme returns the HTTP scheme of the request ("http" or "https").
 // When running behind reverse proxies or load balancers `Request.URL.Scheme` is usually empty.
 // the original scheme is commonly forwarded via headers such as X-Forwarded-Proto.
+// Multi-value proxy headers (e.g. "https, http") use the left-most value.
 // Reference:
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Proto
 func (c *Context) Scheme() string {
 	if c.Request.TLS != nil {
 		return "https"
 	}
-	if scheme := c.requestHeader("X-Forwarded-Proto"); scheme != "" {
+	if scheme := firstHeaderValue(c.requestHeader("X-Forwarded-Proto")); scheme != "" {
 		return scheme
 	}
-	if scheme := c.requestHeader("X-Forwarded-Protocol"); scheme != "" {
+	if scheme := firstHeaderValue(c.requestHeader("X-Forwarded-Protocol")); scheme != "" {
 		return scheme
 	}
 	if ssl := c.requestHeader("X-Forwarded-Ssl"); ssl == "on" {
 		return "https"
 	}
-	if scheme := c.requestHeader("X-Url-Scheme"); scheme != "" {
+	if scheme := firstHeaderValue(c.requestHeader("X-Url-Scheme")); scheme != "" {
 		return scheme
 	}
 	if scheme := c.Request.URL.Scheme; scheme != "" {
 		return scheme
 	}
 	return "http"
+}
+
+// firstHeaderValue returns the left-most non-empty token from a possibly
+// comma-separated proxy header value (for example X-Forwarded-Proto: "https, http").
+func firstHeaderValue(header string) string {
+	if i := strings.IndexByte(header, ','); i >= 0 {
+		header = header[:i]
+	}
+	return strings.TrimSpace(header)
 }
 
 func (c *Context) requestHeader(key string) string {

--- a/context_test.go
+++ b/context_test.go
@@ -2071,6 +2071,13 @@ func TestContextClientIP(t *testing.T) {
 	c.Request.RemoteAddr = addr.String()
 	assert.Equal(t, "20.20.20.20", c.ClientIP())
 
+	// unix without client IP headers must not return net.IP's "<nil>" string
+	c.Request.Header.Del("X-Forwarded-For")
+	c.Request.Header.Del("X-Real-IP")
+	c.Request.Header.Del("X-Appengine-Remote-Addr")
+	c.engine.TrustedPlatform = ""
+	assert.Empty(t, c.ClientIP())
+
 	// reset
 	c.Request = c.Request.WithContext(context.Background())
 	resetContextForClientIPTests(c)
@@ -3099,6 +3106,17 @@ func TestContextScheme(t *testing.T) {
 	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
 	c.Request.TLS = &tls.ConnectionState{}
 	c.Request.Header.Set("X-Forwarded-Proto", "http")
+	assert.Equal(t, "https", c.Scheme())
+
+	// Multi-value proxy headers use the left-most scheme.
+	c, _ = CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Header.Set("X-Forwarded-Proto", "https, http")
+	assert.Equal(t, "https", c.Scheme())
+
+	c, _ = CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Header.Set("X-Forwarded-Protocol", " https , http")
 	assert.Equal(t, "https", c.Scheme())
 }
 


### PR DESCRIPTION
## Summary

Two small correctness fixes in `Context`:

1. **`ClientIP` on Unix sockets**  
   Listening on a Unix socket marks the connection as trusted without parsing `RemoteAddr`, so `remoteIP` stays `nil`. When no client-IP proxy headers are present, `ClientIP` returned the `net.IP` nil string `"<nil>"` instead of an empty string.

2. **`Scheme` with multi-value proxy headers**  
   Headers like `X-Forwarded-Proto: https, http` were returned as-is. Take the left-most non-empty token (common reverse-proxy semantics).

## Test plan

- [x] `go test -count=1 -run 'TestContextClientIP$|TestContextScheme$' .`
- [x] `go test -count=1 -race -run 'TestContextClientIP|TestContextScheme' .`
- [x] `go test -count=1 .`
- Added regression cases for Unix + no headers, and multi-value scheme headers