### PR TITLE
fix(tree): roll back to skipped wildcards at param route dead ends

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -743,6 +743,7 @@ func (engine *Engine) handleHTTPRequest(c *Context) {
 			if tree.method == httpMethod {
 				continue
 			}
+			*c.skippedNodes = (*c.skippedNodes)[:0]
 			if value := tree.root.getValue(rPath, nil, c.skippedNodes, unescape); value.handlers != nil {
 				allowed = append(allowed, tree.method)
 			}

--- a/routes_test.go
+++ b/routes_test.go
@@ -527,6 +527,23 @@ func TestRouteNotAllowedEnabled3(t *testing.T) {
 	assert.Contains(t, allowed, http.MethodPost)
 }
 
+func TestRouteNotAllowedDoesNotReuseSkippedNodes(t *testing.T) {
+	router := New()
+	router.HandleMethodNotAllowed = true
+	router.POST("/b", func(c *Context) {})
+	router.POST("/:p0", func(c *Context) {})
+	router.PUT("/a/:p1", func(c *Context) {})
+
+	// The POST probe for the Allow header matches static "/b" while
+	// recording the skipped wildcard ":p0". handleHTTPRequest must reset
+	// c.skippedNodes before probing the PUT tree, or the stale entry
+	// leaks the POST route into the PUT lookup and PUT is wrongly
+	// reported in the Allow header.
+	w := PerformRequest(router, http.MethodGet, "/b")
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	assert.Equal(t, http.MethodPost, w.Header().Get("Allow"))
+}
+
 func TestRouteNotAllowedDisabled(t *testing.T) {
 	router := New()
 	router.HandleMethodNotAllowed = false

--- a/tree.go
+++ b/tree.go
@@ -410,6 +410,36 @@ type skippedNode struct {
 	paramsCount int16
 }
 
+// rollbackToSkippedNode unwinds the skipped-wildcard stack after the walk hit
+// a dead end. It pops entries until it finds one whose saved remaining path
+// ends with the current remaining path, i.e. a branch point on the walk that
+// led here; entries from abandoned branches are discarded. If one is found,
+// the walk state saved there (remaining path, current node, captured params)
+// is restored and true is returned; the caller must then resume the walk
+// loop, which retries from the branch point with its wildcard child.
+func rollbackToSkippedNode(
+	skippedNodes *[]skippedNode,
+	path *string,
+	n **node,
+	params *Params,
+	globalParamsCount *int16,
+) bool {
+	for length := len(*skippedNodes); length > 0; length-- {
+		sn := (*skippedNodes)[length-1]
+		*skippedNodes = (*skippedNodes)[:length-1]
+		if strings.HasSuffix(sn.path, *path) {
+			*path = sn.path
+			*n = sn.node
+			if params != nil {
+				*params = (*params)[:sn.paramsCount]
+			}
+			*globalParamsCount = sn.paramsCount
+			return true
+		}
+	}
+	return false
+}
+
 // Returns the handle registered with the given path (key). The values of
 // wildcards are saved to a map.
 // If no handle can be found, a TSR (trailing slash redirect) recommendation is
@@ -457,18 +487,8 @@ walk: // Outer loop for walking the tree
 					// If the path at the end of the loop is not equal to '/' and the current node has no child nodes
 					// the current node needs to roll back to last valid skippedNode
 					if path != "/" {
-						for length := len(*skippedNodes); length > 0; length-- {
-							skippedNode := (*skippedNodes)[length-1]
-							*skippedNodes = (*skippedNodes)[:length-1]
-							if strings.HasSuffix(skippedNode.path, path) {
-								path = skippedNode.path
-								n = skippedNode.node
-								if value.params != nil {
-									*value.params = (*value.params)[:skippedNode.paramsCount]
-								}
-								globalParamsCount = skippedNode.paramsCount
-								continue walk
-							}
+						if rollbackToSkippedNode(skippedNodes, &path, &n, value.params, &globalParamsCount) {
+							continue walk
 						}
 					}
 
@@ -531,6 +551,11 @@ walk: // Outer loop for walking the tree
 
 						// ... but we can't
 						value.tsr = len(path) == end+1
+						if !value.tsr {
+							if rollbackToSkippedNode(skippedNodes, &path, &n, value.params, &globalParamsCount) {
+								continue walk
+							}
+						}
 						return value
 					}
 
@@ -543,6 +568,11 @@ walk: // Outer loop for walking the tree
 						// trailing slash exists for TSR recommendation
 						n = n.children[0]
 						value.tsr = (n.path == "/" && n.handlers != nil) || (n.path == "" && n.indices == "/")
+					}
+					if !value.tsr {
+						if rollbackToSkippedNode(skippedNodes, &path, &n, value.params, &globalParamsCount) {
+							continue walk
+						}
 					}
 					return value
 
@@ -588,18 +618,8 @@ walk: // Outer loop for walking the tree
 			// If the current path does not equal '/' and the node does not have a registered handle and the most recently matched node has a child node
 			// the current node needs to roll back to last valid skippedNode
 			if n.handlers == nil && path != "/" {
-				for length := len(*skippedNodes); length > 0; length-- {
-					skippedNode := (*skippedNodes)[length-1]
-					*skippedNodes = (*skippedNodes)[:length-1]
-					if strings.HasSuffix(skippedNode.path, path) {
-						path = skippedNode.path
-						n = skippedNode.node
-						if value.params != nil {
-							*value.params = (*value.params)[:skippedNode.paramsCount]
-						}
-						globalParamsCount = skippedNode.paramsCount
-						continue walk
-					}
+				if rollbackToSkippedNode(skippedNodes, &path, &n, value.params, &globalParamsCount) {
+					continue walk
 				}
 				//	n = latestNode.children[len(latestNode.children)-1]
 			}
@@ -645,18 +665,8 @@ walk: // Outer loop for walking the tree
 
 		// roll back to last valid skippedNode
 		if !value.tsr && path != "/" {
-			for length := len(*skippedNodes); length > 0; length-- {
-				skippedNode := (*skippedNodes)[length-1]
-				*skippedNodes = (*skippedNodes)[:length-1]
-				if strings.HasSuffix(skippedNode.path, path) {
-					path = skippedNode.path
-					n = skippedNode.node
-					if value.params != nil {
-						*value.params = (*value.params)[:skippedNode.paramsCount]
-					}
-					globalParamsCount = skippedNode.paramsCount
-					continue walk
-				}
+			if rollbackToSkippedNode(skippedNodes, &path, &n, value.params, &globalParamsCount) {
+				continue walk
 			}
 		}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -1111,3 +1111,36 @@ func TestTreeFindCaseInsensitivePathWildcardParamAndStaticChild(t *testing.T) {
 		t.Errorf("Wrong result for '/prefix/something': %s", string(out))
 	}
 }
+
+func TestTreeParamFallbackAfterStaticDeadEnd(t *testing.T) {
+	tests := []struct {
+		name    string
+		routes  []string
+		request testRequests
+	}{
+		{
+			name:   "param has child but no handler",
+			routes: []string{"/:p0/:p1", "/bc/:p1/a"},
+			request: testRequests{
+				{"/bc/bc", false, "/:p0/:p1", Params{{Key: "p0", Value: "bc"}, {Key: "p1", Value: "bc"}}},
+			},
+		},
+		{
+			name:   "param has no child for remaining path",
+			routes: []string{"/:p0/:p1/:p2", "/bc/:p1"},
+			request: testRequests{
+				{"/bc/bc/bc", false, "/:p0/:p1/:p2", Params{{Key: "p0", Value: "bc"}, {Key: "p1", Value: "bc"}, {Key: "p2", Value: "bc"}}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := &node{}
+			for _, route := range tt.routes {
+				tree.addRoute(route, fakeHandler(route))
+			}
+			checkRequests(t, tree, tt.request)
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request Checklist

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [ ] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`. (bug fix, no new feature)

## Description

This PR fixes two related correctness bugs in the router's wildcard backtracking (the `skippedNodes` mechanism).

### 1. Param route dead ends never fall back to skipped wildcards

`getValue` pushes a `skippedNode` entry whenever it prefers a static child over a wildcard sibling, and rolls back to it when the static branch fails. Two dead ends inside the `param` case were missing that rollback and returned "not found" directly:

- more path remains but the param node has no child to descend into
- the param node consumed the whole remaining path but has no handler registered

Reproduction:

```go
router.GET("/:p0/:p1", handler)
router.GET("/bc/:p1/a", handler)
// GET /bc/bc returned 404; it now matches /:p0/:p1
```

The walk prefers the static `bc` branch, dead-ends on the handler-less `:p1` node, and previously gave up instead of retrying the skipped `/:p0` branch.

Both dead ends now roll back to the last valid `skippedNode`, consistent with the existing fallback at the other dead ends of `getValue`. Since this would have added a fourth and fifth copy of the same inline rollback loop, the loop is extracted into a `rollbackToSkippedNode` helper used by all five sites (net behavior of the three existing sites is unchanged).

### 2. Stale skippedNodes corrupt 405 Method Not Allowed probes

`handleHTTPRequest` reuses `c.skippedNodes` across the per-method `getValue` probes that build the `Allow` header when `HandleMethodNotAllowed` is enabled. A probe that matches via a static branch leaves its skipped wildcard entries on the stack; when a later method tree's probe dead-ends, it can roll back through such a stale entry into the previous tree's nodes, find a handler there, and wrongly report its own method as allowed. With the routes in the new test, `GET /b` answered `Allow: POST, PUT` instead of `Allow: POST`. The stack is now reset before each probe.

### Tests

- `TestTreeParamFallbackAfterStaticDeadEnd` covers each of the two dead ends (each subtest fails without its corresponding fix).
- `TestRouteNotAllowedDoesNotReuseSkippedNodes` covers the 405 probe reset.
- `go test -race ./...` passes and `golangci-lint run` reports 0 issues.
