### PR TITLE
refactor: replace filterFlags with mime.ParseMediaType

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -7,6 +7,7 @@ package gin
 import (
 	"encoding/xml"
 	"math"
+	"mime"
 	"net/http"
 	"os"
 	"path"
@@ -89,12 +90,11 @@ func assert1(guard bool, text string) {
 }
 
 func filterFlags(content string) string {
-	for i, char := range content {
-		if char == ' ' || char == ';' {
-			return content[:i]
-		}
+	mediatype, _, err := mime.ParseMediaType(content)
+	if err != nil {
+		return content
 	}
-	return content
+	return mediatype
 }
 
 func chooseData(custom, wildcard any) any {


### PR DESCRIPTION
### Changes
Replace handmade `filterFlags` simple string truncation logic with standard library `mime.ParseMediaType` to parse Content-Type header.

### Purpose
- Fix multiple parsing defects of filterFlags: leading whitespace, case sensitivity, incomplete whitespace handling
- Follow RFC standard for MIME type parsing
- Unify media type to lowercase automatically
- Gain better compatibility with malformed HTTP request headers from clients

