### PR TITLE
docs: fix the graceful shutdown example

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -2358,6 +2358,7 @@ package main
 
 import (
   "context"
+  "errors"
   "log"
   "net/http"
   "os"
@@ -2390,7 +2391,7 @@ func main() {
 
   // Wait for interrupt signal to gracefully shutdown the server with
   // a timeout of 5 seconds.
-  quit := make(chan os.Signal)
+  quit := make(chan os.Signal, 1)
   // kill (no param) default send syscall.SIGTERM
   // kill -2 is syscall.SIGINT
   // kill -9 is syscall.SIGKILL but can't be caught, so don't need to add it


### PR DESCRIPTION
# Pull Request Checklist

- [x] Open your pull request against the `master` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [ ] Tests are added or modified as needed to cover code changes. _(no code changes, this only edits `docs/doc.md`)_
- [ ] If the pull request introduces a new feature, the feature is documented in the `docs/doc.md`. _(not a new feature)_

## What

The graceful shutdown example in `docs/doc.md` does not build when copied as written.

**1. `errors` is used but never imported.** The example calls `errors.Is(err, http.ErrServerClosed)`, but `errors` is missing from the import block:

```
main.go:32:52: undefined: errors
```

**2. The signal channel is unbuffered.** `go vet` rejects it:

```
main.go:44:3: misuse of unbuffered os.Signal channel as argument to signal.Notify
```

This one is not just a lint preference. [`signal.Notify`](https://pkg.go.dev/os/signal#Notify) documents that the package will not block sending to the channel, so with no buffer a signal that arrives before the goroutine reaches `<-quit` is dropped and the server never shuts down. A buffer of 1 is what the standard library docs recommend for a channel used to receive one signal.

## How I checked

I pulled every complete `package main` program out of `docs/doc.md` (17 of them) and built each against this repo through a `replace` directive. Only this one failed. After the two changes above, extracting the same block again gives:

| | `go build` | `go vet` |
| --- | --- | --- |
| before | fails, `undefined: errors` | cannot run, build fails first |
| after | passes | clean |

I also swept the repo for the same patterns: `make(chan os.Signal)` and `signal.Notify` each appear exactly once, both inside this one block, so nothing else needs the same treatment.

The diff is 2 insertions and 1 deletion, and I left the snippet's 2 space indentation alone to match the rest of the file.