### PR TITLE
Fix malformed PR links in the v1.9.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,12 +278,12 @@
 
 ### BUG FIXES
 
-- fix(route): redirectSlash bug ([#3227](<(https://github.com/gin-gonic/gin/pull/3227)>))
-- fix(engine): missing route params for CreateTestContext ([#2778](<(https://github.com/gin-gonic/gin/pull/2778)>)) ([#2803](<(https://github.com/gin-gonic/gin/pull/2803)>))
+- fix(route): redirectSlash bug ([#3227](https://github.com/gin-gonic/gin/pull/3227))
+- fix(engine): missing route params for CreateTestContext ([#2778](https://github.com/gin-gonic/gin/pull/2778)) ([#2803](https://github.com/gin-gonic/gin/pull/2803))
 
 ### SECURITY
 
-- Fix the GO-2022-1144 vulnerability ([#3432](<(https://github.com/gin-gonic/gin/pull/3432)>))
+- Fix the GO-2022-1144 vulnerability ([#3432](https://github.com/gin-gonic/gin/pull/3432))
 
 ## Gin v1.8.1
 


### PR DESCRIPTION
Four links in the v1.9.0 section of `CHANGELOG.md` are written as `[#N](<(url)>)`. In markdown, the angle-bracket destination makes the href the literal text `(https://…` (with the stray opening parenthesis), so all four links 404 on GitHub:

- `#3227` (redirectSlash fix)
- `#2778` / `#2803` (CreateTestContext route params)
- `#3432` (GO-2022-1144 fix)

Rewritten as plain `[#N](url)`, matching every other link in the file. All four target URLs verified to return HTTP 200. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)