### PR TITLE
docs: document panic conditions in Handle, StaticFS, and Bind

### DIFF
--- a/routergroup.go
+++ b/routergroup.go
@@ -100,6 +100,8 @@ func (group *RouterGroup) handle(httpMethod, relativePath string, handlers Handl
 // This function is intended for bulk loading and to allow the usage of less
 // frequently used, non-standardized or custom methods (e.g. for internal
 // communication with a proxy).
+//
+// It panics if httpMethod is not a valid HTTP method (uppercase ASCII letters only).
 func (group *RouterGroup) Handle(httpMethod, relativePath string, handlers ...HandlerFunc) IRoutes {
 	if matched := regEnLetter.MatchString(httpMethod); !matched {
 		panic("http method " + httpMethod + " is not valid")
@@ -200,6 +202,7 @@ func (group *RouterGroup) Static(relativePath, root string) IRoutes {
 
 // StaticFS works just like `Static()` but a custom `http.FileSystem` can be used instead.
 // Gin by default uses: gin.Dir()
+// It panics if relativePath contains URL parameters (: or *).
 func (group *RouterGroup) StaticFS(relativePath string, fs http.FileSystem) IRoutes {
 	if strings.Contains(relativePath, ":") || strings.Contains(relativePath, "*") {
 		panic("URL parameters can not be used when serving a static folder")

--- a/utils.go
+++ b/utils.go
@@ -26,6 +26,7 @@ const localhostIP = "127.0.0.1"
 const localhostIPv6 = "::1"
 
 // Bind is a helper function for given interface object and returns a Gin middleware.
+// It panics if val is a pointer; pass the struct value directly (e.g., gin.Bind(Struct{}) not gin.Bind(&Struct{})).
 func Bind(val any) HandlerFunc {
 	value := reflect.ValueOf(val)
 	if value.Kind() == reflect.Ptr {


### PR DESCRIPTION
## Summary

Three exported public API functions contain `panic()` calls on invalid input, but none of the doc comments mention the panic conditions. Callers cannot discover the crash risk without reading the source.

## Changes

- **`RouterGroup.Handle`** — documents that it panics if `httpMethod` is not a valid HTTP method (uppercase ASCII letters only).
- **`RouterGroup.StaticFS`** — documents that it panics if `relativePath` contains URL parameters (`:` or `*`).
- **`Bind`** — documents that it panics if `val` is a pointer; pass the struct value directly.

No behavior change — documentation only.

Fixes #4594