### PR TITLE
fix(context): handle missing HTML renderer

### DIFF
--- a/context.go
+++ b/context.go
@@ -1219,6 +1219,11 @@ func (c *Context) Render(code int, r render.Render) {
 // It also updates the HTTP code and sets the Content-Type as "text/html".
 // See http://golang.org/doc/articles/wiki/
 func (c *Context) HTML(code int, name string, obj any) {
+	if c.engine.HTMLRender == nil {
+		c.Render(code, render.HTML{})
+		return
+	}
+
 	instance := c.engine.HTMLRender.Instance(name, obj)
 	c.Render(code, instance)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1345,6 +1345,82 @@ func TestContextRenderHTML(t *testing.T) {
 	assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 }
 
+func TestContextRenderHTMLWithoutRenderer(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		status         int
+		wantErrors     []string
+		wantAborted    bool
+		wantNextCalled bool
+	}{
+		{
+			name:        "body allowed",
+			method:      http.MethodGet,
+			status:      http.StatusAccepted,
+			wantErrors:  []string{"html renderer is not configured"},
+			wantAborted: true,
+		},
+		{
+			name:           "no content",
+			method:         http.MethodGet,
+			status:         http.StatusNoContent,
+			wantNextCalled: true,
+		},
+		{
+			name:           "not modified",
+			method:         http.MethodGet,
+			status:         http.StatusNotModified,
+			wantNextCalled: true,
+		},
+		{
+			name:        "head",
+			method:      http.MethodHead,
+			status:      http.StatusOK,
+			wantErrors:  []string{"html renderer is not configured"},
+			wantAborted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			router := New()
+			var contextErrors []string
+			var contextAborted bool
+			nextHandlerCalled := false
+
+			handlers := []HandlerFunc{
+				func(c *Context) {
+					c.HTML(tt.status, "index.tmpl", H{"title": "Main website"})
+					contextErrors = c.Errors.Errors()
+					contextAborted = c.IsAborted()
+				},
+				func(_ *Context) {
+					nextHandlerCalled = true
+				},
+			}
+			if tt.method == http.MethodHead {
+				router.HEAD("/", handlers...)
+			} else {
+				router.GET("/", handlers...)
+			}
+
+			req := httptest.NewRequest(tt.method, "/", nil)
+			require.NotPanics(t, func() {
+				router.ServeHTTP(w, req)
+			})
+
+			assert.Equal(t, tt.status, w.Code)
+			assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
+			assert.Equal(t, tt.wantErrors, contextErrors)
+			assert.Equal(t, tt.wantAborted, contextAborted)
+			assert.Equal(t, tt.wantNextCalled, nextHandlerCalled)
+			assert.Empty(t, w.Body.String())
+		})
+	}
+}
+
 func TestContextRenderHTML2(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, router := CreateTestContext(w)

--- a/render/html.go
+++ b/render/html.go
@@ -5,6 +5,7 @@
 package render
 
 import (
+	"errors"
 	"html/template"
 	"net/http"
 
@@ -50,6 +51,8 @@ type HTML struct {
 
 var htmlContentType = []string{"text/html; charset=utf-8"}
 
+var errHTMLRendererNotConfigured = errors.New("html renderer is not configured")
+
 // Instance (HTMLProduction) returns an HTML instance which it realizes Render interface.
 func (r HTMLProduction) Instance(name string, data any) Render {
 	return HTML{
@@ -88,6 +91,9 @@ func (r HTMLDebug) loadTemplate() *template.Template {
 // Render (HTML) executes template and writes its result with custom ContentType for response.
 func (r HTML) Render(w http.ResponseWriter) error {
 	r.WriteContentType(w)
+	if r.Template == nil {
+		return errHTMLRendererNotConfigured
+	}
 
 	if r.Name == "" {
 		return r.Template.Execute(w, r.Data)

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -630,6 +630,16 @@ func TestRenderHTMLTemplate(t *testing.T) {
 	assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 }
 
+func TestRenderHTMLWithoutTemplate(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	err := (HTML{}).Render(w)
+
+	require.EqualError(t, err, "html renderer is not configured")
+	assert.Empty(t, w.Body.String())
+	assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
+}
+
 func TestRenderHTMLTemplateEmptyName(t *testing.T) {
 	w := httptest.NewRecorder()
 	templ := template.Must(template.New("").Parse(`Hello {{.name}}`))


### PR DESCRIPTION
## Summary

- avoid a nil pointer panic when `Context.HTML` is used without configuring an HTML renderer
- pass the missing-renderer error through `Context.Render`, preserving the HTML content type and existing no-body, error, and abort behavior
- cover GET, 204, 304, and HEAD responses

Fixes #3605

## Testing

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go test -tags nomsgpack ./... -count=1`
- `go test -tags go_json ./... -count=1`
- `go test -ldflags='-checklinkname=0' -tags sonic ./... -count=1`
- `go vet ./...`
- `go build ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0 run --verbose`

Local baseline limitations:

- `make fmt-check` reports an existing Go 1.26.5 alignment difference in unchanged `binding/binding_nomsgpack.go`; the changed files are formatted cleanly.
- the locally installed golangci-lint 2.12.2 reports five findings in unchanged code; the CI-pinned 2.11.0 run reports zero issues.

## Pull Request Checklist

- [x] Open against the `master` branch.
- [ ] All tests pass in available continuous integration systems (pending).
- [x] Tests are added for the changed behavior.
- [x] Documentation is not required for this bug fix.
