### PR TITLE
docs: fix broken link to assets-in-binary example

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -2085,7 +2085,7 @@ func main() {
 }
 ```
 
-See a complete example in the `https://github.com/gin-gonic/examples/tree/master/assets-in-binary/example02` directory.
+See a complete example in the [`assets-in-binary`](https://github.com/gin-gonic/examples/tree/master/assets-in-binary) directory.
 
 ## Server Configuration
 


### PR DESCRIPTION
## Description

The link in `docs/doc.md` pointing to the "assets in binary" example was broken:

- Old: `https://github.com/gin-gonic/examples/tree/master/assets-in-binary/example02` → **404**
- The `example02` subdirectory no longer exists in the [`gin-gonic/examples`](https://github.com/gin-gonic/examples) repository. The example now lives directly under [`assets-in-binary`](https://github.com/gin-gonic/examples/tree/master/assets-in-binary) → **200**

This PR updates the link to the correct location and formats it as a Markdown link, consistent with the other example references in the same document.

## Pull Request Checklist

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes. _(N/A — documentation-only change)_
- [x] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`. _(N/A — no new feature)_
