### PR TITLE
Fix ShouldBindBodyWith docs example using binding.Form

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -1582,7 +1582,7 @@ func SomeHandler(c *gin.Context) {
   objA := formA{}
   objB := formB{}
   // This reads c.Request.Body and stores the result into the context.
-  if errA := c.ShouldBindBodyWith(&objA, binding.Form); errA == nil {
+  if errA := c.ShouldBindBodyWith(&objA, binding.JSON); errA == nil {
     c.String(http.StatusOK, `the body should be formA`)
   // At this time, it reuses body stored in the context.
   } else if errB := c.ShouldBindBodyWith(&objB, binding.JSON); errB == nil {


### PR DESCRIPTION
## Summary
- The `ShouldBindBodyWith` example in `docs/doc.md` used `binding.Form`, which does not implement `BindingBody`, so that call is invalid.
- Updated the example to use `binding.JSON`, which matches the supported body binders listed in the same section.

Fixes #3296

## Test plan
- [ ] Confirm the example in `docs/doc.md` compiles conceptually against `ShouldBindBodyWith` / `BindingBody`
- [ ] Skim the surrounding docs note that `Form` should use `ShouldBind` instead of `ShouldBindBodyWith`