### PR TITLE
fix(context): use left-most value for TrustedPlatform ClientIP header

### DIFF
--- a/context.go
+++ b/context.go
@@ -998,8 +998,9 @@ func (c *Context) ShouldBindBodyWithPlain(obj any) error {
 func (c *Context) ClientIP() string {
 	// Check if we're running on a trusted platform, continue running backwards if error
 	if c.engine.TrustedPlatform != "" {
-		// Developers can define their own header of Trusted Platform or use predefined constants
-		if addr := c.requestHeader(c.engine.TrustedPlatform); addr != "" {
+		// Developers can define their own header of Trusted Platform or use predefined constants.
+		// Multi-value headers use the left-most entry (common proxy semantics).
+		if addr := firstHeaderValue(c.requestHeader(c.engine.TrustedPlatform)); addr != "" {
 			return addr
 		}
 	}
@@ -1053,6 +1054,16 @@ func (c *Context) RemoteIP() string {
 		return ""
 	}
 	return ip
+}
+
+
+// firstHeaderValue returns the left-most non-empty token from a possibly
+// comma-separated proxy header value (for example X-Forwarded-Proto: "https, http").
+func firstHeaderValue(header string) string {
+	if i := strings.IndexByte(header, ','); i >= 0 {
+		header = header[:i]
+	}
+	return strings.TrimSpace(header)
 }
 
 // ContentType returns the Content-Type header of the request.

--- a/context.go
+++ b/context.go
@@ -1056,7 +1056,6 @@ func (c *Context) RemoteIP() string {
 	return ip
 }
 
-
 // firstHeaderValue returns the left-most non-empty token from a possibly
 // comma-separated proxy header value (for example X-Forwarded-Proto: "https, http").
 func firstHeaderValue(header string) string {

--- a/context_test.go
+++ b/context_test.go
@@ -1266,6 +1266,14 @@ func TestContextClientIPWithMultipleHeaders(t *testing.T) {
 	assert.Equal(t, "5.6.7.8", c.ClientIP())
 }
 
+func TestContextClientIPTrustedPlatformMultiValue(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.engine.TrustedPlatform = "X-Custom-IP"
+	c.Request.Header.Set("X-Custom-IP", "1.2.3.4, 5.6.7.8")
+	assert.Equal(t, "1.2.3.4", c.ClientIP())
+}
+
 func TestContextClientIPWithSingleHeader(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.Request, _ = http.NewRequest(http.MethodGet, "/test", nil)


### PR DESCRIPTION
Multi-value TrustedPlatform headers use the left-most token.