### PR TITLE
fix: serve index.html via FileFromFS without redirect

### DIFF
--- a/context.go
+++ b/context.go
@@ -1339,6 +1339,24 @@ func (c *Context) File(filepath string) {
 
 // FileFromFS writes the specified file from http.FileSystem into the body stream in an efficient way.
 func (c *Context) FileFromFS(filepath string, fs http.FileSystem) {
+	file, err := fs.Open(filepath)
+	if err != nil {
+		http.NotFound(c.Writer, c.Request)
+		return
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		http.NotFound(c.Writer, c.Request)
+		return
+	}
+
+	if !info.IsDir() {
+		http.ServeContent(c.Writer, c.Request, filepath, info.ModTime(), file)
+		return
+	}
+
 	defer func(old string) {
 		c.Request.URL.Path = old
 	}(c.Request.URL.Path)

--- a/context_test.go
+++ b/context_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/gin-contrib/sse"
@@ -1556,6 +1557,21 @@ func TestContextRenderFileFromFS(t *testing.T) {
 	// else, Content-Type='text/x-go; charset=utf-8'
 	assert.NotEmpty(t, w.Header().Get("Content-Type"))
 	assert.Equal(t, "/some/path", c.Request.URL.Path)
+}
+
+func TestContextRenderFileFromFSIndexHTML(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+	c.FileFromFS("www/index.html", http.FS(fstest.MapFS{
+		"www/index.html": {Data: []byte("index")},
+	}))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "index", w.Body.String())
+	assert.Empty(t, w.Header().Get("Location"))
+	assert.Equal(t, "/", c.Request.URL.Path)
 }
 
 func TestContextRenderAttachment(t *testing.T) {


### PR DESCRIPTION
Fixes #2654

## Reproduction
`Context.FileFromFS("www/index.html", fs)` currently returns a 301 redirect with `Location: ./` instead of serving the requested file. The added `TestContextRenderFileFromFSIndexHTML` reproduces this: it fails on master because the response body is empty and `Location` is `./`.

## Root cause
`FileFromFS` temporarily rewrites `Request.URL.Path` and delegates every request to `http.FileServer`. `net/http` has special redirect behavior for paths ending in `/index.html`, so an explicit file render is treated like a directory-index URL and redirected.

## Fix
Open the requested path from the provided `http.FileSystem` and serve regular files directly with `http.ServeContent`. Directory paths keep the existing `http.FileServer` path so directory/index behavior is unchanged; `TestContextRenderFileFromFS` still passes unchanged.

## Compatibility notes
This changes only explicit file paths passed to `FileFromFS`/`StaticFileFS`: files named `index.html` are now served as requested instead of redirected. Missing files still return 404, and directories keep existing `FileServer` behavior.

`http.File` embeds `io.Seeker`, so files returned by `http.FileSystem` satisfy `http.ServeContent`'s `io.ReadSeeker` requirement. If a custom `http.File` implements `Seek` by returning an error, `ServeContent` degrades to a 500 response (`seeker can't seek`) rather than panicking or writing a partial success response.

`binding/binding_nomsgpack.go` is unformatted on master; left untouched as it is unrelated to this change.

## Validation
- Regression test fails without the fix: `go test . -run TestContextRenderFileFromFSIndexHTML -count=1` fails with empty body and `Location: ./` after reverting `context.go`.
- `go test . -run "TestContextRenderFileFromFS(IndexHTML)?$" -count=1`: PASS.
- `go build ./...`: PASS.
- `go vet ./...`: PASS.
- `gofmt -l .`: reports only pre-existing `binding\binding_nomsgpack.go`; confirmed the same output on pristine `master`.
- `go test ./...`: FAIL on Windows with pre-existing failures also reproduced on clean master: `TestSaveUploadedFileWithPermission`, `TestSaveUploadedFileWithPermissionFailed`, `TestSaveUploadedFileToExistingDir`, and `TestFileDescriptor`.

## Pull Request Checklist

- [x] Open your pull request against the `master` branch.
- [ ] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [x] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.