### PR TITLE
feat(engine): add SkipMethodNotAllowedMiddleware option

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -24,6 +24,7 @@
   - [Custom Recovery behavior](#custom-recovery-behavior)
   - [Using BasicAuth() middleware](#using-basicauth-middleware)
   - [Goroutines inside a middleware](#goroutines-inside-a-middleware)
+  - [Skip middleware for 405 responses](#skip-middleware-for-405-responses)
 - [Logging](#logging)
   - [How to write log file](#how-to-write-log-file)
   - [Custom Log Format](#custom-log-format)
@@ -604,6 +605,51 @@ func main() {
   r.Run(":8080")
 }
 ```
+
+### Skip middleware for 405 responses
+
+Middleware registered with `Use()` runs for every request, including the `405 Method Not
+Allowed` responses produced when `HandleMethodNotAllowed` is enabled. A middleware that
+rejects the request therefore aborts the chain before the `NoMethod()` handler can reply,
+and the client receives the middleware's response instead of a 405.
+
+Enable `SkipMethodNotAllowedMiddleware` to run only the `NoMethod()` handlers for those
+responses:
+
+```go
+func main() {
+  r := gin.New()
+  r.HandleMethodNotAllowed = true
+
+  // Without SkipMethodNotAllowedMiddleware this middleware answers "wrong checksum"
+  // with 400 for a GET request, because a GET carries no X-Checksum header.
+  r.SkipMethodNotAllowedMiddleware = true
+
+  r.Use(func(c *gin.Context) {
+    if c.GetHeader("X-Checksum") == "" {
+      c.String(http.StatusBadRequest, "wrong checksum")
+      c.Abort()
+      return
+    }
+    c.Next()
+  })
+
+  r.NoMethod(func(c *gin.Context) {
+    c.String(http.StatusMethodNotAllowed, "method not allowed")
+  })
+
+  r.POST("/ping", func(c *gin.Context) {
+    c.String(http.StatusOK, "pong")
+  })
+
+  // GET /ping now returns 405 "method not allowed" with an "Allow: POST" header.
+  r.Run(":8080")
+}
+```
+
+The option is disabled by default, so the existing behaviour is unchanged. It only
+applies to 405 responses; requests handled by `NoRoute()` still run the global
+middleware.
 
 ## Logging
 

--- a/gin.go
+++ b/gin.go
@@ -122,6 +122,14 @@ type Engine struct {
 	// handler.
 	HandleMethodNotAllowed bool
 
+	// SkipMethodNotAllowedMiddleware if enabled, global middleware registered via Use()
+	// is not executed when the router answers with 405 Method Not Allowed. Only the
+	// handlers registered with NoMethod run. This lets a NoMethod handler reply with
+	// 405 even when a global middleware (authentication, checksum validation, ...)
+	// would otherwise abort the request first.
+	// Requires HandleMethodNotAllowed to be enabled.
+	SkipMethodNotAllowedMiddleware bool
+
 	// ForwardedByClientIP if enabled, client IP will be parsed from the request's headers that
 	// match those stored at `(*gin.Engine).RemoteIPHeaders`. If no IP was
 	// fetched, it falls back to the IP obtained from
@@ -337,6 +345,7 @@ func (engine *Engine) NoMethod(handlers ...HandlerFunc) {
 // Use attaches a global middleware to the router. i.e. the middleware attached through Use() will be
 // included in the handlers chain for every single request. Even 404, 405, static files...
 // For example, this is the right place for a logger or error management middleware.
+// Set Engine.SkipMethodNotAllowedMiddleware to exclude this middleware from 405 responses.
 func (engine *Engine) Use(middleware ...HandlerFunc) IRoutes {
 	engine.RouterGroup.Use(middleware...)
 	engine.rebuild404Handlers()
@@ -359,6 +368,18 @@ func (engine *Engine) rebuild404Handlers() {
 
 func (engine *Engine) rebuild405Handlers() {
 	engine.allNoMethod = engine.combineHandlers(engine.noMethod)
+}
+
+// noMethodHandlers returns the handlers chain used to answer 405 Method Not Allowed.
+// When SkipMethodNotAllowedMiddleware is enabled the global middleware registered
+// via Use() is left out, so only the NoMethod handlers run.
+// The choice is made here rather than in rebuild405Handlers so that it holds
+// regardless of the order in which Use(), NoMethod() and the flag are set.
+func (engine *Engine) noMethodHandlers() HandlersChain {
+	if engine.SkipMethodNotAllowedMiddleware {
+		return engine.noMethod
+	}
+	return engine.allNoMethod
 }
 
 func (engine *Engine) addRoute(method, path string, handlers HandlersChain) {
@@ -748,7 +769,7 @@ func (engine *Engine) handleHTTPRequest(c *Context) {
 			}
 		}
 		if len(allowed) > 0 {
-			c.handlers = engine.allNoMethod
+			c.handlers = engine.noMethodHandlers()
 			c.writermem.Header().Set("Allow", strings.Join(allowed, ", "))
 			serveError(c, http.StatusMethodNotAllowed, default405Body)
 			return

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -156,6 +156,134 @@ func TestMiddlewareNoMethodDisabled(t *testing.T) {
 	assert.Equal(t, "AC X DB", signature)
 }
 
+// Test the fix for https://github.com/gin-gonic/gin/issues/4189
+func TestMiddlewareNoMethodSkipped(t *testing.T) {
+	signature := ""
+	router := New()
+	router.HandleMethodNotAllowed = true
+	router.SkipMethodNotAllowedMiddleware = true
+	router.Use(func(c *Context) {
+		signature += "A"
+		c.Next()
+		signature += "B"
+	})
+	router.Use(func(c *Context) {
+		signature += "C"
+		c.Next()
+		signature += "D"
+	})
+	router.NoMethod(func(c *Context) {
+		signature += "E"
+		c.Next()
+		signature += "F"
+	}, func(c *Context) {
+		signature += "G"
+		c.Next()
+		signature += "H"
+	})
+	router.NoRoute(func(c *Context) {
+		signature += " X "
+	})
+	router.POST("/", func(c *Context) {
+		signature += " XX "
+	})
+
+	// RUN
+	w := PerformRequest(router, http.MethodGet, "/")
+
+	// TEST
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	assert.Equal(t, http.MethodPost, w.Header().Get("Allow"))
+	assert.Equal(t, "EGHF", signature)
+}
+
+// The flag is read when the request is served, so it takes effect even when it
+// is set after Use() and NoMethod() have already built the handlers chain.
+func TestMiddlewareNoMethodSkippedSetAfterRegistration(t *testing.T) {
+	signature := ""
+	router := New()
+	router.HandleMethodNotAllowed = true
+	router.Use(func(c *Context) {
+		signature += "A"
+		c.Next()
+		signature += "B"
+	})
+	router.NoMethod(func(c *Context) {
+		signature += "E"
+		c.Next()
+		signature += "F"
+	})
+	router.POST("/", func(c *Context) {
+		signature += " XX "
+	})
+	router.SkipMethodNotAllowedMiddleware = true
+
+	// RUN
+	w := PerformRequest(router, http.MethodGet, "/")
+
+	// TEST
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	assert.Equal(t, "EF", signature)
+}
+
+func TestMiddlewareNoMethodSkippedWithoutNoMethodHandlers(t *testing.T) {
+	signature := ""
+	router := New()
+	router.HandleMethodNotAllowed = true
+	router.SkipMethodNotAllowedMiddleware = true
+	router.Use(func(c *Context) {
+		signature += "A"
+		c.Next()
+		signature += "B"
+	})
+	router.POST("/", func(c *Context) {
+		signature += " XX "
+	})
+
+	// RUN
+	w := PerformRequest(router, http.MethodGet, "/")
+
+	// TEST
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	assert.Equal(t, "405 method not allowed", w.Body.String())
+	assert.Empty(t, signature)
+}
+
+// The flag only covers 405 responses, requests falling through to NoRoute must
+// keep running the global middleware.
+func TestMiddlewareNoMethodSkippedDoesNotAffectNoRoute(t *testing.T) {
+	signature := ""
+	router := New()
+	router.HandleMethodNotAllowed = true
+	router.SkipMethodNotAllowedMiddleware = true
+	router.Use(func(c *Context) {
+		signature += "A"
+		c.Next()
+		signature += "B"
+	})
+	router.Use(func(c *Context) {
+		signature += "C"
+		c.Next()
+		signature += "D"
+	})
+	router.NoMethod(func(c *Context) {
+		signature += " E "
+	})
+	router.NoRoute(func(c *Context) {
+		signature += " X "
+	})
+	router.POST("/", func(c *Context) {
+		signature += " XX "
+	})
+
+	// RUN
+	w := PerformRequest(router, http.MethodGet, "/not-registered")
+
+	// TEST
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "AC X DB", signature)
+}
+
 func TestMiddlewareAbort(t *testing.T) {
 	signature := ""
 	router := New()


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

Fixes #4189

## Problem

Middleware registered via `Use()` is prepended to the `NoMethod` handlers by `rebuild405Handlers`, so a global middleware that aborts the request answers before the `NoMethod` handler ever runs. A middleware that validates a header only some methods carry therefore turns every 405 into its own error response:

```go
r := gin.New()
r.HandleMethodNotAllowed = true
r.Use(checkSum)                  // aborts with 400 when X-Checksum is missing
r.NoMethod(methodNotAllowed)     // never reached
r.POST("/ping", pingHandler)
```

`GET /ping` returns `400 wrong checksum` instead of `405 method not allowed`.

## Solution

Add an opt-in `Engine.SkipMethodNotAllowedMiddleware` flag that runs only the `NoMethod` handlers for 405 responses. It is disabled by default, so existing behaviour is unchanged, and `Use()`'s documented "Even 404, 405, static files..." contract still holds unless you opt out.

The flag is resolved when the request is served rather than when the handlers chain is built:

```go
func (engine *Engine) noMethodHandlers() HandlersChain {
	if engine.SkipMethodNotAllowedMiddleware {
		return engine.noMethod
	}
	return engine.allNoMethod
}
```

This matters. Deciding inside `rebuild405Handlers()` looks more natural, but that function only runs from `Use()` and `NoMethod()` — setting a plain struct field triggers no rebuild, so `r.Use(mw); r.NoMethod(h); r.SkipMethodNotAllowedMiddleware = true` would silently do nothing. Resolving at dispatch time makes the flag independent of registration order, and leaves `allNoMethod` semantics untouched, so no existing test needed modification.

Gin already uses these exact semantics internally: `createStaticHandler` dispatches the raw `noRoute` chain rather than `allNoRoute` so global middleware is not re-run for static-file misses (routergroup.go). This change exposes the equivalent behaviour for 405 as an explicit option.

Scope is deliberately limited to 405. `rebuild404Handlers()` has the same property, but this issue is about `NoMethod` and I would rather keep the diff reviewable; happy to extend to `NoRoute` in a follow-up if you would like it.

## Tests

Four tests in `middleware_test.go` alongside `TestMiddlewareNoMethodEnabled`, following its `signature`-string style so they assert handler ordering rather than just a boolean:

- `TestMiddlewareNoMethodSkipped` — flag on: 405, `Allow: POST`, signature `EGHF` (vs `ACEGHFDB`).
- `TestMiddlewareNoMethodSkippedSetAfterRegistration` — flag set after `Use()`/`NoMethod()` still takes effect.
- `TestMiddlewareNoMethodSkippedWithoutNoMethodHandlers` — falls back to the default 405 body, global middleware not run.
- `TestMiddlewareNoMethodSkippedDoesNotAffectNoRoute` — 404 path keeps running global middleware, locking in the 405-only scope.

I mutation-tested these by neutering the flag check: three fail with the exact pre-fix values, confirming they actually guard the behaviour. All existing 404/405 tests pass unmodified. Verified with the full suite, `-race`, `go vet`, `gofmt`, and end to end against a real server running the issue's scenario.

## Note on prior art

This supersedes #4687, which implemented the same option and was closed by its author for lack of review, not because of any objection. That version branched inside `rebuild405Handlers()` and so was sensitive to registration order as described above; `TestMiddlewareNoMethodSkippedSetAfterRegistration` is the regression guard for that case.

---

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.
- [x] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`.


