### PR TITLE
fix: handle nil request in post form getters

### DIFF
--- a/context.go
+++ b/context.go
@@ -649,6 +649,9 @@ func (c *Context) initFormCache() {
 	if c.formCache == nil {
 		c.formCache = make(url.Values)
 		req := c.Request
+		if req == nil {
+			return
+		}
 		if err := req.ParseMultipartForm(c.engine.MaxMultipartMemory); err != nil {
 			if !errors.Is(err, http.ErrNotMultipart) {
 				debugPrint("error on parse multipart form array: %v", err)

--- a/context_test.go
+++ b/context_test.go
@@ -903,6 +903,21 @@ func TestContextDefaultQueryOnEmptyRequest(t *testing.T) {
 	})
 }
 
+func TestContextPostFormOnEmptyRequest(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder()) // here c.Request == nil
+	assert.NotPanics(t, func() {
+		value, ok := c.GetPostForm("NoKey")
+		assert.False(t, ok)
+		assert.Empty(t, value)
+	})
+	assert.NotPanics(t, func() {
+		assert.Equal(t, "nada", c.DefaultPostForm("NoKey", "nada"))
+	})
+	assert.NotPanics(t, func() {
+		assert.Empty(t, c.PostForm("NoKey"))
+	})
+}
+
 func TestContextQueryAndPostForm(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	body := strings.NewReader("foo=bar&page=11&both=&foo=second")


### PR DESCRIPTION
## Summary

Prevents `GetPostForm`, `PostForm`, and `DefaultPostForm` from panicking when a `gin.Context` has no request.

## Root cause

`initFormCache` called `ParseMultipartForm` through `c.Request` without a nil check, while the corresponding query cache already handles a missing request.

## Change

Initialize the empty form cache and return when `c.Request` is nil. Added regression coverage for all three form getters.

## Validation

- `go test ./...`
- `go vet ./...`

Fixes #4772