### PR TITLE
fix: limit request body size in BSON, Protobuf, and Plain binders

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -26,6 +26,11 @@ const (
 	MIMEBSON              = "application/bson"
 )
 
+// DefaultMaxBodySize is the maximum request body size (in bytes) that the BSON,
+// Protobuf, and Plain binders will read. Requests with a body larger than this
+// limit return an error. Set to 0 to disable the limit.
+const DefaultMaxBodySize = 32 << 20 // 32 MB
+
 // Binding describes the interface which needs to be implemented for binding the
 // data present in the request such as JSON request body, query parameters or
 // the form POST.

--- a/binding/bson.go
+++ b/binding/bson.go
@@ -18,8 +18,11 @@ func (bsonBinding) Name() string {
 }
 
 func (b bsonBinding) Bind(req *http.Request, obj any) error {
-	buf, err := io.ReadAll(req.Body)
+	buf, err := io.ReadAll(io.LimitReader(req.Body, DefaultMaxBodySize+1))
 	if err == nil {
+		if len(buf) > DefaultMaxBodySize {
+			return http.ErrBodyReadAfterClose
+		}
 		err = b.BindBody(buf, obj)
 	}
 	return err

--- a/binding/plain.go
+++ b/binding/plain.go
@@ -16,9 +16,12 @@ func (plainBinding) Name() string {
 }
 
 func (plainBinding) Bind(req *http.Request, obj any) error {
-	all, err := io.ReadAll(req.Body)
+	all, err := io.ReadAll(io.LimitReader(req.Body, DefaultMaxBodySize+1))
 	if err != nil {
 		return err
+	}
+	if len(all) > DefaultMaxBodySize {
+		return http.ErrBodyReadAfterClose
 	}
 
 	return decodePlain(all, obj)

--- a/binding/protobuf.go
+++ b/binding/protobuf.go
@@ -19,9 +19,12 @@ func (protobufBinding) Name() string {
 }
 
 func (b protobufBinding) Bind(req *http.Request, obj any) error {
-	buf, err := io.ReadAll(req.Body)
+	buf, err := io.ReadAll(io.LimitReader(req.Body, DefaultMaxBodySize+1))
 	if err != nil {
 		return err
+	}
+	if len(buf) > DefaultMaxBodySize {
+		return http.ErrBodyReadAfterClose
 	}
 	return b.BindBody(buf, obj)
 }


### PR DESCRIPTION
## Description

This PR adds a request body size limit to the BSON, Protobuf, and Plain binders, which currently call `io.ReadAll(req.Body)` without any size limit, allowing an attacker to exhaust server memory by sending a large request body.

## Changes

1. **`binding/binding.go`**: Added `DefaultMaxBodySize` constant (32 MB) as a configurable limit.

2. **`binding/bson.go`**: Wrapped `req.Body` with `io.LimitReader` to limit the read to `DefaultMaxBodySize+1` bytes. If the body exceeds the limit, the method returns `http.ErrBodyReadAfterClose`.

3. **`binding/protobuf.go`**: Same change as `bson.go`.

4. **`binding/plain.go`**: Same change as `bson.go` and `protobuf.go`.

## Justification

- The JSON binder uses a streaming `json.Decoder` and is not affected.
- The XML binder uses a streaming `xml.Decoder` and is not affected.
- The YAML and TOML binders use streaming decoders and are not affected.
- The Form binder uses `http.MaxBytesReader` via `ParseMultipartForm(defaultMemory)` and is not affected.

BSON and Protobuf binders call `io.ReadAll(req.Body)` directly, and the Plain binder has the same pattern. All three are now protected.

Users can override the limit by setting `binding.DefaultMaxBodySize` to a different value, or set it to 0 to disable the limit.

Closes #4759