### PR TITLE
feat(routing): support HTTP QUERY method

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -26,6 +26,9 @@ const (
 	MIMEBSON              = "application/bson"
 )
 
+// MethodQuery is the HTTP QUERY method defined by RFC 9530. until http.MethodQuery is available.
+const MethodQuery string = "QUERY"
+
 // Binding describes the interface which needs to be implemented for binding the
 // data present in the request such as JSON request body, query parameters or
 // the form POST.

--- a/context.go
+++ b/context.go
@@ -43,6 +43,9 @@ const (
 	MIMEBSON              = binding.MIMEBSON
 )
 
+// MethodQuery is the HTTP QUERY method defined by RFC 9530. until http.MethodQuery is available.
+const MethodQuery = binding.MethodQuery
+
 // BodyBytesKey indicates a default body bytes key.
 const BodyBytesKey = "_gin-gonic/gin/bodybyteskey"
 

--- a/context_test.go
+++ b/context_test.go
@@ -2453,6 +2453,22 @@ func TestContextShouldBindWithJSON(t *testing.T) {
 	assert.Equal(t, 0, w.Body.Len())
 }
 
+func TestContextShouldBindWithQUERY(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest(MethodQuery, "/", strings.NewReader(`{"foo":"bar", "bar":"foo"}`))
+	c.Request.Header.Add("Content-Type", MIMEJSON)
+
+	var obj struct {
+		Foo string `json:"foo"`
+		Bar string `json:"bar"`
+	}
+	require.NoError(t, c.ShouldBind(&obj))
+	assert.Equal(t, "foo", obj.Bar)
+	assert.Equal(t, "bar", obj.Foo)
+}
+
 func TestContextShouldBindWithXML(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := CreateTestContext(w)

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -6,7 +6,7 @@
   - [Build with json replacement](#build-with-json-replacement)
   - [Build without MsgPack rendering feature](#build-without-msgpack-rendering-feature)
 - [Routing](#routing)
-  - [Using GET, POST, PUT, PATCH, DELETE and OPTIONS](#using-get-post-put-patch-delete-and-options)
+  - [Using GET, POST, PUT, PATCH, QUERY, DELETE and OPTIONS](#using-get-post-put-patch-query-delete-and-options)
   - [Parameters in path](#parameters-in-path)
   - [Querystring parameters](#querystring-parameters)
   - [Multipart/Urlencoded Form](#multiparturlencoded-form)
@@ -114,7 +114,7 @@ This is useful to reduce the binary size of executable files. See the [detail in
 
 > Learn how to define routes, handle parameters, and organize endpoints.
 
-### Using GET, POST, PUT, PATCH, DELETE and OPTIONS
+### Using GET, POST, PUT, PATCH, QUERY, DELETE and OPTIONS
 
 ```go
 func main() {
@@ -127,6 +127,7 @@ func main() {
   router.PUT("/somePut", putting)
   router.DELETE("/someDelete", deleting)
   router.PATCH("/somePatch", patching)
+  router.QUERY("/someQuery", querying)
   router.HEAD("/someHead", head)
   router.OPTIONS("/someOptions", options)
 

--- a/ginS/gins.go
+++ b/ginS/gins.go
@@ -67,6 +67,11 @@ func GET(relativePath string, handlers ...gin.HandlerFunc) gin.IRoutes {
 	return engine().GET(relativePath, handlers...)
 }
 
+// QUERY is a shortcut for router.Handle("QUERY", path, handle)
+func QUERY(relativePath string, handlers ...gin.HandlerFunc) gin.IRoutes {
+	return engine().QUERY(relativePath, handlers...)
+}
+
 // DELETE is a shortcut for router.Handle("DELETE", path, handle)
 func DELETE(relativePath string, handlers ...gin.HandlerFunc) gin.IRoutes {
 	return engine().DELETE(relativePath, handlers...)

--- a/ginS/gins_test.go
+++ b/ginS/gins_test.go
@@ -31,6 +31,19 @@ func TestGET(t *testing.T) {
 	assert.Equal(t, "test", w.Body.String())
 }
 
+func TestQUERY(t *testing.T) {
+	QUERY("/query", func(c *gin.Context) {
+		c.String(http.StatusOK, "query")
+	})
+
+	req := httptest.NewRequest("QUERY", "/query", nil)
+	w := httptest.NewRecorder()
+	engine().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "query", w.Body.String())
+}
+
 func TestPOST(t *testing.T) {
 	POST("/post", func(c *gin.Context) {
 		c.String(http.StatusCreated, "created")

--- a/routergroup.go
+++ b/routergroup.go
@@ -19,7 +19,7 @@ var (
 	anyMethods = []string{
 		http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch,
 		http.MethodHead, http.MethodOptions, http.MethodDelete, http.MethodConnect,
-		http.MethodTrace,
+		http.MethodTrace, MethodQuery,
 	}
 )
 
@@ -36,6 +36,7 @@ type IRoutes interface {
 	Handle(string, string, ...HandlerFunc) IRoutes
 	Any(string, ...HandlerFunc) IRoutes
 	GET(string, ...HandlerFunc) IRoutes
+	QUERY(string, ...HandlerFunc) IRoutes
 	POST(string, ...HandlerFunc) IRoutes
 	DELETE(string, ...HandlerFunc) IRoutes
 	PATCH(string, ...HandlerFunc) IRoutes
@@ -115,6 +116,11 @@ func (group *RouterGroup) POST(relativePath string, handlers ...HandlerFunc) IRo
 // GET is a shortcut for router.Handle("GET", path, handlers).
 func (group *RouterGroup) GET(relativePath string, handlers ...HandlerFunc) IRoutes {
 	return group.handle(http.MethodGet, relativePath, handlers)
+}
+
+// QUERY is a shortcut for router.Handle("QUERY", path, handlers).
+func (group *RouterGroup) QUERY(relativePath string, handlers ...HandlerFunc) IRoutes {
+	return group.handle(MethodQuery, relativePath, handlers)
 }
 
 // DELETE is a shortcut for router.Handle("DELETE", path, handlers).

--- a/routergroup_test.go
+++ b/routergroup_test.go
@@ -42,6 +42,7 @@ func TestRouterGroupBasicHandle(t *testing.T) {
 	performRequestInGroup(t, http.MethodDelete)
 	performRequestInGroup(t, http.MethodHead)
 	performRequestInGroup(t, http.MethodOptions)
+	performRequestInGroup(t, "QUERY")
 }
 
 func performRequestInGroup(t *testing.T, method string) {
@@ -78,6 +79,9 @@ func performRequestInGroup(t *testing.T, method string) {
 	case http.MethodOptions:
 		v1.OPTIONS("/test", handler)
 		login.OPTIONS("/test", handler)
+	case "QUERY":
+		v1.QUERY("/test", handler)
+		login.QUERY("/test", handler)
 	default:
 		panic("unknown method")
 	}

--- a/routes_test.go
+++ b/routes_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gin-gonic/gin/binding"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -116,6 +117,7 @@ func TestRouterGroupRouteOK(t *testing.T) {
 	testRouteOK(http.MethodDelete, t)
 	testRouteOK(http.MethodConnect, t)
 	testRouteOK(http.MethodTrace, t)
+	testRouteOK(binding.MethodQuery, t)
 }
 
 func TestRouteNotOK(t *testing.T) {
@@ -128,6 +130,7 @@ func TestRouteNotOK(t *testing.T) {
 	testRouteNotOK(http.MethodDelete, t)
 	testRouteNotOK(http.MethodConnect, t)
 	testRouteNotOK(http.MethodTrace, t)
+	testRouteNotOK(binding.MethodQuery, t)
 }
 
 func TestRouteNotOK2(t *testing.T) {
@@ -140,6 +143,7 @@ func TestRouteNotOK2(t *testing.T) {
 	testRouteNotOK2(http.MethodDelete, t)
 	testRouteNotOK2(http.MethodConnect, t)
 	testRouteNotOK2(http.MethodTrace, t)
+	testRouteNotOK2(binding.MethodQuery, t)
 }
 
 func TestRouteRedirectTrailingSlash(t *testing.T) {


### PR DESCRIPTION
# Pull Request Checklist

Please ensure your pull request meets the following requirements:

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [x] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.

---

### Description

This PR introduces support for the HTTP `QUERY` method (defined by RFC 9530 / IETF draft). The HTTP `QUERY` method allows safe, idempotent requests to carry a request payload (e.g., a JSON body).

### Changes

1. **`binding/binding.go` & `context.go`**:
   - Declared `MethodQuery = "QUERY"` as a typed string constant.
   - Bubbled up `gin.MethodQuery` to the top-level package.
2. **`routergroup.go` & `ginS/gins.go`**:
   - Added the `QUERY(string, ...HandlerFunc)` routing method to `IRoutes` and `RouterGroup`.
   - Updated `anyMethods` so that wildcard endpoints (`r.Any(...)`) match `QUERY` requests.
   - Added package-level `ginS.QUERY` shortcut.
3. **Documentation (`docs/doc.md`)**:
   - Updated routing documentation and examples to show how to register `QUERY` endpoints.
4. **Tests**:
   - Added robust tests in `routergroup_test.go` and `routes_test.go`.
   - Added a dedicated JSON body binding test for `QUERY` requests (`TestContextShouldBindWithQUERY`) in `context_test.go`.

### Verification

All local tests pass cleanly with Go's race detector:
```bash
go test -count=1 -race ./...
