### PR TITLE
fix(router): clean StaticFS paths before fs.Open

### DIFF
--- a/routergroup.go
+++ b/routergroup.go
@@ -222,7 +222,9 @@ func (group *RouterGroup) createStaticHandler(relativePath string, fs http.FileS
 			c.Writer.WriteHeader(http.StatusNotFound)
 		}
 
-		file := c.Param("filepath")
+		// Normalize like net/http.FileServer so embed/fs.Sub preflight Open
+		// accepts directory URLs with trailing slashes (#4451).
+		file := path.Clean("/" + c.Param("filepath"))
 		// Check if file exists and/or if we have permission to access it
 		f, err := fs.Open(file)
 		if err != nil {

--- a/routes_test.go
+++ b/routes_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -644,6 +645,23 @@ func TestRouterStaticFSNotFound(t *testing.T) {
 
 	w = PerformRequest(router, http.MethodHead, "/nonexistent")
 	assert.Equal(t, "non existent", w.Body.String())
+}
+
+func TestRouterStaticFSTrailingSlashEmbed(t *testing.T) {
+	fsys := fstest.MapFS{
+		"dir/index.html": &fstest.MapFile{Data: []byte("INDEX")},
+		"dir/file.txt":   &fstest.MapFile{Data: []byte("FILE")},
+	}
+	router := New()
+	router.StaticFS("/static", http.FS(fsys))
+
+	w := PerformRequest(router, http.MethodGet, "/static/dir/")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "INDEX")
+
+	w = PerformRequest(router, http.MethodGet, "/static/dir/file.txt")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "FILE", w.Body.String())
 }
 
 func TestRouterStaticFSFileNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary
- `createStaticHandler` preflight now `path.Clean("/" + filepath)` before `fs.Open`
- Trailing-slash directory URLs on `http.FS` / embed no longer force a preflight 404
- Keeps leading `/` (same shape as `net/http.FileServer`); does not strip to relative

Supersedes incomplete approaches in #4452 / #4779 on path shape.

## Test plan
- [x] `go test . -count=1 -run 'TestRouterStaticFS'`

Fixes #4451