### PR TITLE
feat(binding): support validator constructor options

### DIFF
--- a/binding/default_validator.go
+++ b/binding/default_validator.go
@@ -16,6 +16,15 @@ import (
 type defaultValidator struct {
 	once     sync.Once
 	validate *validator.Validate
+	options  []validator.Option
+}
+
+// NewStructValidator returns Gin's default StructValidator configured with
+// options passed to validator.New.
+func NewStructValidator(options ...validator.Option) StructValidator {
+	return &defaultValidator{
+		options: append([]validator.Option(nil), options...),
+	}
 }
 
 type SliceValidationError []error
@@ -92,7 +101,7 @@ func (v *defaultValidator) Engine() any {
 
 func (v *defaultValidator) lazyinit() {
 	v.once.Do(func() {
-		v.validate = validator.New()
+		v.validate = validator.New(v.options...)
 		v.validate.SetTagName("binding")
 	})
 }

--- a/binding/default_validator_test.go
+++ b/binding/default_validator_test.go
@@ -7,6 +7,8 @@ package binding
 import (
 	"errors"
 	"testing"
+
+	"github.com/go-playground/validator/v10"
 )
 
 func TestSliceValidationError(t *testing.T) {
@@ -86,5 +88,22 @@ func TestDefaultValidator(t *testing.T) {
 				t.Errorf("defaultValidator.Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestNewStructValidatorWithOptions(t *testing.T) {
+	type customID struct {
+		value string
+	}
+	type createRequest struct {
+		ID customID `binding:"required"`
+	}
+
+	v := NewStructValidator(validator.WithRequiredStructEnabled())
+	if err := v.ValidateStruct(createRequest{}); err == nil {
+		t.Fatal("expected required validation to reject a zero-value struct")
+	}
+	if err := v.ValidateStruct(createRequest{ID: customID{value: "present"}}); err != nil {
+		t.Fatalf("expected non-zero struct to pass validation: %v", err)
 	}
 }

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -932,6 +932,14 @@ Skip-validation: Running the example above using the `curl` command returns an e
 
 It is also possible to register custom validators. See the [example code](https://github.com/gin-gonic/examples/tree/master/custom-validation/server.go).
 
+Constructor-only validator options can be applied by replacing `binding.Validator` before handling requests:
+
+```go
+binding.Validator = binding.NewStructValidator(
+  validator.WithRequiredStructEnabled(),
+)
+```
+
 ```go
 package main
 


### PR DESCRIPTION
## Description

Gin owns reusable struct, pointer, slice, and array validation dispatch, but the default implementation hardcodes `validator.New()` inside its private lazy initializer. This prevents callers from applying constructor-only validator options without reimplementing `StructValidator`.

This adds `binding.NewStructValidator(options...)`, passes a private copy of those options into the existing lazy initializer, adds regression coverage for `WithRequiredStructEnabled`, and documents configuration before request handling.

Fixes #4733

## Verification

- `go test ./binding -count=1`
- `go test -tags nomsgpack ./binding -count=1`
- `go test -race ./binding -run Test(NewStructValidatorWithOptions|DefaultValidator) -count=1`
- `make test`
- `make vet`

# Pull Request Checklist

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [x] The new feature is documented in `docs/doc.md`.