### PR TITLE
fix: make nameOfFunction nil-safe for HandlerName

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -129,7 +129,14 @@ func lastChar(str string) uint8 {
 }
 
 func nameOfFunction(f any) string {
-	return runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+	v := reflect.ValueOf(f)
+	if !v.IsValid() || (v.Kind() == reflect.Func && v.IsNil()) {
+		return ""
+	}
+	if fn := runtime.FuncForPC(v.Pointer()); fn != nil {
+		return fn.Name()
+	}
+	return ""
 }
 
 func joinPaths(absolutePath, relativePath string) string {

--- a/utils_test.go
+++ b/utils_test.go
@@ -171,3 +171,13 @@ func TestSafeUint16(t *testing.T) {
 	assert.Equal(t, uint16(100), safeUint16(100))
 	assert.Equal(t, uint16(math.MaxUint16), safeUint16(int(math.MaxUint16)+123))
 }
+
+func TestNameOfFunctionNil(t *testing.T) {
+	if got := nameOfFunction(nil); got != "" {
+		t.Fatalf("got %q", got)
+	}
+	var f HandlerFunc
+	if got := nameOfFunction(f); got != "" {
+		t.Fatalf("nil func got %q", got)
+	}
+}


### PR DESCRIPTION
Copy()/empty chains yield nil handlers; FuncForPC(0).Name() panics.