### PR TITLE
fix(recovery): mask Cookie and Proxy-Authorization in panic dumps

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -91,19 +91,37 @@ func CustomRecoveryWithWriter(out io.Writer, handle RecoveryFunc) HandlerFunc {
 	}
 }
 
-// secureRequestDump returns a sanitized HTTP request dump where the Authorization header,
-// if present, is replaced with a masked value ("Authorization: *") to avoid leaking sensitive credentials.
+// secureRequestDump returns a sanitized HTTP request dump where sensitive
+// credential headers are replaced with a masked value ("Header-Name: *")
+// so panic recovery logs do not leak secrets.
 //
-// Currently, only the Authorization header is sanitized. All other headers and request data remain unchanged.
+// Masked headers: Authorization, Proxy-Authorization, Cookie.
 func secureRequestDump(r *http.Request) string {
 	httpRequest, _ := httputil.DumpRequest(r, false)
 	lines := strings.Split(bytesconv.BytesToString(httpRequest), "\r\n")
 	for i, line := range lines {
-		if strings.HasPrefix(line, "Authorization:") {
-			lines[i] = "Authorization: *"
+		name, ok := headerName(line)
+		if !ok {
+			continue
+		}
+		switch {
+		case strings.EqualFold(name, "Authorization"),
+			strings.EqualFold(name, "Proxy-Authorization"),
+			strings.EqualFold(name, "Cookie"):
+			// Keep the canonical header name from the dump for stable log output.
+			lines[i] = name + ": *"
 		}
 	}
 	return strings.Join(lines, "\r\n")
+}
+
+// headerName returns the header field name from a single dump line "Name: value".
+func headerName(line string) (string, bool) {
+	idx := strings.IndexByte(line, ':')
+	if idx <= 0 {
+		return "", false
+	}
+	return line[:idx], true
 }
 
 func defaultHandleRecovery(c *Context, err any) {

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -347,19 +347,71 @@ func TestSecureRequestDump(t *testing.T) {
 			wantContains:   "",
 			wantNotContain: "Authorization: *",
 		},
+		{
+			name: "Cookie header is masked",
+			req: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+				r.Header.Set("Cookie", "session=super-secret; theme=dark")
+				return r
+			}(),
+			wantContains:   "Cookie: *",
+			wantNotContain: "super-secret",
+		},
+		{
+			name: "Proxy-Authorization header is masked",
+			req: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+				r.Header.Set("Proxy-Authorization", "Basic dXNlcjpwYXNz")
+				return r
+			}(),
+			wantContains:   "Proxy-Authorization: *",
+			wantNotContain: "dXNlcjpwYXNz",
+		},
+		{
+			name: "multiple sensitive headers are masked",
+			req: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+				r.Header.Set("Authorization", "Bearer tok")
+				r.Header.Set("Cookie", "sid=abc")
+				r.Header.Set("Proxy-Authorization", "Basic xyz")
+				r.Header.Set("X-Request-Id", "req-1")
+				return r
+			}(),
+			wantContains:   "X-Request-Id: req-1",
+			wantNotContain: "Bearer tok",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := secureRequestDump(tt.req)
 			if tt.wantContains != "" && !strings.Contains(result, tt.wantContains) {
-				t.Errorf("maskHeaders() = %q, want contains %q", result, tt.wantContains)
+				t.Errorf("secureRequestDump() = %q, want contains %q", result, tt.wantContains)
 			}
 			if tt.wantNotContain != "" && strings.Contains(result, tt.wantNotContain) {
-				t.Errorf("maskHeaders() = %q, want NOT contain %q", result, tt.wantNotContain)
+				t.Errorf("secureRequestDump() = %q, want NOT contain %q", result, tt.wantNotContain)
 			}
 		})
 	}
+
+	// Combined check: secrets from every sensitive header must be gone.
+	t.Run("no secret values remain when all sensitive headers set", func(t *testing.T) {
+		r, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+		r.Header.Set("Authorization", "Bearer tok")
+		r.Header.Set("Cookie", "sid=abc")
+		r.Header.Set("Proxy-Authorization", "Basic xyz")
+		result := secureRequestDump(r)
+		for _, secret := range []string{"Bearer tok", "sid=abc", "Basic xyz"} {
+			if strings.Contains(result, secret) {
+				t.Errorf("secureRequestDump leaked %q in %q", secret, result)
+			}
+		}
+		for _, masked := range []string{"Authorization: *", "Cookie: *", "Proxy-Authorization: *"} {
+			if !strings.Contains(result, masked) {
+				t.Errorf("secureRequestDump missing %q in %q", masked, result)
+			}
+		}
+	})
 }
 
 // TestReadNthLine tests the readNthLine function with various scenarios.


### PR DESCRIPTION
## Summary

`secureRequestDump` is used when Recovery middleware logs a panic. Previously only `Authorization` was redacted, so **session cookies** and **proxy credentials** could still appear in logs.

This change also masks:

- `Cookie`
- `Proxy-Authorization`

Header matching is done by field name (case-insensitive) so the dump stays stable across `http.Header` canonicalization.

## Test plan

- [x] Extended `TestSecureRequestDump` for Cookie / Proxy-Authorization / multi-header cases
- [x] `go test -count=1 -run TestSecureRequestDump .`
- [x] `go test -count=1 .`