### PR TITLE
docs(contributing): remove unrelated Gitea logging link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ We welcome both issue reports and pull requests! Please follow these guidelines 
   - Please provide a clear description of your issue, and a minimal reproducible code example if possible.
   - Include the Gin version (or commit reference), Go version, and operating system.
   - Indicate whether you can reproduce the bug and describe steps to do so.
-  - Attach relevant logs per [Logging Documentation](https://docs.gitea.com/administration/logging-config#collecting-logs-for-help).
+  - Attach relevant logs when available.
 
 - **Feature requests:**
   - Before opening a request, check that a similar idea hasn’t already been suggested.


### PR DESCRIPTION
## Summary

- Remove the unrelated Gitea logging documentation link from the Gin contribution guide.
- Keep the guidance asking bug reporters to attach relevant logs when available.

## Why

The contribution guide currently directs Gin contributors to Gitea's server logging documentation. That documentation is specific to a different project and does not provide relevant instructions for reporting Gin issues.

## Testing

- `git diff --check`
- Manually verified the Markdown list structure.
- No Go tests were run because this is a documentation-only change.

## AI assistance

AI assistance was used to identify the unrelated link, prepare the one-line documentation change, and draft this pull request description.

## Pull Request Checklist

- [x] This pull request targets the `master` branch.
- [ ] All available CI checks pass. Pending after the pull request is opened.
- [x] Tests are not needed because this change only updates documentation.
- [x] This pull request does not introduce a new feature.
