### PR TITLE
fix(context): match Connection tokens for IsWebsocket

### DIFF
--- a/context.go
+++ b/context.go
@@ -1063,9 +1063,20 @@ func (c *Context) ContentType() string {
 // IsWebsocket returns true if the request headers indicate that a websocket
 // handshake is being initiated by the client.
 func (c *Context) IsWebsocket() bool {
-	if strings.Contains(strings.ToLower(c.requestHeader("Connection")), "upgrade") &&
+	if hasConnectionToken(c.requestHeader("Connection"), "upgrade") &&
 		strings.EqualFold(c.requestHeader("Upgrade"), "websocket") {
 		return true
+	}
+	return false
+}
+
+// hasConnectionToken reports whether name appears as a comma-separated token
+// in a Connection header (RFC 9110), case-insensitively.
+func hasConnectionToken(header, name string) bool {
+	for part := range strings.SplitSeq(header, ",") {
+		if strings.EqualFold(strings.TrimSpace(part), name) {
+			return true
+		}
 	}
 	return false
 }

--- a/context_test.go
+++ b/context_test.go
@@ -3955,3 +3955,21 @@ func BenchmarkGetMapFromFormData(b *testing.B) {
 		})
 	}
 }
+
+func TestContextIsWebsocketConnectionToken(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Header.Set("Connection", "keep-alive")
+	c.Request.Header.Set("Upgrade", "websocket")
+	assert.False(t, c.IsWebsocket())
+
+	c.Request.Header.Set("Connection", "Upgrade")
+	assert.True(t, c.IsWebsocket())
+
+	c.Request.Header.Set("Connection", "keep-alive, Upgrade")
+	assert.True(t, c.IsWebsocket())
+
+	// Substring in a different token must not match ("keep-alive-upgrade").
+	c.Request.Header.Set("Connection", "keep-alive-upgrade")
+	assert.False(t, c.IsWebsocket())
+}


### PR DESCRIPTION
Use comma-separated Connection tokens instead of substring Contains("upgrade").