### PR TITLE
fix: support non-standard X-Forwarded-For formats (bracketed IPv6, port suffix)

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -486,7 +486,13 @@ func (engine *Engine) validateHeader(header string) (clientIP string, valid bool
 	items := strings.Split(header, ",")
 	for i := len(items) - 1; i >= 0; i-- {
 		ipStr := strings.TrimSpace(items[i])
-		ip := net.ParseIP(ipStr)
+		// Handle formats like "[::1]:port", "1.2.3.4:port", and "[::1]"
+		host, _, err := net.SplitHostPort(ipStr)
+		if err != nil {
+			// No port present; strip brackets if present (e.g. "[::1]")
+			host = strings.Trim(ipStr, "[]")
+		}
+		ip := net.ParseIP(host)
 		if ip == nil {
 			break
 		}


### PR DESCRIPTION
## Description

Parses `X-Forwarded-For` headers in formats produced by common reverse proxies that are currently rejected:

| Format | Example | Source |
|--------|---------|--------|
| Bracketed IPv6 | `[240e:318:2f4a:de56::240]` | IIS ARR |
| IPv4 with port | `192.168.8.39:38792` | IIS ARR + "Include TCP port" |
| Bracketed IPv6 with port | `[240e:318:2f4a:de56::240]:38792` | Cloud LBs with `xff_client_port` |

### Root Cause

`validateHeader` calls `net.ParseIP` directly on each comma-split item. `net.ParseIP` does not accept either bracket-wrapped IPv6 addresses or `host:port` pairs, so all three formats fall through to `break` and the function returns `false`.

### Fix

Use `net.SplitHostPort` to strip the port (and unwrap brackets) when present. When `SplitHostPort` returns an error (no port), strip brackets manually with `strings.Trim(s, "[]")`. This handles all four cases listed above while preserving the existing behaviour for bare IPv4 and IPv6 addresses.

### Related Issue

Fixes #4572

## Checklist

- [x] Code compiles (`go build ./...`)
- [x] Tests pass (`go test ./...`)
- [x] `gofmt` is clean
