### PR TITLE
fix(binding): include field name in BindUnmarshaler errors

### DIFF
--- a/binding/form_mapping.go
+++ b/binding/form_mapping.go
@@ -196,6 +196,14 @@ func trySetCustom(val string, value reflect.Value) (isSet bool, err error) {
 	return false, nil
 }
 
+// wrapBindErr prefixes a bind error with the form/query field name.
+func wrapBindErr(fieldName string, err error) error {
+	if err == nil || fieldName == "" {
+		return err
+	}
+	return fmt.Errorf("%s: %w", fieldName, err)
+}
+
 // trySetUsingParser tries to set a custom type value based on the presence of the "parser" tag on the field.
 // If the parser tag does not exist or does not match any of the supported parsers, gin will skip over this.
 func trySetUsingParser(val string, value reflect.Value, parser string) (isSet bool, err error) {
@@ -264,9 +272,9 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 		}
 
 		if ok, err = trySetUsingParser(vs[0], value, opt.parser); ok {
-			return ok, err
+			return ok, wrapBindErr(tagValue, err)
 		} else if ok, err = trySetCustom(vs[0], value); ok {
-			return ok, err
+			return ok, wrapBindErr(tagValue, err)
 		}
 
 		if vs, err = trySplit(vs, field); err != nil {
@@ -289,9 +297,9 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 		}
 
 		if ok, err = trySetUsingParser(vs[0], value, opt.parser); ok {
-			return ok, err
+			return ok, wrapBindErr(tagValue, err)
 		} else if ok, err = trySetCustom(vs[0], value); ok {
-			return ok, err
+			return ok, wrapBindErr(tagValue, err)
 		}
 
 		if vs, err = trySplit(vs, field); err != nil {
@@ -312,9 +320,9 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 		}
 
 		if ok, err = trySetUsingParser(val, value, opt.parser); ok {
-			return ok, err
+			return ok, wrapBindErr(tagValue, err)
 		} else if ok, err = trySetCustom(val, value); ok {
-			return ok, err
+			return ok, wrapBindErr(tagValue, err)
 		}
 		return true, setWithProperType(val, value, field, opt)
 	}
@@ -323,9 +331,9 @@ func setByForm(value reflect.Value, field reflect.StructField, form map[string][
 func setWithProperType(val string, value reflect.Value, field reflect.StructField, opt setOptions) error {
 	// this if-check is required for parsing nested types like []MyId, where MyId is [12]byte
 	if ok, err := trySetUsingParser(val, value, opt.parser); ok {
-		return err
+		return wrapBindErr(field.Name, err)
 	} else if ok, err = trySetCustom(val, value); ok {
-		return err
+		return wrapBindErr(field.Name, err)
 	}
 
 	// If it is a string type, no spaces are removed, and the user data is not modified here

--- a/binding/form_mapping_test.go
+++ b/binding/form_mapping_test.go
@@ -505,6 +505,23 @@ func (f *customUnmarshalParamHex) UnmarshalParam(param string) error {
 	return nil
 }
 
+type failUnmarshalParam struct{}
+
+func (f *failUnmarshalParam) UnmarshalParam(param string) error {
+	return errors.New("boom")
+}
+
+func TestBindUnmarshalerErrorIncludesFieldName(t *testing.T) {
+	var s struct {
+		ID failUnmarshalParam `form:"uuid4"`
+	}
+	err := mappingByPtr(&s, formSource{"uuid4": {"xxx"}}, "form")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uuid4")
+	assert.Contains(t, err.Error(), "boom")
+	assert.ErrorContains(t, err, "boom") // still unwrap-friendly via %w
+}
+
 func TestMappingCustomUnmarshalParamHexWithFormTag(t *testing.T) {
 	var s struct {
 		Foo customUnmarshalParamHex `form:"foo"`


### PR DESCRIPTION
## Summary
- Prefix `BindUnmarshaler` / `encoding.TextUnmarshaler` bind errors with the form/query tag name
- Nested element path uses the Go field name (no parent tag in scope)
- Errors stay unwrap-friendly via `%w`

## Test plan
- [x] `go test ./binding -count=1 -run 'TestBindUnmarshalerErrorIncludesFieldName|TestMappingCustomUnmarshal'`

Fixes #4296