### PR TITLE
fix(render): encode non-BMP runes as UTF-16 surrogate pairs in AsciiJSON

### DIFF
--- a/render/json.go
+++ b/render/json.go
@@ -10,6 +10,7 @@ import (
 	"html/template"
 	"net/http"
 	"unicode"
+	"unicode/utf16"
 
 	"github.com/gin-gonic/gin/codec/json"
 	"github.com/gin-gonic/gin/internal/bytesconv"
@@ -164,8 +165,14 @@ func (r AsciiJSON) Render(w http.ResponseWriter) error {
 
 	for _, r := range bytesconv.BytesToString(ret) {
 		if r > unicode.MaxASCII {
-			escapeBuf = fmt.Appendf(escapeBuf[:0], "\\u%04x", r) // Reuse escapeBuf
-			buffer.Write(escapeBuf)
+			if r <= 0xFFFF {
+				escapeBuf = fmt.Appendf(escapeBuf[:0], "\\u%04x", r)
+				buffer.Write(escapeBuf)
+			} else {
+				r1, r2 := utf16.EncodeRune(r)
+				escapeBuf = fmt.Appendf(escapeBuf[:0], "\\u%04x\\u%04x", r1, r2)
+				buffer.Write(escapeBuf)
+			}
 		} else {
 			buffer.WriteByte(byte(r))
 		}

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -5,6 +5,7 @@
 package render
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"html/template"
@@ -267,6 +268,22 @@ func TestRenderAsciiJSONFail(t *testing.T) {
 
 	// json: unsupported type: chan int
 	require.Error(t, (AsciiJSON{data}).Render(w))
+}
+
+func TestRenderAsciiJSONNonBMP(t *testing.T) {
+	w := httptest.NewRecorder()
+	data := map[string]string{"msg": "😀"}
+
+	err := (AsciiJSON{Data: data}).Render(w)
+	require.NoError(t, err)
+
+	// Non-BMP characters must be encoded as UTF-16 surrogate pairs
+	assert.Equal(t, `{"msg":"\ud83d\ude00"}`, w.Body.String())
+
+	// Verify round-trip: json.Unmarshal should recover the original emoji
+	var decoded map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &decoded))
+	assert.Equal(t, "😀", decoded["msg"])
 }
 
 func TestRenderPureJSON(t *testing.T) {

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -277,8 +277,10 @@ func TestRenderAsciiJSONNonBMP(t *testing.T) {
 	err := (AsciiJSON{Data: data}).Render(w)
 	require.NoError(t, err)
 
-	// Non-BMP characters must be encoded as UTF-16 surrogate pairs
-	assert.Equal(t, `{"msg":"\ud83d\ude00"}`, w.Body.String())
+	body := w.Body.String()
+	// Non-BMP characters must be encoded as UTF-16 surrogate pairs on the wire.
+	assert.Contains(t, body, `\ud83d\ude00`)
+	assert.JSONEq(t, `{"msg":"😀"}`, body)
 
 	// Verify round-trip: json.Unmarshal should recover the original emoji
 	var decoded map[string]string


### PR DESCRIPTION
## Summary

`render.AsciiJSON` corrupts any Unicode code point above U+FFFF (non-BMP characters such as emoji). It escaped every non-ASCII rune with `\u%04x`, but `%04x` is a *minimum* width, not a fixed width. A non-BMP rune needs 5+ hex digits, so a single `\uXXXXX` token was written. JSON `\u` escapes are exactly 4 hex digits, so a decoder reads the first 4 as one character and the trailing digit(s) as literal text.

### Example — 😀 (U+1F600)

| | value |
|---|---|
| Input | `😀` |
| Before fix | `{"msg":"\u1f600"}` → decodes to `ὠ0` |
| After fix | `{"msg":"\ud83d\ude00"}` → decodes to `😀` |

### Fix

For runes above U+FFFF, use `utf16.EncodeRune` to produce a proper UTF-16 surrogate pair (`\uXXXX\uXXXX`), per RFC 8259 §7. BMP runes (U+0001–U+FFFF) continue to use the existing `\u%04x` format.

## Test plan

- [x] `TestRenderAsciiJSONNonBMP` — renders `{"msg":"😀"}`, asserts output is `{"msg":"\ud83d\ude00"}`, and verifies round-trip via `json.Unmarshal` recovers `😀`
- [x] `TestRenderAsciiJSON` — existing test still passes (BMP characters `语言` unaffected)
- [x] `go test ./render/...` — all render tests pass

Fixes #4688
