### PR TITLE
fix(context): Context.Value looks up non-string Keys

### DIFF
--- a/context.go
+++ b/context.go
@@ -1527,10 +1527,8 @@ func (c *Context) Value(key any) any {
 	if key == ContextKey {
 		return c
 	}
-	if keyAsString, ok := key.(string); ok {
-		if val, exists := c.Get(keyAsString); exists {
-			return val
-		}
+	if val, exists := c.Get(key); exists {
+		return val
 	}
 	if !c.hasRequestContext() {
 		return nil

--- a/context_test.go
+++ b/context_test.go
@@ -3955,3 +3955,11 @@ func BenchmarkGetMapFromFormData(b *testing.B) {
 		})
 	}
 }
+
+func TestContextValueNonStringKey(t *testing.T) {
+	type ctxKey struct{}
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.Set(ctxKey{}, "secret")
+	assert.Equal(t, "secret", c.Value(ctxKey{}))
+}


### PR DESCRIPTION
Set/Get support any keys; Value previously only checked string keys.