### PR TITLE
fix(context): encode FileAttachment filename* with PathEscape

### DIFF
--- a/context.go
+++ b/context.go
@@ -1360,7 +1360,9 @@ func (c *Context) FileAttachment(filepath, filename string) {
 	if isASCII(filename) {
 		c.Writer.Header().Set("Content-Disposition", `attachment; filename="`+escapeQuotes(filename)+`"`)
 	} else {
-		c.Writer.Header().Set("Content-Disposition", `attachment; filename*=UTF-8''`+url.QueryEscape(filename))
+		// RFC 5987 filename* values use percent-encoding (space as %20).
+		// url.QueryEscape is wrong here because it encodes spaces as '+'.
+		c.Writer.Header().Set("Content-Disposition", `attachment; filename*=UTF-8''`+url.PathEscape(filename))
 	}
 	http.ServeFile(c.Writer, c.Request, filepath)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1595,7 +1595,23 @@ func TestContextRenderUTF8Attachment(t *testing.T) {
 
 	assert.Equal(t, 200, w.Code)
 	assert.Contains(t, w.Body.String(), "func New(opts ...OptionFunc) *Engine {")
-	assert.Equal(t, `attachment; filename*=UTF-8''`+url.QueryEscape(newFilename), w.Header().Get("Content-Disposition"))
+	assert.Equal(t, `attachment; filename*=UTF-8''`+url.PathEscape(newFilename), w.Header().Get("Content-Disposition"))
+}
+
+func TestContextRenderUTF8AttachmentWithSpace(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+	// Non-ASCII + space: PathEscape uses %20; QueryEscape would wrongly use '+'.
+	newFilename := "报告 测试.go"
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.FileAttachment("./gin.go", newFilename)
+
+	assert.Equal(t, 200, w.Code)
+	got := w.Header().Get("Content-Disposition")
+	assert.Equal(t, `attachment; filename*=UTF-8''`+url.PathEscape(newFilename), got)
+	assert.NotContains(t, got, "+")
+	assert.Contains(t, got, "%20")
 }
 
 // TestContextRenderYAML tests that the response is serialized as YAML


### PR DESCRIPTION
## Summary

For non-ASCII download names, `FileAttachment` builds a RFC 5987 `filename*` parameter with `url.QueryEscape`. That encoder is for form queries and turns spaces into `+`, so a name like `报告 测试.pdf` becomes `报告+测试.pdf` in many clients.

Switch to `url.PathEscape` so spaces become `%20` (and the encoding matches percent-encoded attr-char expectations).

## Test plan

- [x] Updated UTF-8 attachment test to expect `PathEscape`
- [x] Added regression test for non-ASCII filename containing a space
- [x] `go test -count=1 -run 'TestContextRender.*Attachment' .`
- [x] `go test -count=1 .`