### PR TITLE
fix(context): fix data race on c.Keys in Copy

### DIFF
--- a/context.go
+++ b/context.go
@@ -132,9 +132,8 @@ func (c *Context) Copy() *Context {
 	cp.handlers = nil
 	cp.fullPath = c.fullPath
 
-	cKeys := c.Keys
 	c.mu.RLock()
-	cp.Keys = maps.Clone(cKeys)
+	cp.Keys = maps.Clone(c.Keys)
 	c.mu.RUnlock()
 
 	cParams := c.Params

--- a/context_test.go
+++ b/context_test.go
@@ -776,6 +776,29 @@ func TestContextCopyNilErrorsAndAccepted(t *testing.T) {
 	assert.Nil(t, cp.Accepted)
 }
 
+func TestContextCopyRace(t *testing.T) {
+	c := &Context{}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			c.Set("foo", "bar")
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			c.Copy()
+		}
+	}()
+
+	wg.Wait()
+}
+
 func TestContextHandlerName(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	c.handlers = HandlersChain{func(c *Context) {}, handlerNameTest}


### PR DESCRIPTION
# Pull Request Checklist

Please ensure your pull request meets the following requirements:

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [ ] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.

---

### Description

In `Context.Copy()`, `cKeys := c.Keys` was evaluated outside the `c.mu.RLock()` critical section. When `c.Set()` is called concurrently, accessing `c.Keys` without holding `RLock` causes a data race under `go test -race` and can clone a stale `nil` map.

### Fix
Moved `c.Keys` evaluation directly inside the `c.mu.RLock()` block:
```go
c.mu.RLock()
cp.Keys = maps.Clone(c.Keys)
c.mu.RUnlock()
