### PR TITLE
fix(binding): do not panic ValidateStruct on nil pointers

### DIFF
--- a/binding/default_validator.go
+++ b/binding/default_validator.go
@@ -52,6 +52,9 @@ func (v *defaultValidator) ValidateStruct(obj any) error {
 	value := reflect.ValueOf(obj)
 	switch value.Kind() {
 	case reflect.Ptr:
+		if value.IsNil() {
+			return nil
+		}
 		if value.Elem().Kind() != reflect.Struct {
 			return v.ValidateStruct(value.Elem().Interface())
 		}

--- a/binding/default_validator_test.go
+++ b/binding/default_validator_test.go
@@ -93,7 +93,11 @@ func TestValidateStructNilPointer(t *testing.T) {
 	var p *struct {
 		A string `binding:"required"`
 	}
-	require.NoError(t, Validator.ValidateStruct(p))
+	if err := Validator.ValidateStruct(p); err != nil {
+		t.Fatalf("nil *struct: %v", err)
+	}
 	var i *int
-	require.NoError(t, Validator.ValidateStruct(i))
+	if err := Validator.ValidateStruct(i); err != nil {
+		t.Fatalf("nil *int: %v", err)
+	}
 }

--- a/binding/default_validator_test.go
+++ b/binding/default_validator_test.go
@@ -88,3 +88,12 @@ func TestDefaultValidator(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateStructNilPointer(t *testing.T) {
+	var p *struct {
+		A string `binding:"required"`
+	}
+	require.NoError(t, Validator.ValidateStruct(p))
+	var i *int
+	require.NoError(t, Validator.ValidateStruct(i))
+}


### PR DESCRIPTION
Nil pointers hit Elem().Interface() and panic despite the never-panic contract.