### PR TITLE
fix: clean path in createStaticHandler before opening file (#4451)

### DIFF
--- a/routergroup.go
+++ b/routergroup.go
@@ -223,6 +223,10 @@ func (group *RouterGroup) createStaticHandler(relativePath string, fs http.FileS
 		}
 
 		file := c.Param("filepath")
+		// Clean the path to handle trailing slashes and invalid paths.
+		// Many fs.FS implementations (e.g. fs.Sub, http.FS) reject paths with
+		// trailing slashes because fs.ValidPath considers them invalid.
+		file = path.Clean(file)
 		// Check if file exists and/or if we have permission to access it
 		f, err := fs.Open(file)
 		if err != nil {


### PR DESCRIPTION
### Description

When using `router.StaticFS` with an `http.FileSystem` backed by Go's `fs.FS` (via `http.FS`), visiting a URL with a trailing slash (e.g. `/tutorials/making-gin/`) causes `createStaticHandler` to call `fs.Open(file)` with a path containing a trailing slash. Many `fs.FS` implementations (including `fs.Sub`) reject such paths because `fs.ValidPath` considers trailing slashes invalid.

Go's standard `http.FileServer` handles this correctly by calling `path.Clean` before opening the file. This fix applies the same `path.Clean` call in `createStaticHandler`'s existence check, ensuring the path is normalized before being passed to the filesystem.

### Root Cause

In `createStaticHandler`, the `file` parameter from `c.Param("filepath")` retains the raw URL path, including trailing slashes. The existence check `fs.Open(file)` fails for embedded filesystem implementations that enforce `fs.ValidPath` rules, causing the static file handler to return 404 even though the file exists.

### Fix

Added `path.Clean(file)` before the `fs.Open(file)` call in `createStaticHandler`. The `path.Clean` function:
- Removes trailing slashes
- Normalizes multiple slashes
- Resolves `.` and `..` segments

This matches the behavior of Go's `net/http.FileServer` which uses `path.Clean` in its `serveFile` function.

### Related Issues

Fixes #4451
