### PR TITLE
fix: limit request body size in BSON and Protobuf binders

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -125,3 +125,9 @@ func validate(obj any) error {
 	}
 	return Validator.ValidateStruct(obj)
 }
+
+// MaxBodySize is the maximum request body size in bytes that BSON and
+// Protobuf binders will read. If the request body exceeds this limit,
+// the binding returns an error. Defaults to 32 MB.
+var MaxBodySize int64 = 32 << 20
+

--- a/binding/bson.go
+++ b/binding/bson.go
@@ -5,6 +5,7 @@
 package binding
 
 import (
+	"errors"
 	"io"
 	"net/http"
 
@@ -18,11 +19,14 @@ func (bsonBinding) Name() string {
 }
 
 func (b bsonBinding) Bind(req *http.Request, obj any) error {
-	buf, err := io.ReadAll(req.Body)
-	if err == nil {
-		err = b.BindBody(buf, obj)
+	body, err := io.ReadAll(io.LimitReader(req.Body, MaxBodySize+1))
+	if err != nil {
+		return err
 	}
-	return err
+	if int64(len(body)) > MaxBodySize {
+		return errors.New("request body too large")
+	}
+	return b.BindBody(body, obj)
 }
 
 func (bsonBinding) BindBody(body []byte, obj any) error {

--- a/binding/protobuf.go
+++ b/binding/protobuf.go
@@ -19,11 +19,14 @@ func (protobufBinding) Name() string {
 }
 
 func (b protobufBinding) Bind(req *http.Request, obj any) error {
-	buf, err := io.ReadAll(req.Body)
+	body, err := io.ReadAll(io.LimitReader(req.Body, MaxBodySize+1))
 	if err != nil {
 		return err
 	}
-	return b.BindBody(buf, obj)
+	if int64(len(body)) > MaxBodySize {
+		return errors.New("request body too large")
+	}
+	return b.BindBody(body, obj)
 }
 
 func (protobufBinding) BindBody(body []byte, obj any) error {


### PR DESCRIPTION
### Description

Fixes #4759

**Problem:** The BSON and Protobuf binders (`binding/bson.go` and `binding/protobuf.go`) read the entire request body into memory using `io.ReadAll(req.Body)` without any size limit. A client can send a very large request body to an endpoint using these binders and force large memory allocations, potentially leading to resource exhaustion.

**Fix:**
1. Added a configurable `MaxBodySize` variable (default 32MB) to the `binding` package
2. Both BSON and Protobuf binders now use `io.LimitReader` with `MaxBodySize+1` to cap the read, and return an error if the body exceeds `MaxBodySize`

**Changes:**
- `binding/binding.go`: Added `MaxBodySize` variable (default 32MB)
- `binding/bson.go`: Replaced unbounded `io.ReadAll(req.Body)` with bounded reader
- `binding/protobuf.go`: Same fix as BSON

**Testing:**
- Existing tests should pass since the default 32MB limit is generous
- Users can set `binding.MaxBodySize` to customize the limit