### PR TITLE
fix(context): prevent nil pointer panic in PostForm getters when Request is nil

### DIFF
--- a/context.go
+++ b/context.go
@@ -649,12 +649,14 @@ func (c *Context) initFormCache() {
 	if c.formCache == nil {
 		c.formCache = make(url.Values)
 		req := c.Request
-		if err := req.ParseMultipartForm(c.engine.MaxMultipartMemory); err != nil {
-			if !errors.Is(err, http.ErrNotMultipart) {
-				debugPrint("error on parse multipart form array: %v", err)
+		if req != nil {
+			if err := req.ParseMultipartForm(c.engine.MaxMultipartMemory); err != nil {
+				if !errors.Is(err, http.ErrNotMultipart) {
+					debugPrint("error on parse multipart form array: %v", err)
+				}
 			}
+			c.formCache = req.PostForm
 		}
-		c.formCache = req.PostForm
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -903,6 +903,31 @@ func TestContextDefaultQueryOnEmptyRequest(t *testing.T) {
 	})
 }
 
+func TestContextPostFormOnEmptyRequest(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder()) // here c.Request == nil
+	assert.NotPanics(t, func() {
+		value, ok := c.GetPostForm("NoKey")
+		assert.False(t, ok)
+		assert.Empty(t, value)
+	})
+	assert.NotPanics(t, func() {
+		assert.Equal(t, "nada", c.DefaultPostForm("NoKey", "nada"))
+	})
+	assert.NotPanics(t, func() {
+		assert.Empty(t, c.PostForm("NoKey"))
+	})
+	assert.NotPanics(t, func() {
+		values, ok := c.GetPostFormArray("NoKey")
+		assert.False(t, ok)
+		assert.Empty(t, values)
+	})
+	assert.NotPanics(t, func() {
+		dicts, ok := c.GetPostFormMap("NoKey")
+		assert.False(t, ok)
+		assert.Empty(t, dicts)
+	})
+}
+
 func TestContextQueryAndPostForm(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	body := strings.NewReader("foo=bar&page=11&both=&foo=second")

--- a/context_test.go
+++ b/context_test.go
@@ -928,6 +928,16 @@ func TestContextPostFormOnEmptyRequest(t *testing.T) {
 	})
 }
 
+func TestContextPostFormMalformedMultipart(t *testing.T) {
+	c, _ := CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(http.MethodPost, "/", strings.NewReader("not multipart"))
+	c.Request.Header.Set("Content-Type", "multipart/form-data; boundary=xxx")
+
+	assert.NotPanics(t, func() {
+		assert.Empty(t, c.PostForm("NoKey"))
+	})
+}
+
 func TestContextQueryAndPostForm(t *testing.T) {
 	c, _ := CreateTestContext(httptest.NewRecorder())
 	body := strings.NewReader("foo=bar&page=11&both=&foo=second")


### PR DESCRIPTION
## Summary

`Context.GetPostForm`, `Context.PostForm`, `Context.DefaultPostForm`, and the array/map variants panic when `c.Request` is nil. This differs from the equivalent query getters, which return empty values safely.

### Root cause

`initFormCache` called `c.Request.ParseMultipartForm(...)` without checking whether `c.Request` is nil, causing a nil-pointer dereference.

### Fix

Added a nil guard in `initFormCache` — when `c.Request` is nil, an empty `url.Values` cache is initialized and returned, matching the behavior of `initQueryCache`.

### Behavior after fix

- `GetPostForm("key")` returns `("", false)`
- `PostForm("key")` returns `""`
- `DefaultPostForm("key", "fallback")` returns `"fallback"`

## Test plan

- [x] `TestContextPostFormOnEmptyRequest` — verifies all PostForm getters (including array and map variants) do not panic and return empty/default values when `c.Request == nil`
- [x] `go test . -race` — all existing tests pass

Fixes #4772
