### PR TITLE
fix: prevent nil pointer panic in PostForm getters when Context has no request

### DIFF
--- a/context.go
+++ b/context.go
@@ -647,14 +647,18 @@ func (c *Context) PostFormArray(key string) (values []string) {
 
 func (c *Context) initFormCache() {
 	if c.formCache == nil {
-		c.formCache = make(url.Values)
-		req := c.Request
-		if err := req.ParseMultipartForm(c.engine.MaxMultipartMemory); err != nil {
-			if !errors.Is(err, http.ErrNotMultipart) {
-				debugPrint("error on parse multipart form array: %v", err)
+		if c.Request != nil {
+			c.formCache = make(url.Values)
+			req := c.Request
+			if err := req.ParseMultipartForm(c.engine.MaxMultipartMemory); err != nil {
+				if !errors.Is(err, http.ErrNotMultipart) {
+					debugPrint("error on parse multipart form array: %v", err)
+				}
 			}
+			c.formCache = req.PostForm
+		} else {
+			c.formCache = url.Values{}
 		}
-		c.formCache = req.PostForm
 	}
 }
 


### PR DESCRIPTION
Fixes #4772

## Problem
`Context.GetPostForm`, `Context.PostForm`, and `Context.DefaultPostForm` panic when `c.Request` is nil. This happens when creating a context with `gin.CreateTestContext` without setting a request.

The root cause is that `initFormCache` calls `c.Request.ParseMultipartForm(...)` without checking whether `c.Request` is nil.

## Solution
Add a nil check for `c.Request` in `initFormCache`, matching the pattern already used by `initQueryCache`. When `c.Request` is nil, initialize an empty form cache and return.

## Changes
- `context.go`: wrap the form parsing logic in a `c.Request != nil` check, with an else branch that sets `c.formCache = url.Values{}`

## Verification
- `GetPostForm("key")` returns `("", false)` when called without a request
- `PostForm("key")` returns `""`
- `DefaultPostForm("key", "fallback")` returns `"fallback"`
- Normal request processing is unaffected