### PR TITLE
feat(engine): optional skip of global middleware on 405

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -122,6 +122,13 @@ type Engine struct {
 	// handler.
 	HandleMethodNotAllowed bool
 
+	// NoMethodSkipHandlers when true, the 405 chain is only Engine.NoMethod
+	// handlers — global middleware from Engine.Use is not prepended. Default
+	// false keeps historical behavior (logger/recovery still run on 405).
+	// Only applies when HandleMethodNotAllowed is true.
+	// Set this before Use/NoMethod (rebuild happens on those calls).
+	NoMethodSkipHandlers bool
+
 	// ForwardedByClientIP if enabled, client IP will be parsed from the request's headers that
 	// match those stored at `(*gin.Engine).RemoteIPHeaders`. If no IP was
 	// fetched, it falls back to the IP obtained from
@@ -358,6 +365,10 @@ func (engine *Engine) rebuild404Handlers() {
 }
 
 func (engine *Engine) rebuild405Handlers() {
+	if engine.NoMethodSkipHandlers {
+		engine.allNoMethod = engine.noMethod
+		return
+	}
 	engine.allNoMethod = engine.combineHandlers(engine.noMethod)
 }
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -251,3 +251,41 @@ func TestMiddlewareWrite(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, strings.ReplaceAll("hola\n<map><foo>bar</foo></map>{\"foo\":\"bar\"}{\"foo\":\"bar\"}event:test\ndata:message\n\n", " ", ""), strings.ReplaceAll(w.Body.String(), " ", ""))
 }
+
+func TestNoMethodSkipHandlers(t *testing.T) {
+	router := New()
+	router.HandleMethodNotAllowed = true
+	router.NoMethodSkipHandlers = true
+	router.Use(func(c *Context) {
+		c.String(http.StatusBadRequest, "mw")
+		c.Abort()
+	})
+	router.NoMethod(func(c *Context) {
+		c.String(http.StatusMethodNotAllowed, "no method")
+	})
+	router.POST("/ping", func(c *Context) {
+		c.String(http.StatusOK, "pong")
+	})
+
+	w := PerformRequest(router, http.MethodGet, "/ping")
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	assert.Equal(t, "no method", w.Body.String())
+}
+
+func TestNoMethodIncludesGlobalMiddlewareByDefault(t *testing.T) {
+	router := New()
+	router.HandleMethodNotAllowed = true
+	// NoMethodSkipHandlers left false
+	router.Use(func(c *Context) {
+		c.String(http.StatusBadRequest, "mw")
+		c.Abort()
+	})
+	router.NoMethod(func(c *Context) {
+		c.String(http.StatusMethodNotAllowed, "no method")
+	})
+	router.POST("/ping", func(c *Context) { c.Status(http.StatusOK) })
+
+	w := PerformRequest(router, http.MethodGet, "/ping")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "mw", w.Body.String())
+}


### PR DESCRIPTION
## Summary
- New opt-in `Engine.NoMethodSkipHandlers` (default `false`)
- When true (and `HandleMethodNotAllowed` is on), the 405 chain is only `NoMethod` handlers — global `Use` middleware is not prepended
- Lets body-reading / aborting middleware avoid turning GET-on-POST into 400 instead of 405
- Set the flag before `Use` / `NoMethod` (rebuild runs on those calls)

## Test plan
- [x] `go test . -count=1 -run 'TestNoMethod|TestMiddlewareNoMethod'`

Fixes #4189